### PR TITLE
QA - Terminology Update invalid codesystem CanonicalUris

### DIFF
--- a/source/medicationrequest/codesystem-medicationrequest-course-of-therapy.xml
+++ b/source/medicationrequest/codesystem-medicationrequest-course-of-therapy.xml
@@ -7,7 +7,7 @@
   <experimental value="false"/>
   <description value=""/>
   <caseSensitive value="true"/>
-  <valueSet value="http://hl7.org/fhir/valueSet/medicationrequest-course-of-therapy"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy"/>
   <content value="complete"/>
   <concept>
     <code value="continuous"/>

--- a/source/medicationrequest/codesystem-medicationrequest-intent.xml
+++ b/source/medicationrequest/codesystem-medicationrequest-intent.xml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <url value="http://hl7.org/fhir/ValueSet/medicationrequest-intent"/>
+  <url value="http://hl7.org/fhir/CodeSystem/medicationrequest-intent"/>
   <name value="MedicationRequest Intent Codes"/>
   <status value="draft"/>
   <experimental value="false"/>
   <description value=""/>
   <caseSensitive value="true"/>
-  <valueSet value="http://hl7.org/fhir/valueSet/medicationrequest-intent"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/medicationrequest-intent"/>
   <content value="complete"/>
   <concept>
     <code value="proposal"/>

--- a/source/medicationrequest/codesystem-medicationrequest-status.xml
+++ b/source/medicationrequest/codesystem-medicationrequest-status.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <url value="http://hl7.org/fhir/ValueSet/medicationrequest-status"/>
+  <url value="http://hl7.org/fhir/CodeSystem/medicationrequest-status"/>
   <name value="MedicationRequest Status Codes"/>
   <status value="draft"/>
   <experimental value="false"/>

--- a/source/medicationrequest/valueset-medicationrequest-intent.xml
+++ b/source/medicationrequest/valueset-medicationrequest-intent.xml
@@ -17,7 +17,7 @@
   <description value="MedicationRequest Intent Codes"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/ValueSet/medicationrequest-intent"/>
+      <system value="http://hl7.org/fhir/CodeSystem/medicationrequest-intent"/>
     </include>
   </compose>
 </ValueSet>

--- a/source/medicationrequest/valueset-medicationrequest-status.xml
+++ b/source/medicationrequest/valueset-medicationrequest-status.xml
@@ -17,7 +17,7 @@
   <description value="MedicationRequest Status Codes"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/ValueSet/medicationrequest-status"/>
+      <system value="http://hl7.org/fhir/CodeSystem/medicationrequest-status"/>
     </include>
   </compose>
 </ValueSet>


### PR DESCRIPTION
## Description

Resolved issue with duplicate CanonicalUris between ValueSet and CodeSystem in the MedicationRequest resource terminologies - and the case of the codesystem-medicationrequest-course-of-therapy complete ValueSet CanonicalURI
