### PR TITLE
Made a minor change to the ID in an example for the Evidence resource

### DIFF
--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -26,7 +26,7 @@
 			<display value="acute ischemic stroke"/>
 		</evidenceSource>
 		<intendedGroup>
-			<reference value="Group/AcuteIschemicStroke0-4halfHours"/>
+			<reference value="Group/AcuteIschemicStroke3-4halfHours"/>
 			<display value="stroke at 3-4.5 hours"/>
 		</intendedGroup>
 		<directnessMatch>


### PR DESCRIPTION
J#25774

There was a minor error introduced in my past couple of FHIR pull requests representing the FHIR Jira tracker item 25774. The error is in the reference to a made up resource "Group/AcuteIschemicStroke3-4halfHours" but it was accidentally written as "0-4halfHours" instead of "3-4halfHours." So this has been fixed for this pull request, where it's just one character difference (changing "0" to a "3").