### PR TITLE
FHIR-27772 - add assert.stopTestOnFail boolean to TestScript

### DIFF
--- a/source/testscript/testscript-example-history.xml
+++ b/source/testscript/testscript-example-history.xml
@@ -91,6 +91,7 @@
         <direction value="response"/>
         <operator value="in"/>
         <responseCode value="200,204"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -115,6 +116,7 @@
         <description value="Confirm that the returned HTTP status is 201(Created)."/>
         <direction value="response"/>
         <responseCode value="201"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -139,6 +141,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <responseCode value="200"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -165,6 +168,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -172,12 +176,14 @@
       <assert>
         <description value="Confirm that the returned resource type is Bundle."/>
         <resource value="Bundle"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
     <action>
       <assert>
         <description value="Confirm that the returned Bundle conforms to the base FHIR specification."/>
+        <stopTestOnFail value="false"/>
         <validateProfileId value="bundle-profile"/>
         <warningOnly value="false"/>
       </assert>
@@ -187,6 +193,7 @@
         <description value="Confirm that the returned Bundle type equals &#39;history&#39;."/>
         <operator value="equals"/>
         <path value="fhir:Bundle/fhir:type/@value"/>
+        <stopTestOnFail value="false"/>
         <value value="history"/>
         <warningOnly value="false"/>
       </assert>

--- a/source/testscript/testscript-example-multisystem.xml
+++ b/source/testscript/testscript-example-multisystem.xml
@@ -106,6 +106,7 @@
       <assert>
         <description value="Confirm that the request method GET was sent by the client system under test."/>
         <requestMethod value="get"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -115,6 +116,7 @@
         <direction value="request"/>
         <headerField value="Accept"/>
         <operator value="contains"/>
+        <stopTestOnFail value="false"/>
         <value value="xml"/>
         <warningOnly value="false"/>
       </assert>
@@ -124,6 +126,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -132,6 +135,7 @@
         <description value="Confirm that the returned format is XML."/>
         <direction value="response"/>
         <contentType value="xml"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -140,6 +144,7 @@
         <description value="Confirm that the returned resource type is Patient."/>
         <direction value="response"/>
         <resource value="Patient"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -173,6 +178,7 @@
         <direction value="request"/>
         <headerField value="Accept"/>
         <operator value="contains"/>
+        <stopTestOnFail value="false"/>
         <value value="xml"/>
         <warningOnly value="false"/>
       </assert>
@@ -182,6 +188,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -190,6 +197,7 @@
         <description value="Confirm that the returned format is XML."/>
         <direction value="response"/>
         <contentType value="xml"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -198,6 +206,7 @@
         <description value="Confirm that the returned resource type is Patient."/>
         <direction value="response"/>
         <resource value="Patient"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>

--- a/source/testscript/testscript-example-readtest.xml
+++ b/source/testscript/testscript-example-readtest.xml
@@ -75,6 +75,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -82,6 +83,7 @@
       <assert>
         <description value="Confirm that the returned format is XML."/>
         <contentType value="xml"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -90,6 +92,7 @@
         <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server might not support versioning."/>
         <headerField value="Last-Modified"/>
         <operator value="notEmpty"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="true"/>
       </assert>
     </action>
@@ -97,12 +100,14 @@
       <assert>
         <description value="Confirm that the returned resource type is Patient."/>
         <resource value="Patient"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
     <action>
       <assert>
         <description value="Confirm that the returned Patient conforms to the base FHIR specification."/>
+        <stopTestOnFail value="false"/>
         <validateProfileId value="patient-profile"/>
         <warningOnly value="false"/>
       </assert>
@@ -128,6 +133,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 404(Not Found)."/>
         <response value="notFound"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -152,6 +158,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 404(Not Found)."/>
         <response value="notFound"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -176,6 +183,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 400(Bad Request)."/>
         <response value="bad"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>

