### PR TITLE
Use meld on Linux/Windows and don't open diff windows for all the same file

### DIFF
--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/test/support/TestingUtilities.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/test/support/TestingUtilities.java
@@ -214,21 +214,29 @@ public class TestingUtilities {
   public static String checkJsonSrcIsSame(String s1, String s2, boolean showDiff) throws JsonSyntaxException, FileNotFoundException, IOException {
     String result = compareJsonSrc(s1, s2);
     if (result != null && SHOW_DIFF && showDiff) {
-      
       String diff = null; 
-      if (System.getProperty("os.name").contains("win"))
-        diff = Utilities.path("usr", "bin", "meld");
-      else
-        diff = Utilities.path(System.getenv("ProgramFiles(X86)"), "WinMerge", "WinMergeU.exe");
+      if (System.getProperty("os.name").contains("Linux"))
+        diff = Utilities.path("/", "usr", "bin", "meld");
+      else {
+    	if (Utilities.checkFile("WinMerge", Utilities.path(System.getenv("ProgramFiles(X86)"), "WinMerge"), "\\WinMergeU.exe", null))
+    		diff = Utilities.path(System.getenv("ProgramFiles(X86)"), "WinMerge", "WinMergeU.exe");
+    	else if (Utilities.checkFile("WinMerge", Utilities.path(System.getenv("ProgramFiles(X86)"), "Meld"), "\\Meld.exe", null))
+    		diff = Utilities.path(System.getenv("ProgramFiles(X86)"), "Meld", "Meld.exe");
+      }
+      if (diff == null || diff.isEmpty())
+    	  return result;
+      
       List<String> command = new ArrayList<String>();
-      String f1 = Utilities.path("[tmp]", "input.json");
-      String f2 = Utilities.path("[tmp]", "output.json");
+      String f1 = Utilities.path("[tmp]", "input" + s1.hashCode() + ".json");
+      String f2 = Utilities.path("[tmp]", "output" + s2.hashCode() + ".json");
       TextFile.stringToFile(s1, f1);
       TextFile.stringToFile(s2, f2);
-      command.add("\"" + diff + "\" \"" + f1 + "\" \"" + f2 + "\"");
+      command.add(diff);
+      command.add(f1);
+      command.add(f2);
 
       ProcessBuilder builder = new ProcessBuilder(command);
-      builder.directory(new CSFile("c:\\temp"));
+      builder.directory(new CSFile(Utilities.path("[tmp]")));
       builder.start();
       
     }

--- a/implementations/java/org.hl7.fhir.utilities/src/org/hl7/fhir/utilities/Utilities.java
+++ b/implementations/java/org.hl7.fhir.utilities/src/org/hl7/fhir/utilities/Utilities.java
@@ -254,7 +254,8 @@ public class Utilities {
   	throws IOException
   {
     if (!new CSFile(dir+file).exists()) {
-      errors.add("Unable to find "+purpose+" file "+file+" in "+dir);
+      if (errors != null)
+    	  errors.add("Unable to find "+purpose+" file "+file+" in "+dir);
       return false;
     } else {
       return true;


### PR DESCRIPTION
## Description

Use `meld` as a backup tool on Linux/Windows, and don't open the same `input.json` and `output.json` in many windows when there are many diffs to be shown.
