### PR TITLE
GF#18321 Typo in identifier notes generated for all resources

### DIFF
--- a/tools/java/org.hl7.fhir.igtools/src/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/tools/java/org.hl7.fhir.igtools/src/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -642,7 +642,7 @@ public class StructureDefinitionRenderer extends BaseRenderer {
 
   private String businessIdWarning(String resource, String name) {
     if (name.equals("identifier"))
-      return ""+translate("sd.dict", "This is a business identifer, not a resource identifier (see %sdiscussion%s)", "<a href=\""+prefix+"resource.html#identifiers\">", "</a>");
+      return ""+translate("sd.dict", "This is a business identifier, not a resource identifier (see %sdiscussion%s)", "<a href=\""+prefix+"resource.html#identifiers\">", "</a>");
     if (name.equals("version")) // && !resource.equals("Device"))
       return ""+translate("sd.dict", "This is a business versionId, not a resource version id (see %sdiscussion%s)", "<a href=\""+prefix+"resource.html#versions\">", "</a>");
     return null;

--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/definitions/generators/specification/DictHTMLGenerator.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/definitions/generators/specification/DictHTMLGenerator.java
@@ -243,7 +243,7 @@ public class DictHTMLGenerator  extends OutputStreamWriter {
 
   private String businessIdWarning(String resource, String name) {
     if (name.equals("identifier"))
-      return "This is a business identifer, not a resource identifier (see <a href=\""+prefix+"resource.html#identifiers\">discussion</a>)";
+      return "This is a business identifier, not a resource identifier (see <a href=\""+prefix+"resource.html#identifiers\">discussion</a>)";
     if (name.equals("version")) // && !resource.equals("Device"))
       return "This is a business versionId, not a resource version id (see <a href=\""+prefix+"resource.html#versions\">discussion</a>)";
     return null;


### PR DESCRIPTION
## Description

The Java code in the tools had a spelling error in the message that it appends for all idetifers (not this missing "i" there)
Was discovered on Patient