### PR TITLE
Update conversion map for EnrollmentResponse R3<->R4

### DIFF
--- a/implementations/r3maps/R3toR4/EnrollmentResponse.map
+++ b/implementations/r3maps/R3toR4/EnrollmentResponse.map
@@ -9,7 +9,11 @@ group EnrollmentResponse(source src : EnrollmentResponseR3, target tgt : Enrollm
   src.identifier -> tgt.identifier;
   src.status -> tgt.status;
   src.request -> tgt.request;
-  src.outcome -> tgt.outcome;
+  src.outcome as vs then {
+   vs.coding as c where code in 'complete' | 'error' | 'partial' then {
+     c.code -> tgt.outcome;
+   };
+  };
   src.disposition -> tgt.disposition;
   src.created -> tgt.created;
   src.organization -> tgt.organization;

--- a/implementations/r3maps/R4toR3/EnrollmentResponse.map
+++ b/implementations/r3maps/R4toR3/EnrollmentResponse.map
@@ -9,7 +9,7 @@ group EnrollmentResponse(source src : EnrollmentResponseR3, target tgt : Enrollm
   src.identifier -> tgt.identifier;
   src.status -> tgt.status;
   src.request -> tgt.request;
-  src.outcome -> tgt.outcome;
+  src.outcome as vs where value in 'complete' | 'error' | 'partial' -> tgt.outcome as vt, vt.coding as c, c.system = 'http://hl7.org/fhir/remittance-outcome', c.code = vs;
   src.disposition -> tgt.disposition;
   src.created -> tgt.created;
   src.organization -> tgt.organization;


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Didn't address all changes the spec, just ones necessary for the examples in the spec for conversion to R4 and back.