### PR TITLE
fixes #19293

### DIFF
--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/java/JavaResourceGenerator.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/java/JavaResourceGenerator.java
@@ -177,7 +177,7 @@ public class JavaResourceGenerator extends JavaBaseGenerator {
     if (clss == JavaGenClass.Resource) {
 		  
 		  if (!isAbstract) {
-		    write("@ResourceDef(name=\""+upFirst(name).replace("ListResource", "List")+"\", profile=\"http://hl7.org/fhir/Profile/"+upFirst(name)+"\")\r\n");
+		    write("@ResourceDef(name=\""+upFirst(name).replace("ListResource", "List")+"\", profile=\"http://hl7.org/fhir/StructureDefinition/"+upFirst(name)+"\")\r\n");
 		  }
 		  
 		  if (HAPI_16) {


### PR DESCRIPTION
## HL7 FHIR Pull Request

[HL7 FHIR gForge tracker 19293](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19293).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Fixes : all Java model Classes have the profile set to: http://hl7.org/fhir/Profile/[Resource Name] instead of the correct: http://hl7.org/fhir/StructureDefinition/[Resource Name] 
Now profile is set correctly
