### PR TITLE
GF#22805 - harmonized value sets for Immunization.subpotentReason and…

### DIFF
--- a/source/immunization/codesystem-immunization-subpotent-reason.xml
+++ b/source/immunization/codesystem-immunization-subpotent-reason.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
   <url value="http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason"/>
@@ -11,7 +11,7 @@
   <caseSensitive value="true"/>
   <content value="complete"/>
   <concept>
-    <code value="partial"/>
+    <code value="partialdose"/>
     <display value="Partial Dose"/>
     <definition value="The full volume of the dose was not administered to the patient."/>
   </concept>
@@ -24,5 +24,15 @@
     <code value="recall"/>
     <display value="Manufacturer Recall"/>
     <definition value="The vaccine was recalled by the manufacturer."/>
+  </concept>
+  <concept>
+    <code value="adversestorage"/>
+    <display value="Adverse Storage"/>
+    <definition value="The vaccine experienced adverse storage conditions."/>
+  </concept>
+  <concept>
+    <code value="expired"/>
+    <display value="Expired Product"/>
+    <definition value="The vaccine was expired at the time of administration."/>
   </concept>
 </CodeSystem>

--- a/source/immunization/immunization-example-subpotent.xml
+++ b/source/immunization/immunization-example-subpotent.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--Authored by Joginder Madra-->
 <Immunization xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/immunization.xsd">
 	<id value="subpotent"/>
@@ -78,7 +78,7 @@
 	<subpotentReason>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/immunization-subpotent-reason"/>
-			<code value="partial"/>
+			<code value="partialdose"/>
 		</coding>
 	</subpotentReason>
 	<education>

--- a/source/immunizationevaluation/codesystem-immunization-evaluation-dose-status-reason.xml
+++ b/source/immunizationevaluation/codesystem-immunization-evaluation-dose-status-reason.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
   <url value="http://terminology.hl7.org/CodeSystem/immunization-evaluation-dose-status-reason"/>
@@ -11,28 +11,33 @@
   <caseSensitive value="true"/>
   <content value="complete"/>
   <concept>
-    <code value="advstorage"/>
-    <display value="Adverse storage condition"/>
-    <definition value="The product was stored in a manner inconsistent with manufacturer guidelines potentially reducing the effectiveness of the product."/>
+    <code value="partialdose"/>
+    <display value="Partial Dose"/>
+    <definition value="The full volume of the dose was not administered to the patient."/>
   </concept>
   <concept>
-    <code value="coldchbrk"/>
-    <display value="Cold chain break"/>
-    <definition value="The product was stored at a temperature inconsistent with manufacturer guidelines potentially reducing the effectiveness of the product."/>
+    <code value="coldchainbreak"/>
+    <display value="Cold Chain Break"/>
+    <definition value="The vaccine experienced a cold chain break."/>
   </concept>
   <concept>
-    <code value="explot"/>
-    <display value="Expired lot"/>
-    <definition value="The product was administered after the expiration date associated with lot of vaccine."/>
+    <code value="recall"/>
+    <display value="Manufacturer Recall"/>
+    <definition value="The vaccine was recalled by the manufacturer."/>
   </concept>
   <concept>
-    <code value="outsidesched"/>
-    <display value="Administered outside recommended schedule"/>
-    <definition value="The product was administered at a time inconsistent with the documented schedule."/>
+    <code value="adversestorage"/>
+    <display value="Adverse Storage"/>
+    <definition value="The vaccine experienced adverse storage conditions."/>
   </concept>
   <concept>
-    <code value="prodrecall"/>
-    <display value="Product recall"/>
-    <definition value="The product administered has been recalled by the manufacturer."/>
+    <code value="expired"/>
+    <display value="Expired Product"/>
+    <definition value="The vaccine was expired at the time of administration."/>
+  </concept>
+  <concept>
+    <code value="outsideschedule"/>
+    <display value="Outside Schedule"/>
+    <definition value="The vaccine was administered in a manner that is inconsistent with the evaluated schedule."/>
   </concept>
 </CodeSystem>

--- a/source/immunizationevaluation/immunizationevaluation-example-notvalid.xml
+++ b/source/immunizationevaluation/immunizationevaluation-example-notvalid.xml
@@ -32,8 +32,8 @@
 	<doseStatusReason>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/immunization-evaluation-dose-status-reason"/>
-			<code value="outsidesched"/>
-			<display value="Administered outside recommended schedule"/>
+			<code value="outsideschedule"/>
+			<display value="Outside Schedule"/>
 		</coding>
 	</doseStatusReason>
 	<series value="Vaccination Series 1"/>


### PR DESCRIPTION
… ImmunizationEvaluation.doseStatusReason

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 FHIR gForge tracker](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemBrowse&tracker_id=677).

If you made changes to any files within `./source` please indicate the gForge tracker number this pull request is associated with: `   `

## Description

Per gForge #22805, the example value sets for Immunization.subpotentReason and ImmunizationEvaluation.doseStatusReason have been harmonized where there are overlapping terms