### PR TITLE
removed the actual never used javax.annotation dependency and import

### DIFF
--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/java/JavaGenerator.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/java/JavaGenerator.java
@@ -48,9 +48,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import javax.annotation.Resource;
-
 import org.hl7.fhir.definitions.Config;
 import org.hl7.fhir.definitions.model.Definitions;
 import org.hl7.fhir.definitions.model.ElementDefn;


### PR DESCRIPTION
## HL7 FHIR Pull Request

removed https://github.com/HL7/fhir/blob/8e9ff3675b976a7db2074b3a239193c912b65c9e/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/java/JavaGenerator.java#L52

as it was never used and cause build errors.