### PR TITLE
Updated the value set certainty rating url for the Evidence resource for three examples

### DIFF
--- a/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
@@ -122,7 +122,7 @@
 	<certainty>
 		<rating>
 			<coding>
-				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
+				<system value="http://terminology.hl7.org/CodeSystem/evidence-quality"/>
 				<code value="high"/>
 				<display value="High quality"/>
 			</coding>

--- a/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
@@ -122,7 +122,7 @@
 	<certainty>
 		<rating>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/certainty-rating"/>
+				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
 				<code value="high"/>
 				<display value="High quality"/>
 			</coding>

--- a/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
@@ -179,7 +179,7 @@
 		<description value="Moderate certainty due to risk of bias"/>
 		<rating>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/certainty-rating"/>
+				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
 				<code value="moderate"/>
 				<display value="Moderate"/>
 			</coding>

--- a/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
@@ -179,7 +179,7 @@
 		<description value="Moderate certainty due to risk of bias"/>
 		<rating>
 			<coding>
-				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
+				<system value="http://terminology.hl7.org/CodeSystem/evidence-quality"/>
 				<code value="moderate"/>
 				<display value="Moderate"/>
 			</coding>

--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -155,7 +155,7 @@
 		<description value="Very low certainty due to risk of bias, inconsistency, imprecision, and indirectness"/>
 		<rating>
 			<coding>
-				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
+				<system value="http://terminology.hl7.org/CodeSystem/evidence-quality"/>
 				<code value="very-low"/>
 				<display value="Very low quality"/>
 			</coding>

--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -155,7 +155,7 @@
 		<description value="Very low certainty due to risk of bias, inconsistency, imprecision, and indirectness"/>
 		<rating>
 			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/certainty-rating"/>
+				<system value="http://hl7.org/fhir/ValueSet/evidence-quality"/>
 				<code value="very-low"/>
 				<display value="Very low quality"/>
 			</coding>


### PR DESCRIPTION
Corrected three examples for the Evidence resource so it uses this url for certainty rating: http://hl7.org/fhir/ValueSet/evidence-quality

In relation to J#28134 https://jira.hl7.org/browse/FHIR-28134