### PR TITLE
GF#19647 - Add warning for use of SNOMED CT normal form properties in…

### DIFF
--- a/source/snomedct.html
+++ b/source/snomedct.html
@@ -177,8 +177,8 @@ In addition to the <a href="terminology-service.html#standard-props">standard pr
   value in the Concept file of the RF2 distribution (i.e. If 900000000000073002
   |Sufficiently defined concept definition status| then true).</td></tr>
 <tr><td>moduleId</td><td>code</td><td>The SNOMED CT concept id of the module that the concept belongs to.</td></tr>
-<tr><td>normalForm</td><td>string</td><td>Generated Necessary Normal Form expression for the provided code or expression, with terms.</td></tr>
-<tr><td>normalFormTerse</td><td>string</td><td>Generated Necessary Normal form expression for the provided code or expression, concept ids only.</td></tr>
+<tr><td>normalForm</td><td>string</td><td>Generated Necessary Normal Form expression for the provided code or expression, with terms.  The normal form expressions are not suitable for use in subsumption testing.</td></tr>
+<tr><td>normalFormTerse</td><td>string</td><td>Generated Necessary Normal form expression for the provided code or expression, concept ids only.  The normal form expressions are not suitable for use in subsumption testing.</td></tr>
 </table>
 <p>
 SNOMED CT relationships, where the relationship


### PR DESCRIPTION
… subsumption testing.

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Add warning for use of SNOMED CT normal form properties in subsumption testing.
