### PR TITLE
Changes as described in FHIR Tracker Item J# 26652

### DIFF
--- a/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
@@ -36,7 +36,7 @@
 		<intended>
 			<reference value="Group/ASTRAL-12"/>
 			<type value="Group"/>
-			<display value="Stroke with ASTRAL Score = 12"/>
+			<display value="patients 0-4.5 hours after acute ischemic stroke onset with ASTRAL score = 12"/>
 		</intended>
 	</variableDefinition>
 	<variableDefinition>
@@ -63,32 +63,6 @@
 				<system value="http://terminology.hl7.org/CodeSystem/directness"/>
 				<code value="high"/>
 				<display value="High quality match"/>
-			</coding>
-		</directnessMatch>
-	</variableDefinition>
-	<variableDefinition>
-		<variableRole>
-			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-				<code value="exposure"/>
-				<display value="exposure"/>
-			</coding>
-		</variableRole>
-		<observed>
-			<reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-			<type value="EvidenceVariable"/>
-			<display value="Alteplase for Stroke"/>
-		</observed>
-		<intended>
-			<reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-			<type value="EvidenceVariable"/>
-			<display value="Alteplase for Stroke"/>
-		</intended>
-		<directnessMatch>
-			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/directness"/>
-				<code value="exact"/>
-				<display value="Exact match"/>
 			</coding>
 		</directnessMatch>
 	</variableDefinition>

--- a/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
@@ -29,9 +29,9 @@
 			</coding>
 		</variableRole>
 		<observed>
-			<reference value="Group/AcuteIschemicStroke0-3Hours"/>
-			<type value="Group"/>
-			<display value="stroke at 0-3 hours"/>
+			<reference value="EvidenceVariable/Wardlaw2014Analysis1.16.3EvidenceSet"/>
+			<type value="EvidenceVariable"/>
+			<display value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
 		</observed>
 		<intended>
 			<reference value="Group/AcuteIschemicStroke0-3Hours"/>

--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -29,9 +29,9 @@
 			</coding>
 		</variableRole>
 		<observed>
-			<reference value="Group/AcuteIschemicStroke"/>
-			<type value="Group"/>
-			<display value="acute ischemic stroke"/>
+			<reference value="EvidenceVariable/Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
+			<type value="EvidenceVariable"/>
+			<display value="Stroke Thrombolysis Trialists’ 2014-2016 IPD-MA Cohort"/>
 		</observed>
 		<intended>
 			<reference value="Group/AcuteIschemicStroke3-4halfHours"/>

--- a/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
@@ -29,14 +29,14 @@
 			</coding>
 		</variableRole>
 		<observed>
-			<reference value="Group/AcuteIschemicStroke"/>
+			<reference value="Group/Emberson-2014-IPD-MA-Alteplase-Cohort"/>
 			<type value="Group"/>
-			<display value="adults with acute ischemic stroke"/>
+			<display value="Emberson 2014 IPD-MA Alteplase Cohort"/>
 		</observed>
 		<intended>
-			<reference value="Group/AcuteIschemicStroke"/>
+			<reference value="Group/AcuteIschemicStrokeTreatedWithAlteplase"/>
 			<type value="Group"/>
-			<display value="adults with acute ischemic stroke"/>
+			<display value="adults with acute ischemic stroke treated with alteplase"/>
 		</intended>
   </variableDefinition>
   <variableDefinition>
@@ -56,25 +56,6 @@
 			<reference value="EvidenceVariable/example-fatal-ICH-in-7-days"/>
 			<type value="EvidenceVariable"/>
 			<display value="fatal ICH"/>
-		</intended>
-  </variableDefinition>
-  <variableDefinition>
-		<variableRole>
-			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-				<code value="exposure"/>
-				<display value="exposure"/>
-			</coding>
-		</variableRole>
-		<observed>
-			<reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-			<type value="EvidenceVariable"/>
-			<display value="Alteplase for Stroke"/>
-		</observed>
-		<intended>
-			<reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-			<type value="EvidenceVariable"/>
-			<display value="Alteplase for Stroke"/>
 		</intended>
   </variableDefinition>
 	<synthesisType>

