### PR TITLE
Update conversion map for Claim+Money R3<->R4 

### DIFF
--- a/implementations/r3maps/R3toR4/Claim.map
+++ b/implementations/r3maps/R3toR4/Claim.map
@@ -59,6 +59,12 @@ group Claim(source src : ClaimR3, target tgt : Claim) extends DomainResource <<t
     vs.preAuthRef -> vt.preAuthRef;
     vs.claimResponse -> vt.claimResponse;
   };
+  src.accident as vs -> tgt.accident as vt then {
+    vs.date -> vt.date;
+    vs.type -> vt.type;
+    vs.location : Address as vs0 -> vt.location = create("Address") as vt0 then Address(vs0, vt0);
+    vs.location : Reference as vs0 -> vt.location = create("Reference") as vt0 then Reference(vs0, vt0);
+  };
   src.item as vs -> tgt.item as vt then {
     vs.sequence -> vt.sequence;
     vs.careTeamLinkId -> vt.careTeamSequence;

--- a/implementations/r3maps/R3toR4/Claim.map
+++ b/implementations/r3maps/R3toR4/Claim.map
@@ -26,11 +26,90 @@ group Claim(source src : ClaimR3, target tgt : Claim) extends DomainResource <<t
   src.enterer -> tgt.enterer;
   src.insurer -> tgt.insurer;
   src.provider -> tgt.provider;
+  src.priority -> tgt.priority;
+  src.organization where src.provider.exists().not() -> tgt.provider;
   src.fundsReserve -> tgt.fundsReserve;
   src.prescription -> tgt.prescription;
   src.originalPrescription -> tgt.originalPrescription;
+  src.payee as vs -> tgt.payee as vt then {
+    vs.type -> vt.type;
+    vs.party -> vt.party;
+  };
   src.referral -> tgt.referral;
   src.facility -> tgt.facility;
+  src.careTeam as vs -> tgt.careTeam as vt then {
+    vs.sequence -> vt.sequence;
+    vs.provider -> vt.provider;
+    vs.responsible -> vt.responsible;
+    vs.role -> vt.role;
+    vs.qualification -> vt.qualification;
+  };
+  src.diagnosis as vs -> tgt.diagnosis as vt then {
+    vs.sequence -> vt.sequence;
+    vs.diagnosis : Reference as vs0 -> vt.diagnosis = create("Reference") as vt0 then Reference(vs0, vt0);
+    vs.diagnosis : CodeableConcept as vs0 -> vt.diagnosis = create("CodeableConcept") as vt0 then CodeableConcept(vs0, vt0);
+    vs.type -> vt.type;
+    vs.packageCode -> vt.packageCode;
+  };
+  src.insurance as vs -> tgt.insurance as vt then {
+    vs.sequence -> vt.sequence;
+    vs.focal -> vt.focal;
+    vs.coverage -> vt.coverage;
+    vs.businessArrangement -> vt.businessArrangement;
+    vs.preAuthRef -> vt.preAuthRef;
+    vs.claimResponse -> vt.claimResponse;
+  };
+  src.item as vs -> tgt.item as vt then {
+    vs.sequence -> vt.sequence;
+    vs.careTeamLinkId -> vt.careTeamSequence;
+    vs.diagnosisLinkId -> vt.diagnosisSequence;
+    vs.procedureLinkId -> vt.procedureSequence;
+    vs.informationLinkId -> vt.informationSequence;
+    vs.revenue -> vt.revenue;
+    vs.category -> vt.category;
+    vs.service -> vt.productOrService;
+    vs.modifier -> vt.modifier;
+    vs.programCode -> vt.programCode;
+    vs.serviced : date as vs0 -> vt.serviced = create("date") as vt0 then date(vs0, vt0);
+    vs.serviced : Period as vs0 -> vt.serviced as vt0 then Period(vs0, vt0);
+    vs.location : CodeableConcept as vs0 -> vt.diagnosis = create("CodeableConcept") as vt0 then CodeableConcept(vs0, vt0);
+    vs.location : Address as vs0 -> vt.location = create("Address") as vt0 then Address(vs0, vt0);
+    vs.location : Reference as vs0 -> vt.location = create("Reference") as vt0 then Reference(vs0, vt0);
+    vs.quantity -> vt.quantity;
+    vs.unitPrice -> vt.unitPrice;
+    vs.factor -> vt.factor;
+    vs.net -> vt.net;
+    vs.udi -> vt.udi;
+    vs.bodySite -> vt.bodySite;
+    vs.subSite -> vt.subSite;
+    vs.encounter -> vt.encounter;
+    vs.detail as vsd -> vt.detail as vtd then {
+      vsd.sequence -> vst.sequence;
+      vsd.revenue -> vst.revenue;
+      vsd.category -> vst.category;
+      vsd.service -> vst.productOrService;
+      vsd.modifier -> vst.modifier;
+      vsd.programCode -> vst.programCode;
+      vsd.quantity -> vst.quantity;
+      vsd.unitPrice -> vst.unitPrice;
+      vsd.factor -> vst.factor;
+      vsd.net -> vst.net;
+      vsd.udi -> vst.udi;
+      vsd.subDetail as vsds -> vst.detail as vsts then {
+        vsds.sequence -> vsts.sequence;
+        vsds.revenue -> vsts.revenue;
+        vsds.category -> vsts.category;
+        vsds.service -> vsts.productOrService;
+        vsds.modifier -> vsts.modifier;
+        vsds.programCode -> vsts.programCode;
+        vsds.quantity -> vsts.quantity;
+        vsds.unitPrice -> vsts.unitPrice;
+        vsds.factor -> vsts.factor;
+        vsds.net -> vsts.net;
+        vsds.udi -> vsts.udi;
+      };
+    };
+  };
   src.total -> tgt.total;
 }
 

