### PR TITLE
Update conversion map for AdverseEvent R3<->R4

### DIFF
--- a/implementations/r3maps/R3toR4/AdverseEvent.map
+++ b/implementations/r3maps/R3toR4/AdverseEvent.map
@@ -8,10 +8,10 @@ imports "http://hl7.org/fhir/StructureMap/*3to4"
 group AdverseEvent(source src : AdverseEventR3, target tgt : AdverseEvent) extends DomainResource <<type+>> {
   src.identifier -> tgt.identifier;
   src.actuality -> tgt.actuality;
-  src.category -> tgt.category;
-  src.event -> tgt.event;
+  src.category as vs -> tgt.category as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/adverse-event-category', c.code = vs;
+  src.type -> tgt.event;
+  src.description as vs where src.type.exists().not() -> tgt.event as vt, vt.text = vs "use description in leiu of type for event";
   src.subject -> tgt.subject;
-  src.context -> tgt.context;
   src.date -> tgt.date;
   src.detected -> tgt.detected;
   src.recordedDate -> tgt.recordedDate;

--- a/implementations/r3maps/R4toR3/AdverseEvent.map
+++ b/implementations/r3maps/R4toR3/AdverseEvent.map
@@ -8,10 +8,13 @@ imports "http://hl7.org/fhir/StructureMap/*4to3"
 group AdverseEvent(source src : AdverseEventR3, target tgt : AdverseEvent) extends DomainResource <<type+>> {
   src.identifier -> tgt.identifier;
   src.actuality -> tgt.actuality;
-  src.category -> tgt.category;
-  src.event -> tgt.event;
+  src.category as vs then {
+   vs.coding as c where system = 'http://terminology.hl7.org/CodeSystem/adverse-event-category' then {
+     c.code -> tgt.category;
+   };
+  };
+  src.event -> tgt.type;
   src.subject -> tgt.subject;
-  src.context -> tgt.context;
   src.date -> tgt.date;
   src.detected -> tgt.detected;
   src.recordedDate -> tgt.recordedDate;


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Only `.description` gets lost in the roundtripping, but that's because it duplicates the functionality of `.type` which is also provided.

Didn't address all changes in AdverseEvent, just ones necessary for the examples in the spec for conversion to R4 and back.