--- a/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
@@ -29,14 +29,14 @@
 			</coding>
 		</variableRole>
 		<observed>
-			<reference value="Group/AcuteIschemicStroke"/>
+			<reference value="Group/Emberson-2014-IPD-MA-No-Alteplase-Cohort"/>
 			<type value="Group"/>
-			<display value="adults with acute ischemic stroke"/>
+			<display value="Emberson 2014 IPD-MA No Alteplase Cohort"/>
 		</observed>
 		<intended>
-			<reference value="Group/AcuteIschemicStroke"/>
+			<reference value="Group/AcuteIschemicStrokeTreatedWithoutAlteplase"/>
 			<type value="Group"/>
-			<display value="adults with acute ischemic stroke"/>
+			<display value="adults with acute ischemic stroke treated without alteplase"/>
 		</intended>
   </variableDefinition>
   <variableDefinition>
@@ -56,25 +56,6 @@
 			<reference value="EvidenceVariable/example-fatal-ICH-in-7-days"/>
 			<type value="EvidenceVariable"/>
 			<display value="fatal ICH"/>
-		</intended>
-  </variableDefinition>
-  <variableDefinition>
-		<variableRole>
-			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-				<code value="exposure"/>
-				<display value="exposure"/>
-			</coding>
-		</variableRole>
-		<observed>
-			<reference value="EvidenceVariable/example-no-alteplase"/>
-			<type value="EvidenceVariable"/>
-			<display value="no alteplase"/>
-		</observed>
-		<intended>
-			<reference value="EvidenceVariable/example-no-alteplase"/>
-			<type value="EvidenceVariable"/>
-			<display value="no alteplase"/>
 		</intended>
   </variableDefinition>
 	<synthesisType>