--- a/implementations/r3maps/R4toR3/Claim.map
+++ b/implementations/r3maps/R4toR3/Claim.map
@@ -54,9 +54,15 @@ group Claim(source src : Claim, target tgt : ClaimR3) extends DomainResource <<t
     vs.sequence -> vt.sequence;
     vs.focal -> vt.focal;
     vs.coverage -> vt.coverage;
-    vs.businessArrangement -> vs.businessArrangement;
+    vs.businessArrangement -> vt.businessArrangement;
     vs.preAuthRef -> vt.preAuthRef;
     vs.claimResponse -> vt.claimResponse;
+  };
+  src.accident as vs -> tgt.accident as vt then {
+    vs.date -> vt.date;
+    vs.type -> vt.type;
+    vs.location : Address as vs0 -> vt.location = create("Address") as vt0 then Address(vs0, vt0);
+    vs.location : Reference as vs0 -> vt.location = create("Reference") as vt0 then Reference(vs0, vt0);
   };
   src.item as vs -> tgt.item as vt then {
     vs.sequence -> vt.sequence;
@@ -82,7 +88,7 @@ group Claim(source src : Claim, target tgt : ClaimR3) extends DomainResource <<t
     vs.bodySite -> vt.bodySite;
     vs.subSite -> vt.subSite;
     vs.encounter -> vt.encounter;
-    vs.detail as vsd -> vt.detail as vtd then {
+    vs.detail as vsd -> vt.detail as vst then {
       vsd.sequence -> vst.sequence;
       vsd.revenue -> vst.revenue;
       vsd.category -> vst.category;

--- a/implementations/r3maps/R4toR3/Claim.map
+++ b/implementations/r3maps/R4toR3/Claim.map
@@ -26,11 +26,89 @@ group Claim(source src : Claim, target tgt : ClaimR3) extends DomainResource <<t
   src.enterer -> tgt.enterer;
   src.insurer -> tgt.insurer;
   src.provider -> tgt.provider;
+  src.priority -> tgt.priority;
   src.fundsReserve -> tgt.fundsReserve;
   src.prescription -> tgt.prescription;
   src.originalPrescription -> tgt.originalPrescription;
+  src.payee as vs -> tgt.payee as vt then {
+    vs.type -> vt.type;
+    vs.party -> vt.party;
+  };
   src.referral -> tgt.referral;
   src.facility -> tgt.facility;
+  src.careTeam as vs -> tgt.careTeam as vt then {
+    vs.sequence -> vt.sequence;
+    vs.provider -> vt.provider;
+    vs.responsible -> vt.responsible;
+    vs.role -> vt.role;
+    vs.qualification -> vt.qualification;
+  };
+  src.diagnosis as vs -> tgt.diagnosis as vt then {
+    vs.sequence -> vt.sequence;
+    vs.diagnosis : Reference as vs0 -> vt.diagnosis = create("Reference") as vt0 then Reference(vs0, vt0);
+    vs.diagnosis : CodeableConcept as vs0 -> vt.diagnosis = create("CodeableConcept") as vt0 then CodeableConcept(vs0, vt0);
+    vs.type -> vt.type;
+    vs.packageCode -> vt.packageCode;
+  };
+  src.insurance as vs -> tgt.insurance as vt then {
+    vs.sequence -> vt.sequence;
+    vs.focal -> vt.focal;
+    vs.coverage -> vt.coverage;
+    vs.businessArrangement -> vs.businessArrangement;
+    vs.preAuthRef -> vt.preAuthRef;
+    vs.claimResponse -> vt.claimResponse;
+  };
+  src.item as vs -> tgt.item as vt then {
+    vs.sequence -> vt.sequence;
+    vs.careTeamSequence -> vt.careTeamLinkId;
+    vs.diagnosisSequence -> vt.diagnosisLinkId;
+    vs.procedureSequence -> vt.procedureLinkId;
+    vs.informationSequence -> vt.informationLinkId;
+    vs.revenue -> vt.revenue;
+    vs.category -> vt.category;
+    vs.productOrService -> vt.service;
+    vs.modifier -> vt.modifier;
+    vs.programCode -> vt.programCode;
+    vs.serviced : date as vs0 -> vt.serviced = create("date") as vt0 then date(vs0, vt0);
+    vs.serviced : Period as vs0 -> vt.serviced as vt0 then Period(vs0, vt0);
+    vs.location : CodeableConcept as vs0 -> vt.diagnosis = create("CodeableConcept") as vt0 then CodeableConcept(vs0, vt0);
+    vs.location : Address as vs0 -> vt.location = create("Address") as vt0 then Address(vs0, vt0);
+    vs.location : Reference as vs0 -> vt.location = create("Reference") as vt0 then Reference(vs0, vt0);
+    vs.quantity -> vt.quantity;
+    vs.unitPrice -> vt.unitPrice;
+    vs.factor -> vt.factor;
+    vs.net -> vt.net;
+    vs.udi -> vt.udi;
+    vs.bodySite -> vt.bodySite;
+    vs.subSite -> vt.subSite;
+    vs.encounter -> vt.encounter;
+    vs.detail as vsd -> vt.detail as vtd then {
+      vsd.sequence -> vst.sequence;
+      vsd.revenue -> vst.revenue;
+      vsd.category -> vst.category;
+      vsd.productOrService -> vst.service;
+      vsd.modifier -> vst.modifier;
+      vsd.programCode -> vst.programCode;
+      vsd.quantity -> vst.quantity;
+      vsd.unitPrice -> vst.unitPrice;
+      vsd.factor -> vst.factor;
+      vsd.net -> vst.net;
+      vsd.udi -> vst.udi;
+      vsd.subDetail as vsds -> vst.detail as vsts then {
+        vsds.sequence -> vsts.sequence;
+        vsds.revenue -> vsts.revenue;
+        vsds.category -> vsts.category;
+        vsds.productOrService -> vsts.service;
+        vsds.modifier -> vsts.modifier;
+        vsds.programCode -> vsts.programCode;
+        vsds.quantity -> vsts.quantity;
+        vsds.unitPrice -> vsts.unitPrice;
+        vsds.factor -> vsts.factor;
+        vsds.net -> vsts.net;
+        vsds.udi -> vsts.udi;
+      };
+    };
+  };
   src.total -> tgt.total;
 }
 

--- a/implementations/r3maps/R4toR3/Money.map
+++ b/implementations/r3maps/R4toR3/Money.map
@@ -8,5 +8,6 @@ imports "http://hl7.org/fhir/StructureMap/*4to3"
 group Money(source src : Money, target tgt : MoneyR3) extends Element <<type+>> {
   src.value -> tgt.value;
   src.currency -> tgt.code "code";
+  src -> tgt.system as vt, vt.value = "urn:iso:std:iso:4217";
 }
 


### PR DESCRIPTION
## Description
Upgrade conversion maps for `Claim` examples to R4.

All examples pass except:

- `employmentImpacted`  and `hospitalization` have been deleted, so it's not possible to roundtrip them as no extensions are defined for them either
- `organization(Reference)` got merged with `provider(Reference)`  and there is no function to parse a `Reference` for its type (however well you can figure that out, right), so any organisations get converted into a provider in the roundtrip
- `oral-bridge`, `oral-contained`, `vision-glasses` examples fail on default rules for `contained` resources - won't tackle them in this PR to keep scope down