### PR TITLE
Fixed error in MIN and MAX value representation

### DIFF
--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/conformance/ShExGenerator.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/conformance/ShExGenerator.java
@@ -578,11 +578,11 @@ public class ShExGenerator {
       StringBuilder facets =  new StringBuilder();
       if(ed.hasMinValue()) {
         Type mv = ed.getMinValue();
-        facets.append(tmplt(MINVALUE_TEMPLATE).add("val", TurtleParser.ttlLiteral(mv.primitiveValue(), mv.fhirType())).render());
+        facets.append(tmplt(MINVALUE_TEMPLATE).add("val", mv.primitiveValue()).render());
       }
       if(ed.hasMaxValue()) {
         Type mv = ed.getMaxValue();
-        facets.append(tmplt(MAXVALUE_TEMPLATE).add("val", TurtleParser.ttlLiteral(mv.primitiveValue(), mv.fhirType())).render());
+        facets.append(tmplt(MAXVALUE_TEMPLATE).add("val", mv.primitiveValue()).render());
       }
       if(ed.hasMaxLength()) {
         int ml = ed.getMaxLength();


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Fixed error in ShEx min and max integer values.  

This worked with the older ShEx parsers because we added this exception.  Newer parsers no longer recognize this variation.
