### PR TITLE
[WIP] Update conversion map for ExplanationOfBenefit R3<->R4

### DIFF
--- a/implementations/r3maps/R3toR4/ExplanationOfBenefit.map
+++ b/implementations/r3maps/R3toR4/ExplanationOfBenefit.map
@@ -21,13 +21,17 @@ group ExplanationOfBenefit(source src : ExplanationOfBenefitR3, target tgt : Exp
   src.facility -> tgt.facility;
   src.claim -> tgt.claim;
   src.claimResponse -> tgt.claimResponse;
-  src.outcome -> tgt.outcome;
+  src.outcome as vs then {
+   vs.coding as c where code in 'complete' | 'error' | 'partial' then {
+     c.code -> tgt.outcome;
+   };
+  };
   src.disposition -> tgt.disposition;
   src.related as s -> tgt.related as t then ExplanationOfBenefitRelated(s, t);
   src.prescription -> tgt.prescription;
   src.originalPrescription -> tgt.originalPrescription;
   src.payee as s -> tgt.payee as t then ExplanationOfBenefitPayee(s, t);
-  src.information as s -> tgt.information as t then ExplanationOfBenefitInformation(s, t);
+  src.information as s -> tgt.supportingInfo as t then ExplanationOfBenefitInformation(s, t);
   src.careTeam as s -> tgt.careTeam as t then ExplanationOfBenefitCareTeam(s, t);
   src.diagnosis as s -> tgt.diagnosis as t then ExplanationOfBenefitDiagnosis(s, t);
   src.procedure as s -> tgt.procedure as t then ExplanationOfBenefitProcedure(s, t);
@@ -36,7 +40,7 @@ group ExplanationOfBenefit(source src : ExplanationOfBenefitR3, target tgt : Exp
   src.accident as s -> tgt.accident as t then ExplanationOfBenefitAccident(s, t);
   src.item as s -> tgt.item as t then ExplanationOfBenefitItem(s, t);
   src.addItem as s -> tgt.addItem as t then ExplanationOfBenefitAddItem(s, t);
-  src.total as s -> tgt.total as t then ExplanationOfBenefitTotal(s, t);
+  src.totalCost as s -> tgt.total as t then ExplanationOfBenefitTotalCost(s, t);
   src.payment as s -> tgt.payment as t then ExplanationOfBenefitPayment(s, t);
   src.form -> tgt.form;
   src.processNote as s -> tgt.processNote as t then ExplanationOfBenefitProcessNote(s, t);
@@ -51,7 +55,6 @@ group ExplanationOfBenefitRelated(source src, target tgt) extends BackboneElemen
 
 group ExplanationOfBenefitPayee(source src, target tgt) extends BackboneElement {
   src.type -> tgt.type;
-  src.resource -> tgt.resource;
   src.party -> tgt.party;
 }
 
@@ -98,13 +101,13 @@ group ExplanationOfBenefitAccident(source src, target tgt) extends BackboneEleme
 
 group ExplanationOfBenefitItem(source src, target tgt) extends BackboneElement {
   src.sequence -> tgt.sequence;
-  src.careTeamSequence -> tgt.careTeamSequence;
-  src.diagnosisSequence -> tgt.diagnosisSequence;
-  src.procedureSequence -> tgt.procedureSequence;
-  src.informationSequence -> tgt.informationSequence;
+  src.careTeamLinkId -> tgt.careTeamSequence;
+  src.diagnosisLinkId -> tgt.diagnosisSequence;
+  src.procedureLinkId -> tgt.procedureSequence;
+  src.informationLinkId -> tgt.informationSequence;
   src.revenue -> tgt.revenue;
   src.category -> tgt.category;
-  src.service -> tgt.service;
+  src.service -> tgt.productOrService;
   src.modifier -> tgt.modifier;
   src.programCode -> tgt.programCode;
   src.serviced -> tgt.serviced;
@@ -207,9 +210,9 @@ group ExplanationOfBenefitAddItemDetailSubDetail(source src, target tgt) extends
   src.adjudication -> tgt.adjudication;
 }
 
-group ExplanationOfBenefitTotal(source src, target tgt) extends BackboneElement {
-  src.category -> tgt.category;
-  src.amount -> tgt.amount;
+group ExplanationOfBenefitTotalCost(source src, target tgt) extends BackboneElement {
+  // src.category -> tgt.category;
+  src as src -> tgt.amount = src "set total amount";
 }
 
 group ExplanationOfBenefitPayment(source src, target tgt) extends BackboneElement {

--- a/implementations/r3maps/R4toR3/ExplanationOfBenefit.map
+++ b/implementations/r3maps/R4toR3/ExplanationOfBenefit.map
@@ -21,13 +21,13 @@ group ExplanationOfBenefit(source src : ExplanationOfBenefitR3, target tgt : Exp
   src.facility -> tgt.facility;
   src.claim -> tgt.claim;
   src.claimResponse -> tgt.claimResponse;
-  src.outcome -> tgt.outcome;
+  src.outcome as vs where value in 'complete' | 'error' | 'partial' -> tgt.outcome as vt, vt.coding as c, c.system = 'http://hl7.org/fhir/remittance-outcome', c.code = vs;
   src.disposition -> tgt.disposition;
   src.related as s -> tgt.related as t then ExplanationOfBenefitRelated(s, t);
   src.prescription -> tgt.prescription;
   src.originalPrescription -> tgt.originalPrescription;
   src.payee as s -> tgt.payee as t then ExplanationOfBenefitPayee(s, t);
-  src.information as s -> tgt.information as t then ExplanationOfBenefitInformation(s, t);
+  src.supportingInfo as s -> tgt.information as t then ExplanationOfBenefitInformation(s, t);
   src.careTeam as s -> tgt.careTeam as t then ExplanationOfBenefitCareTeam(s, t);
   src.diagnosis as s -> tgt.diagnosis as t then ExplanationOfBenefitDiagnosis(s, t);
   src.procedure as s -> tgt.procedure as t then ExplanationOfBenefitProcedure(s, t);
@@ -51,7 +51,6 @@ group ExplanationOfBenefitRelated(source src, target tgt) extends BackboneElemen
 
 group ExplanationOfBenefitPayee(source src, target tgt) extends BackboneElement {
   src.type -> tgt.type;
-  src.resource -> tgt.resource;
   src.party -> tgt.party;
 }
 
@@ -98,13 +97,13 @@ group ExplanationOfBenefitAccident(source src, target tgt) extends BackboneEleme
 
 group ExplanationOfBenefitItem(source src, target tgt) extends BackboneElement {
   src.sequence -> tgt.sequence;
-  src.careTeamSequence -> tgt.careTeamSequence;
-  src.diagnosisSequence -> tgt.diagnosisSequence;
-  src.procedureSequence -> tgt.procedureSequence;
-  src.informationSequence -> tgt.informationSequence;
+  src.careTeamSequence -> tgt.careTeamLinkId;
+  src.diagnosisSequence -> tgt.diagnosisLinkId;
+  src.procedureSequence -> tgt.procedureLinkId;
+  src.informationSequence -> tgt.informationLinkId;
   src.revenue -> tgt.revenue;
   src.category -> tgt.category;
-  src.service -> tgt.service;
+  src.productOrService -> tgt.service;
   src.modifier -> tgt.modifier;
   src.programCode -> tgt.programCode;
   src.serviced -> tgt.serviced;


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description
WIP, issue with casting to money:

```
org.hl7.fhir.exceptions.FHIRException: Unable to convert a org.hl7.fhir.r4.elementmodel.Element to an Money
	at org.hl7.fhir.r4.model.Base.castToMoney(Base.java:508)
	at org.hl7.fhir.r4.model.ExplanationOfBenefit$TotalComponent.setProperty(ExplanationOfBenefit.java:10501)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.processTarget(StructureMapUtilities.java:1809)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.executeRule(StructureMapUtilities.java:1395)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.executeGroup(StructureMapUtilities.java:1382)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.executeDependency(StructureMapUtilities.java:1440)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.executeRule(StructureMapUtilities.java:1403)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.executeGroup(StructureMapUtilities.java:1382)
	at org.hl7.fhir.r4.utils.StructureMapUtilities.transform(StructureMapUtilities.java:1356)
	at org.hl7.fhir.conversion.tests.R3R4ConversionTests.test(R3R4ConversionTests.java:166)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
```
