### PR TITLE
Pre-create the required test-output folder in r3maps

### DIFF
--- a/implementations/java/org.hl7.fhir.validation/src/org/hl7/fhir/conversion/tests/R3R4ConversionTests.java
+++ b/implementations/java/org.hl7.fhir.validation/src/org/hl7/fhir/conversion/tests/R3R4ConversionTests.java
@@ -151,6 +151,7 @@ public class R3R4ConversionTests implements ITransformerServices, IValidatorReso
         ByteArrayOutputStream bso = new ByteArrayOutputStream();
         new org.hl7.fhir.r4.elementmodel.JsonParser(contextR3).compose(r3, bso, OutputStyle.PRETTY, null);
         cnt = bso.toByteArray();
+        Utilities.createDirectory(Utilities.path(TestingUtilities.home(), "implementations", "r3maps", "test-output"));
         TextFile.bytesToFile(cnt, Utilities.path(TestingUtilities.home(), "implementations", "r3maps", "test-output", tn+"-"+workingid+".input.json"));
       }
 


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description
Pre-create the required test-output folder in r3maps - without this, conversion tests will fail unless the user manually creates the folder.