--- a/source/evidencevariable/evidencevariable-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
+++ b/source/evidencevariable/evidencevariable-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EvidenceVariable xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/evidencevariable.xsd">
+  <id value="example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
+  <text>
+    <status value="generated" />
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>
+        Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis
+      </p>
+	</div>
+  </text>
+  <name value="Stroke Thrombolysis Trialists’ 2014-2016 IPD-MA Cohort"/>
+  <title value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+	<status value="draft"/>
+	<relatedArtifact>
+		<type value="citation"/>
+		<label value="Emberson 2014"/>
+		<display value="Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials."/>
+		<citation value="Emberson J, Lees KR, Lyden P, Blackwell L, Albers G, Bluhmki E, et al;Stroke Thrombolysis Trialists&apos; Collaborative Group. Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. Lancet 2014 Nov 29;384(9958):1929-35 PMID 25106063"/>
+		<url value="https://doi.org/10.1016/S0140-6736(14)60584-5"/>
+	</relatedArtifact>
+	<relatedArtifact>
+		<type value="citation"/>
+		<label value="Lees 2016"/>
+		<display value="Figure 2 Lees 2016"/>
+		<citation value="Lees KR, Emberson J, Blackwell L, Bluhmki E, Davis SM, Donnan GA, et al; Stroke Thrombolysis Trialists’ Collaborators Group. Effects of alteplase for acute stroke on the distribution of functional outcomes: a pooled analysis of 9 trials. Stroke. 2016;47:2373-2379. PMID 27507856"/>
+		<url value="https://doi.org/10.1161/STROKEAHA.116.013644"/>
+	</relatedArtifact>
+	<actual value="true"/>
+	<characteristicCombination value="union"/>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/ECASSIII-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="ECASS III Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/IST3-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="IST3 Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/ECASS-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="ECASS Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/ECASSII-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="ECASSII Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/EPITHET-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="EPITHET Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/ATLANTIS-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="ATLANTIS Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<reference value="Group/NINDS-Trial-Cohort"/>
+			<type value="Group"/>
+			<display value="NINDS Trial Cohort"/>
+		</definitionReference>
+	</characteristic>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
+++ b/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EvidenceVariable xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/evidencevariable.xsd">
+  <id value="example-Wardlaw2014Analysis1.16.3EvidenceSet"/>
+  <text>
+    <status value="generated" />
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>
+        &quot;Wardlaw 2014 Analysis 1.16.3 Evidence set&quot; is a grouping of six Evidence results used in a meta-analysis.
+      </p>
+	</div>
+  </text>
+  <name value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
+  <title value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
+	<status value="draft"/>
+	<note>
+		<text value="Short names for Evidence sources are detailed in &quot;References to studies included in this review&quot;"/>
+	</note>
+	<relatedArtifact>
+		<type value="citation"/>
+		<label value="Wardlaw 2014"/>
+		<display value="Analysis 1.16.3 from Wardlaw 2014"/>
+		<citation value="Wardlaw JM, Murray V, Berge E, del Zoppo GJ. Thrombolysis for acute ischaemic stroke. Cochrane Database Syst Rev. 2014 Jul 29(7):CD000213. PMID 25072528"/>
+		<url value="https://doi.org/10.1002/14651858.CD000213.pub3"/>
+	</relatedArtifact>
+	<type value="dichotomous"/>
+	<actual value="true"/>
+	<characteristicCombination value="union"/>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="NINDS 1995"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="ECASS 1995"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="ECASS II 1998"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="ATLANTIS B 1999"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="ATLANTIS A 2000"/>
+		</definitionReference>
+	</characteristic>
+	<characteristic>
+		<definitionReference>
+			<type value="Evidence"/>
+			<display value="IST3 2012"/>
+		</definitionReference>
+	</characteristic>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-spreadsheet.xml
+++ b/source/evidencevariable/evidencevariable-spreadsheet.xml
@@ -18,8 +18,7 @@
   
   
   <TabRatio>709</TabRatio>
-  <ActiveSheet>12</ActiveSheet>
-  <FirstVisibleSheet>8</FirstVisibleSheet>
+  <ActiveSheet>7</ActiveSheet>
   <RefModeR1C1/>
   <ProtectStructure>False</ProtectStructure>
   <ProtectWindows>False</ProtectWindows>
@@ -1660,7 +1659,7 @@
     <Cell ss:StyleID="s87"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s87"><Data ss:Type="String">1..1</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s87"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s87"><Data ss:Type="String">Reference(Group) | canonical(ActivityDefinition) | CodeableConcept | Expression |</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s87"><Data ss:Type="String">Reference(Group | EvidenceVariable) | canonical(Any) | CodeableConcept | Expression |</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s87"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s87"><Data ss:Type="String">Y</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s87"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -4103,9 +4102,9 @@
    <FreezePanes/>
    <FrozenNoSplit/>
    <SplitHorizontal>1</SplitHorizontal>
-   <TopRowBottomPane>26</TopRowBottomPane>
+   <TopRowBottomPane>10</TopRowBottomPane>
    <SplitVertical>1</SplitVertical>
-   <LeftColumnRightPane>9</LeftColumnRightPane>
+   <LeftColumnRightPane>1</LeftColumnRightPane>
    <ActivePane>0</ActivePane>
    
    <ProtectObjects>False</ProtectObjects>
@@ -6200,22 +6199,22 @@
     <Cell ss:StyleID="s147"><Data ss:Type="String">y</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">
-    <Cell ss:StyleID="s146"/>
+    <Cell ss:StyleID="s146"><Data ss:Type="String">Wardlaw 2014 Analysis 1.16.3 Evidence set</Data></Cell>
     <Cell ss:StyleID="s87"/>