--- a/source/testscript/testscript-example-search.xml
+++ b/source/testscript/testscript-example-search.xml
@@ -95,6 +95,7 @@
         <direction value="request"/>
         <operator value="contains"/>
         <requestURL value="family"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -103,6 +104,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <responseCode value="200"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -110,6 +112,7 @@
       <assert>
         <description value="Confirm that the returned resource type is Bundle."/>
         <resource value="Bundle"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -117,6 +120,7 @@
       <assert>
         <description value="Confirm that the returned Bundle correctly defines the navigation links."/>
         <navigationLinks value="true"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -143,6 +147,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 201(Created)."/>
         <response value="created"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -152,6 +157,7 @@
         <direction value="response"/>
         <headerField value="Location"/>
         <operator value="notEmpty"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -171,6 +177,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -178,6 +185,7 @@
       <assert>
         <description value="Confirm that the returned resource type is Patient."/>
         <resource value="Patient"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -202,6 +210,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -209,6 +218,7 @@
       <assert>
         <description value="Confirm that the returned format is XML."/>
         <contentType value="xml"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -216,12 +226,14 @@
       <assert>
         <description value="Confirm that the returned resource type is Bundle."/>
         <resource value="Bundle"/>
+        <stopTestOnFail value="true"/>
         <warningOnly value="false"/>
       </assert>
     </action>
     <action>
       <assert>
         <description value="Confirm that the returned Bundle conforms to the base FHIR specification."/>
+        <stopTestOnFail value="false"/>
         <validateProfileId value="bundle-profile"/>
         <warningOnly value="false"/>
       </assert>
@@ -231,6 +243,7 @@
         <description value="Confirm that the returned Bundle type equals &#39;searchset&#39;."/>
         <operator value="equals"/>
         <path value="fhir:Bundle/fhir:type/@value"/>
+        <stopTestOnFail value="false"/>
         <value value="searchset"/>
         <warningOnly value="false"/>
       </assert>
@@ -239,6 +252,7 @@
       <assert>
         <description value="Confirm that the returned Bundle total is greater than or equal to the number of returned entries."/>
         <expression value="Bundle.total.toInteger() &gt;= entry.count()"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>

--- a/source/testscript/testscript-example-update.xml
+++ b/source/testscript/testscript-example-update.xml
@@ -90,6 +90,7 @@
         <direction value="response"/>
         <operator value="in"/>
         <responseCode value="200,204"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -114,6 +115,7 @@
         <description value="Confirm that the returned HTTP status is 201(Created)."/>
         <direction value="response"/>
         <responseCode value="201"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -141,6 +143,7 @@
       <assert>
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -148,6 +151,7 @@
       <assert>
         <description value="Confirm that the returned format is XML."/>
         <contentType value="xml"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -156,6 +160,7 @@
         <description value="Confirm that the returned HTTP Header Last-Modified is present. Warning only as the server might not support versioning."/>
         <headerField value="Last-Modified"/>
         <operator value="notEmpty"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="true"/>
       </assert>
     </action>

--- a/source/testscript/testscript-example.xml
+++ b/source/testscript/testscript-example.xml
@@ -34,6 +34,20 @@
       </coding>
     </valueCodeableConcept>
   </useContext>
+  <useContext>
+    <code>
+      <system value="http://terminology.hl7.org/CodeSystem/usage-context-type"/>
+      <code value="program"/>
+    </code>
+    <valueRange>
+      <low>
+        <value value="2018" />
+        <unit value="year" />
+        <system value="http://unitsofmeasure.org" />
+        <code value="a" />
+      </low>
+    </valueRange>
+  </useContext>
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166"/>
@@ -103,6 +117,7 @@
         <direction value="response"/>
         <operator value="in"/>
         <responseCode value="200,204"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -127,6 +142,7 @@
         <description value="Confirm that the returned HTTP status is 201(Created)."/>
         <direction value="response"/>
         <responseCode value="201"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -147,6 +163,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -156,6 +173,7 @@
         <compareToSourceId value="fixture-patient-create"/>
         <compareToSourceExpression value="Patient.name.first().family"/>
         <operator value="equals"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -182,6 +200,7 @@
         <description value="Confirm that the returned HTTP status is 200(OK)."/>
         <direction value="response"/>
         <response value="okay"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -191,6 +210,7 @@
         <direction value="response"/>
         <headerField value="Last-Modified"/>
         <operator value="notEmpty"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="true"/>
       </assert>
     </action>
@@ -198,12 +218,14 @@
       <assert>
         <description value="Confirm that the returned resource type is Patient."/>
         <resource value="Patient"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
     <action>
       <assert>
         <description value="Confirm that the returned Patient conforms to the base FHIR specification."/>
+        <stopTestOnFail value="false"/>
         <validateProfileId value="patient-profile"/>
         <warningOnly value="false"/>
       </assert>
