### PR TITLE
Fix "Null node type" error from unspecified NodeType encountered while processing Xhtml narrative - GF#19646

### DIFF
--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/BaseNarrative.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/BaseNarrative.java
@@ -3,6 +3,7 @@ package org.hl7.fhir.r4.model;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.INarrative;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
+import org.hl7.fhir.utilities.xhtml.NodeType;
 
 public abstract class BaseNarrative extends Type implements INarrative {
 
@@ -15,7 +16,7 @@ public abstract class BaseNarrative extends Type implements INarrative {
 	public void setDivAsString(String theString) {
 		XhtmlNode div;
 		if (StringUtils.isNotBlank(theString)) {
-			div = new XhtmlNode();
+			div = new XhtmlNode(NodeType.Element, "div");
 			div.setValueAsString(theString);
 		} else {
 			div = null;

--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
@@ -259,7 +259,7 @@ public class Narrative extends BaseNarrative implements INarrative {
         if (Configuration.errorOnAutoCreate())
           throw new Error("Attempt to auto-create Narrative.div");
         else if (Configuration.doAutoCreate())
-          this.div = new XhtmlNode(); // cc
+          this.div = new XhtmlNode(NodeType.Element, "div"); // cc
       return this.div;
     }
 


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

GF#19646
There are instances in the BaseNarrative and Narrative Java classes where new XhtmlNode classes are being created without a specified NodeType.  This causes IG Publisher to fail with a "Null node type" error when producing the output during the "Check Generate" phase for an IG with an example 'document' type Bundle resource instance.  This error further cascades by failing to generate the .html file for the example in the 'temp' directory which causes Jekyll to throw an error when the file is not found.