-    <Cell ss:StyleID="s88"/>
-    <Cell ss:StyleID="s87"/>
-    <Cell ss:StyleID="s87"/>
+    <Cell ss:StyleID="s88"><Data ss:Type="String">A grouping of six Evidence resources from six studies</Data></Cell>
+    <Cell ss:StyleID="s87"><Data ss:Type="String">example-Wardlaw2014Analysis1.16.3EvidenceSet</Data></Cell>
+    <Cell ss:StyleID="s87"><Data ss:Type="String">evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml</Data></Cell>
     <Cell ss:StyleID="s137"/>
-    <Cell ss:StyleID="s147"/>
+    <Cell ss:StyleID="s147"><Data ss:Type="String">y</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">
-    <Cell ss:StyleID="s146"/>
+    <Cell ss:StyleID="s146"><Data ss:Type="String">Stroke Thrombolysis Trialists’ 2014-2016 IPD-MA Cohort</Data></Cell>
     <Cell ss:StyleID="s87"/>
-    <Cell ss:StyleID="s88"/>
-    <Cell ss:StyleID="s87"/>
-    <Cell ss:StyleID="s87"/>
+    <Cell ss:StyleID="s88"><Data ss:Type="String">Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis</Data></Cell>
+    <Cell ss:StyleID="s87"><Data ss:Type="String">example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort</Data></Cell>
+    <Cell ss:StyleID="s87"><Data ss:Type="String">evidencevariable-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml</Data></Cell>
     <Cell ss:StyleID="s137"/>
-    <Cell ss:StyleID="s147"/>
+    <Cell ss:StyleID="s147"><Data ss:Type="String">y</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">
     <Cell ss:StyleID="s146"/>
@@ -6486,12 +6485,13 @@
     <Footer x:Margin="0.3"/>
     <PageMargins x:Bottom="0.75" x:Left="0.7" x:Right="0.7" x:Top="0.75"/>
    </PageSetup>
+   <Selected/>
    <FreezePanes/>
    <FrozenNoSplit/>
    <SplitHorizontal>1</SplitHorizontal>
    <TopRowBottomPane>1</TopRowBottomPane>
    <SplitVertical>1</SplitVertical>
-   <LeftColumnRightPane>3</LeftColumnRightPane>
+   <LeftColumnRightPane>1</LeftColumnRightPane>
    <ActivePane>0</ActivePane>
    
    <ProtectObjects>False</ProtectObjects>
@@ -8653,8 +8653,6 @@
     <Footer x:Margin="0.3"/>
     <PageMargins x:Bottom="0.75" x:Left="0.7" x:Right="0.7" x:Top="0.75"/>
    </PageSetup>
-   <Selected/>
-   
    <ProtectObjects>False</ProtectObjects>
    <ProtectScenarios>False</ProtectScenarios>
   </WorksheetOptions>

--- a/vscache/audit-event-outcome.cache
+++ b/vscache/audit-event-outcome.cache
@@ -1,0 +1,33 @@
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/audit-event-outcome",
+  "code" : "0"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Success",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/audit-event-outcome",
+  "code" : "0",
+  "display" : "Success"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Success",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://hl7.org/fhir/audit-event-outcome",
+  "code" : "8",
+  "display" : "Serious Failure"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Serious failure",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------


### PR DESCRIPTION

1. Currently characteristic.definitionReference is Reference(Group), but we will change it to be Reference (Group | EvidenceVariable).

2. We will also change characteristic.definitionCanonical to be canonical(Any)

3. We will modify all five of the current Evidence examples to reference Groups or EvidenceVariables to represent the actual groups used in research cohorts in published studies. To support this, the EvidenceVariable resource will be changed as described in this FHIR tracker item and we will add two EvidenceVariable examples. These new EvidenceVariable examples will be called, "Wardlaw2014Analysis1.16.3EvidenceSet" and "Stroke_Thrombolysis_Trialists_2014-2016_IPD-MA_Cohort."
