### PR TITLE
Format JSON in examples

### DIFF
--- a/source/extensibility.html
+++ b/source/extensibility.html
@@ -97,11 +97,13 @@ In JSON, extensions are represented similarly:
 </p>
 <pre class="json" fragment="HumanName">
 {
-  "extension" : [{
-    "url" : "http://hl7.org/fhir/StructureDefinition/iso-21090-EN-use",
-    "valueCode" : "I"
-  }],
-  "text" : "Chief Red Cloud"
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/iso-21090-EN-use",
+      "valueCode": "I"
+    }
+  ],
+  "text": "Chief Red Cloud"
 }
 </pre>
 </div>
@@ -155,24 +157,31 @@ Or in JSON:
 </p>
 <pre class="json" fragment="Patient">
 {
-  "resourceType" : "Patient",
-  "extension" : [{
-    "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
-    "extension" : [{
-      "url" : "code",
-      "valueCodeableConcept" : {
-          "coding" : [{
-             "system" : "urn:iso:std:iso:3166",
-             "code" : "DE"
-          }]
-       }
-    }, {
-      "url" : "period",
-      "valuePeriod" : {
-         "start" : "2009-03-14"
-      }
-    }]
-	}]
+  "resourceType": "Patient",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
+      "extension": [
+        {
+          "url": "code",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "DE"
+              }
+            ]
+          }
+        },
+        {
+          "url": "period",
+          "valuePeriod": {
+            "start": "2009-03-14"
+          }
+        }
+      ]
+    }
+  ]
 }
 </pre>
 </div>
@@ -213,30 +222,36 @@ The URL of the extension is thus different. In XML:
 or in JSON:
 </p>
 <pre class="json" fragment="Patient">
-
 {
-  "resourceType" : "Patient",
-  "extension" : [{
-    "url" : "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
-    "extension" : [{
-      "url" : "code",
-      "valueCodeableConcept" : {
-        "coding" : [{
-          "system" : "urn:iso:std:iso:3166",
-          "code" : "DE"
-        }]
-      }
-    },{
-      "url" : "period",
-      "valuePeriod" : {
-        "start" : "2009-03-14"
-      }
-    },
-		{
-      "url": "http://acme.org/fhir/StructureDefinition/passport-number",
-      "valueString": "12345ABC"
-    }]
-  }]
+  "resourceType": "Patient",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-citizenship",
+      "extension": [
+        {
+          "url": "code",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "DE"
+              }
+            ]
+          }
+        },
+        {
+          "url": "period",
+          "valuePeriod": {
+            "start": "2009-03-14"
+          }
+        },
+        {
+          "url": "http://acme.org/fhir/StructureDefinition/passport-number",
+          "valueString": "12345ABC"
+        }
+      ]
+    }
+  ]
 }
 </pre>
 <p>
@@ -317,11 +332,13 @@ Or in JSON:
 </p>
 <pre class="json">
 {
-  "resourceType" : "MedicationRequest",
-  "modifierExtension" : [{
-    "url" : "http://example.org/fhir/StructureDefinition/anti-prescription",
-    "valueBoolean" : true
-  }],
+  "resourceType": "MedicationRequest",
+  "modifierExtension": [
+    {
+      "url": "http://example.org/fhir/StructureDefinition/anti-prescription",
+      "valueBoolean": true
+    }
+  ],
   .. other content ...
 }
 </pre>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=20180  `

## Description

I noticed that some of the formatting on the extensions page were formatted oddly. I'm not against a more compact representation, but some examples are really hard to read. I'm looking for feedback on this change. I propose that the formatting of embedded examples match the "pretty" example formatting in the rest of the spec. 

https://github.com/HL7/fhir/blob/master/implementations/java/org.hl7.fhir.r4/src/org/hl7/fhir/r4/formats/JsonCreatorDirect.java

I think this is equivalent to `JSON.stringify(data, null, 2)` in javascript. 

If this sounds like a good idea, I can find all the other examples and update them too. 
