### PR TITLE
Update conversion map for Procedure R3<->R4

### DIFF
--- a/implementations/r3maps/R3toR4/Procedure.map
+++ b/implementations/r3maps/R3toR4/Procedure.map
@@ -1,5 +1,18 @@
 ﻿map "http://hl7.org/fhir/StructureMap/Procedure3to4" = "R3 to R4 Conversions for Procedure"
 
+conceptmap "EventStatus" {
+  prefix s = "http://hl7.org/fhir/ValueSet/event-status"
+  prefix t = "http://hl7.org/fhir/ValueSet/event-status"
+
+  s:"entered-in-error" - t:"entered-in-error"
+  s:"in-progress" - t:"in-progress"
+  s:aborted - t:stopped
+  s:completed - t:completed
+  s:preparation - t:preparation
+  s:suspended - t:suspended
+  s:unknown - t:unknown
+}
+
 uses "http://hl7.org/fhir/3.0/StructureDefinition/Procedure" alias ProcedureR3 as source
 uses "http://hl7.org/fhir/StructureDefinition/Procedure" alias Procedure as target
 
@@ -11,12 +24,13 @@ group Procedure(source src : ProcedureR3, target tgt : Procedure) extends Domain
   src.instantiatesUri -> tgt.instantiatesUri;
   src.basedOn -> tgt.basedOn;
   src.partOf -> tgt.partOf;
-  src.status -> tgt.status;
-  src.statusReason -> tgt.statusReason;
+  src.status as vs where (src.notDone = true).not() -> tgt.status = translate(vs, "#EventStatus", "code");
+  src.status where (src.notDone = true) -> tgt.status = create("code") as vt, vt.value = "not-done";
+  src.notDoneReason as vs -> tgt.statusReason = create("CodeableConcept") as vt then CodeableConcept(vs, vt);
   src.category -> tgt.category;
   src.code -> tgt.code;
   src.subject -> tgt.subject;
-  src.context -> tgt.context;
+  src.context : Reference as vs -> tgt.encounter = create("Reference") as vt then Reference(vs, vt);
   src.performed -> tgt.performed;
   src.recorder -> tgt.recorder;
   src.asserter -> tgt.asserter;
@@ -37,7 +51,7 @@ group Procedure(source src : ProcedureR3, target tgt : Procedure) extends Domain
 }
 
 group ProcedurePerformer(source src : ProcedureR3, target tgt : Procedure) extends BackboneElement <<type+>> {
-  src.function -> tgt.function;
+  src.role -> tgt.function;
   src.actor -> tgt.actor;
   src.onBehalfOf -> tgt.onBehalfOf;
 }

--- a/implementations/r3maps/R4toR3/Procedure.map
+++ b/implementations/r3maps/R4toR3/Procedure.map
@@ -1,5 +1,20 @@
 ﻿map "http://hl7.org/fhir/StructureMap/Procedure4to3" = "R4 to R3 Conversion for Procedure"
 
+conceptmap "EventStatus" {
+  prefix s = "http://hl7.org/fhir/ValueSet/event-status"
+  prefix t = "http://hl7.org/fhir/ValueSet/event-status"
+
+  s:"entered-in-error" - t:"entered-in-error"
+  s:"in-progress" - t:"in-progress"
+  s:"on-hold" - t:suspended
+  s:aborted - t:stopped
+  s:completed - t:completed
+  s:preparation - t:preparation
+  s:stopped - t:aborted
+  s:suspended - t:suspended
+  s:unknown - t:unknown
+}
+
 uses "http://hl7.org/fhir/StructureDefinition/Procedure" alias Procedure as source
 uses "http://hl7.org/fhir/3.0/StructureDefinition/Procedure" alias ProcedureR3 as target
 
@@ -11,12 +26,13 @@ group Procedure(source src : ProcedureR3, target tgt : Procedure) extends Domain
   src.instantiatesUri -> tgt.instantiatesUri;
   src.basedOn -> tgt.basedOn;
   src.partOf -> tgt.partOf;
-  src.status -> tgt.status;
-  src.statusReason -> tgt.statusReason;
+  src.status where value = 'not-done' -> tgt.status = create("code") as vt, vt.value = "suspended",  tgt.notDone = true;
+  src.status as vs where (value = 'not-done').not() -> tgt.status = translate(vs, "#EventStatus", "code");
+  src.statusReason as vs where src.status = 'not-done' -> tgt.notDoneReason = create("CodeableConcept") as vt then CodeableConcept(vs, vt);
   src.category -> tgt.category;
   src.code -> tgt.code;
   src.subject -> tgt.subject;
-  src.context -> tgt.context;
+  src.encounter : Reference as vs -> tgt.context = create("Reference") as vt then Reference(vs, vt);
   src.performed -> tgt.performed;
   src.recorder -> tgt.recorder;
   src.asserter -> tgt.asserter;
@@ -37,7 +53,7 @@ group Procedure(source src : ProcedureR3, target tgt : Procedure) extends Domain
 }
 
 group ProcedurePerformer(source src : ProcedureR3, target tgt : Procedure) extends BackboneElement <<type+>> {
-  src.function -> tgt.function;
+  src.function -> tgt.role;
   src.actor -> tgt.actor;
   src.onBehalfOf -> tgt.onBehalfOf;
 }


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Update conversion map for `Procedure`. The only examples that fail roundtripping are ones that specify `"notDone": false` which is redundant.

However, `.context` will get translated to `.encounter`, even if the reference type is `EpisodeOfCare` 
