### PR TITLE
Update conversion map for Coverage R3<->R4

### DIFF
--- a/implementations/r3maps/R3toR4/Coverage.map
+++ b/implementations/r3maps/R3toR4/Coverage.map
@@ -17,21 +17,49 @@ group Coverage(source src : CoverageR3, target tgt : Coverage) extends DomainRes
   src.relationship -> tgt.relationship;
   src.period -> tgt.period;
   src.payor -> tgt.payor;
-  src.class as s -> tgt.class as t then CoverageClass(s, t);
+  src.grouping as g where src.grouping.group.exists() -> tgt.class as t then CoverageGroupingGroup(g, t);
+  src.grouping as g where src.grouping.subGroup.exists() -> tgt.class as t then CoverageGroupingSubGroup(g, t);
+  src.grouping as g where src.grouping.plan.exists() -> tgt.class as t then CoverageGroupingPlan(g, t);
+  src.grouping as g where src.grouping.subPlan.exists() -> tgt.class as t then CoverageGroupingSubPlan(g, t);
+  src.grouping as g where src.grouping.class.exists() -> tgt.class as t then CoverageGroupingClass(g, t);
+  src.grouping as g where src.grouping.subClass.exists() -> tgt.class as t then CoverageGroupingSubClass(g, t);
   src.order -> tgt.order;
   src.network -> tgt.network;
-  src.copay as s -> tgt.copay as t then CoverageCopay(s, t);
   src.contract -> tgt.contract;
 }
 
-group CoverageClass(source src, target tgt) extends BackboneElement {
-  src.type -> tgt.type;
-  src.value -> tgt.value;
-  src.name -> tgt.name;
+group CoverageGroupingGroup(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'group';
+  src.group -> tgt.value;
+  src.groupDisplay -> tgt.name;
 }
 
-group CoverageCopay(source src, target tgt) extends BackboneElement {
-  src.type -> tgt.type;
-  src.value -> tgt.value;
+group CoverageGroupingSubGroup(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'subgroup';
+  src.subGroup -> tgt.value;
+  src.subGroupDisplay -> tgt.name;
 }
 
+group CoverageGroupingPlan(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'plan';
+  src.plan -> tgt.value;
+  src.planDisplay -> tgt.name;
+}
+
+group CoverageGroupingSubPlan(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'subplan';
+  src.subPlan -> tgt.value;
+  src.subPlanDisplay -> tgt.name;
+}
+
+group CoverageGroupingClass(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'class';
+  src.class -> tgt.value;
+  src.classDisplay -> tgt.name;
+}
+
+group CoverageGroupingSubClass(source src, target tgt) extends BackboneElement {
+  src -> tgt.type as vt, vt.coding as c, c.system = 'http://terminology.hl7.org/CodeSystem/coverage-class', c.code = 'subclass';
+  src.subClass -> tgt.value;
+  src.subClassDisplay -> tgt.name;
+}

--- a/implementations/r3maps/R4toR3/Coverage.map
+++ b/implementations/r3maps/R4toR3/Coverage.map
@@ -17,21 +17,90 @@ group Coverage(source src : CoverageR3, target tgt : Coverage) extends DomainRes
   src.relationship -> tgt.relationship;
   src.period -> tgt.period;
   src.payor -> tgt.payor;
-  src.class as s -> tgt.class as t then CoverageClass(s, t);
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'group' then {
+        c then CoverageClassGroup(class, t);
+      };
+    };
+  };
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'subgroup' then {
+        c then CoverageClassSubGroup(class, t);
+      };
+    };
+  };
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'plan' then {
+        c then CoverageClassPlanGroup(class, t);
+      };
+    };
+  };
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'subplan' then {
+        c then CoverageClassSubPlanGroup(class, t);
+      };
+    };
+  };
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'class' then {
+        c then CoverageClassClassGroup(class, t);
+      };
+    };
+  };
+  src.class as class -> tgt.grouping as t then {
+    class.type as vs then {
+      vs.coding as c where code = 'subclass' then {
+        c then CoverageClassSubClassGroup(class, t);
+      };
+    };
+  };
+  src.class as class then {
+    class.type as vs then {
+      vs.coding as c where code = 'sequence' then {
+        c then CoverageClassSequenceGroup(class, tgt);
+      };
+    };
+  };
   src.order -> tgt.order;
   src.network -> tgt.network;
-  src.copay as s -> tgt.copay as t then CoverageCopay(s, t);
   src.contract -> tgt.contract;
 }
 
-group CoverageClass(source src, target tgt) extends BackboneElement {
-  src.type -> tgt.type;
-  src.value -> tgt.value;
-  src.name -> tgt.name;
+group CoverageClassGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.group;
+  src.name -> tgt.groupDisplay;
 }
 
-group CoverageCopay(source src, target tgt) extends BackboneElement {
-  src.type -> tgt.type;
-  src.value -> tgt.value;
+group CoverageClassSubGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.subGroup;
+  src.name -> tgt.subGroupDisplay;
 }
 
+group CoverageClassPlanGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.plan;
+  src.name -> tgt.planDisplay;
+}
+
+group CoverageClassSubPlanGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.subPlan;
+  src.name -> tgt.subPlanDisplay;
+}
+
+group CoverageClassClassGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.class;
+  src.name -> tgt.classDisplay;
+}
+
+group CoverageClassSubClassGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.subClass;
+  src.name -> tgt.subClassDisplay;
+}
+
+group CoverageClassSequenceGroup(source src, target tgt) extends BackboneElement {
+  src.value -> tgt.sequence;
+}


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Didn't address all changes the spec, just ones necessary for the examples in the spec for conversion to R4 and back.

It doesn't seem like you can just 'create' a variable and pass it as an input to the group, so a lot of duplication had to be done... happy to see if there's a better way to do this. This setup roundtrips perfectly, though.