@@ -214,6 +236,7 @@
         <operator value="equals"/>
         <path value="fhir:Patient/fhir:name/fhir:family/@value"/>
         <sourceId value="fixture-patient-read"/>
+        <stopTestOnFail value="false"/>
         <value value="Chalmers"/>
         <warningOnly value="false"/>
       </assert>
@@ -224,6 +247,7 @@
         <operator value="equals"/>
         <path value="fhir:Patient/fhir:name/fhir:given/@value"/>
         <sourceId value="fixture-patient-read"/>
+        <stopTestOnFail value="false"/>
         <value value="Peter"/>
         <warningOnly value="false"/>
       </assert>
@@ -235,6 +259,7 @@
         <compareToSourcePath value="fhir:Patient/fhir:name/fhir:family/@value"/>
         <operator value="equals"/>
         <path value="fhir:Patient/fhir:name/fhir:family/@value"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -245,6 +270,7 @@
         <compareToSourcePath value="fhir:Patient/fhir:name/fhir:given/@value"/>
         <path value="fhir:Patient/fhir:name/fhir:given/@value"/>
         <sourceId value="fixture-patient-read"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="false"/>
       </assert>
     </action>
@@ -252,6 +278,7 @@
       <assert>
         <description value="Confirm that the returned resource contains the expected retained elements and values. Warning only to provide users with reviewable results."/>
         <minimumId value="fixture-patient-minimum"/>
+        <stopTestOnFail value="false"/>
         <warningOnly value="true"/>
       </assert>
     </action>

--- a/source/testscript/testscript-spreadsheet.xml
+++ b/source/testscript/testscript-spreadsheet.xml
@@ -859,9 +859,9 @@
  </Worksheet>
  <Worksheet ss:Name="Data Elements">
   <Names>
-   <NamedRange ss:Hidden="1" ss:Name="_FilterDatabase" ss:RefersTo="='Data Elements'!R1C1:R103C24"/>
+   <NamedRange ss:Hidden="1" ss:Name="_FilterDatabase" ss:RefersTo="='Data Elements'!R1C1:R104C24"/>
   </Names>
-  <Table ss:ExpandedColumnCount="27" ss:ExpandedRowCount="172" ss:StyleID="s68" x:FullColumns="1" x:FullRows="1">
+  <Table ss:ExpandedColumnCount="27" ss:ExpandedRowCount="173" ss:StyleID="s68" x:FullColumns="1" x:FullRows="1">
    <Column ss:AutoFitWidth="0" ss:StyleID="s69" ss:Width="295.0"/>
    <Column ss:AutoFitWidth="0" ss:StyleID="s68" ss:Width="77.0"/>
    <Column ss:StyleID="s68" ss:Width="29.0"/>
@@ -3238,6 +3238,31 @@
     <Cell ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s100"><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
+   <Row ss:Height="90">
+    <Cell ss:StyleID="s88"><Data ss:Type="String">TestScript.setup.action.assert.stopTestOnFail</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><Data ss:Type="String">1..1</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><Data ss:Type="String">boolean</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><Data ss:Type="String">If this assert fails, will the current test execution stop?</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s89"><Data ss:Type="String">Whether or not the current test execution will stop on failure for this assert</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s90"><Data ss:Type="String">If this element is specified and it is true, then assertion failures should not stop the current test execution from proceeding.</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:Index="23" ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s100"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+   </Row>
    <Row ss:AutoFitHeight="0" ss:Height="75">
     <Cell ss:StyleID="s88"><Data ss:Type="String">TestScript.setup.action.assert.validateProfileId</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s89"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -5368,7 +5393,7 @@
    <ProtectScenarios>False</ProtectScenarios>
    <x:PageLayoutZoom>0</x:PageLayoutZoom>
   </WorksheetOptions>
-  <AutoFilter xmlns="urn:schemas-microsoft-com:office:excel" x:Range="R1C1:R103C24">
+  <AutoFilter xmlns="urn:schemas-microsoft-com:office:excel" x:Range="R1C1:R104C24">
   </AutoFilter>
  </Worksheet>
  <Worksheet ss:Name="Invariants">


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-27772`

## Description

_Addition of new boolean element to TestScript supporting the ability to control the test engine behavior when an assert fails. New boolean element is TestScript.setup.action.assert.stopTestOnFail where a value of `true` represents the current behavior of stopping the currently executing test and `false` allows, if present, the next assert to evaluate._
