### PR TITLE
Restore fix for "Null node type" error causing IG Publisher to fail.

### DIFF
--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
@@ -259,7 +259,7 @@ public class Narrative extends BaseNarrative implements INarrative {
         if (Configuration.errorOnAutoCreate())
           throw new Error("Attempt to auto-create Narrative.div");
         else if (Configuration.doAutoCreate())
-          this.div = new XhtmlNode(NodeType.Element, "div"); // cc
+          this.div = new XhtmlNode(NodeType.Element, "div"); // cc 
       return this.div;
     }
 

--- a/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
+++ b/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/model/Narrative.java
@@ -259,7 +259,7 @@ public class Narrative extends BaseNarrative implements INarrative {
         if (Configuration.errorOnAutoCreate())
           throw new Error("Attempt to auto-create Narrative.div");
         else if (Configuration.doAutoCreate())
-          this.div = new XhtmlNode(); // cc
+          this.div = new XhtmlNode(NodeType.Element, "div"); // cc
       return this.div;
     }
 


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

GF#19785
Restore fix for "Null node type" error causing IG Publisher failure.  This fix was removed in the latest commit and is needed for building the IPS IG (and others?). 
