### PR TITLE
Security cr

### DIFF
--- a/source/auditevent/audit-event-example-create-traceID.xml
+++ b/source/auditevent/audit-event-example-create-traceID.xml
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
+	<id value="example-rest-create-traceID"/>
+	<type>
+		<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
+		<code value="rest"/>
+		<display value="Restful Operation"/>
+	</type>
+	<subtype>
+		<system value="http://hl7.org/fhir/restful-interaction"/>
+		<code value="create"/>
+		<display value="create"/>
+	</subtype>
+	<action value="C"/>
+	<recorded value="2019-12-04T11:59:28.646+00:00"/>
+	<outcome>
+		<coding>
+			<system value="http://terminology.hl7.org/CodeSystem/audit-event-outcome"/>
+			<code value="0"/>
+			<display value="Success"/>
+		</coding>
+	</outcome> 
+
+	<agent>
+		<type>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/extra-security-role-type"/>
+				<code value="humanuser"/>
+				<display value="human user"/>
+			</coding>
+		</type> 
+
+		<who>
+			<identifier>
+				<value value="95"/>
+			</identifier>
+		</who>
+		<altId value="601847123"/>
+		<name value="Grahame Grieve"/>
+		<requestor value="true"/>
+	</agent>
+	<agent>
+		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<type>
+			<coding>
+				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+				<code value="110153"/>
+				<display value="Source Role ID"/>
+			</coding>
+		</type> 
+		<who>
+			<identifier>
+				<system value="urn:oid:2.16.840.1.113883.4.2"/> 
+				<value value="2.16.840.1.113883.4.2"/> 
+			</identifier>
+		</who>
+		<altId value="6580"/> 
+		<requestor value="false"/> 
+		<network>
+			<address value="Workstation1.ehr.familyclinic.com"/>
+			<type value="1"/>
+		</network> 
+	</agent>
+	<source>
+		<site value="Cloud"/>
+		<observer>
+		<identifier>
+			<value value="hl7connect.healthintersections.com.au"/>
+			</identifier>
+		</observer>
+		<type>
+			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
+			<code value="3"/>
+			<display value="Web Server"/>
+		</type>
+	</source>
+	<entity>
+		<what>
+			<reference value="Patient/example/_history/1"/>
+		</what>
+		<type>
+			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+			<code value="1"/>
+			<display value="Person"/>
+		</type>
+		<role>
+			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+			<code value="1"/>
+			<display value="Patient"/>
+		</role>
+	</entity>
+	<entity>
+		<!-- The TraceID from the software stack -->
+		<what>
+			<identifier>
+			    <type>
+					<text value="TraceID"/>
+				</type>
+				<system value="http://example.com/server"/>
+				<value value="6b507ee2d716780372c255df69ece653"/>
+			</identifier>
+		</what>
+		<type>
+			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+			<code value="2"/>
+			<display value="System Object"/>
+		</type>
+		<role>
+			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+			<code value="21"/>
+			<display value="Job Stream"/>
+		</role>
+	</entity>
+</AuditEvent>

--- a/source/auditevent/auditevent-introduction.xml
+++ b/source/auditevent/auditevent-introduction.xml
@@ -56,6 +56,13 @@ See the
 <a href="valueset-audit-event-sub-type.html">Audit Event Sub-Type</a> vocabulary for guidance on some security relevant events.
 </p>
 <p>
+The AuditEvent resource holds the details of an event in terms of who, what, where, when, and why. 
+Where the identification of the who participated is the agent. 
+An agent can be a person, an organization, software, device, or other actors that may be ascribed responsibility.  
+What objects were used/created/updated is recorded as the entity. 
+An entity is an identifiable physical, digital, conceptual or other kind of thing; entities may be real or imaginary.
+</p>
+<p>
 The content of an AuditEvent is intended for use by security system administrators, security and privacy information 
 managers, and records management personnel.  This content is not intended to be accessible or used directly by other 
 healthcare users, such as providers or patients, although reports generated from the raw data would be useful. An 

--- a/source/auditevent/list-AuditEvent-examples.xml
+++ b/source/auditevent/list-AuditEvent-examples.xml
@@ -54,6 +54,18 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="RESTful create with TraceID"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="audit-event-example-create-traceID"/>
+    </extension>
+    <item>
+      <reference value="AuditEvent/example-rest-create-traceID"/>
+      <display value="RESTful create"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
       <valueString value="Accounting of a Disclosure"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -401,6 +401,65 @@
         <map value="Provenance.reason, Provenance.activity"/>
       </mapping>
     </element>
+    <element id="AuditEvent.basedOn">
+      <path value="AuditEvent.basedOn"/>
+      <short value="Workflow authorization within which this event occurred"/>
+      <definition value="Allows tracing of authorizatino for the events and tracking whether proposals/recommendations were acted upon."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CarePlan"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/NutritionOrder"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ServiceRequest"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Event.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.why[x]"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="Act.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w3c.prov"/>
+        <map value="Activity.Activity"/>
+      </mapping>
+    </element>    
+	<element id="AuditEvent.encounter">
+      <path value="AuditEvent.encounter"/>
+      <short value="Encounter within which this event occurred or which the event is tightly associated"/>
+      <definition value="This will typically be the encounter the event occurred, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission lab tests)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Encounter"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Event.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.why[x]"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="Act.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w3c.prov"/>
+        <map value="Activity.Activity"/>
+      </mapping>
+    </element>
     <element id="AuditEvent.agent">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/uml-dir">
         <valueCode value="down"/>

--- a/source/provenance/provenance-introduction.xml
+++ b/source/provenance/provenance-introduction.xml
@@ -8,7 +8,7 @@ The Provenance resource tracks information about the activity that created, revi
 This information can be used to form assessments about its quality, reliability, trustworthiness, or to provide pointers for where to go to further investigate the origins of the resource and the information in it. 
 </p>
 <p>
-<a href="provenance.html">Provenance resources</a> are a record-keeping assertion that gathers information about the context in which the information in a resource was obtained. 
+Provenance resources are a record-keeping assertion that gathers information about the context in which the information in a resource was obtained. 
 Provenance resources are prepared by the application that initiates the create/update etc. of the resource.
 An <a href="auditevent.html">AuditEvent</a> resource contains overlapping information, but is created as events occur, to track and audit the events. 
 AuditEvent resources are often (though not exclusively) created by the application responding to the read/query/create/update/etc. event. 
@@ -57,7 +57,7 @@ Where:
 </p>
 <ul>
 <li>Entity - An entity is a physical, digital, conceptual or other kind of thing with some fixed aspects; entities may be real or imaginary. One or more entities can be the input (.entity) of an activity, and one or more entities can be the output (.target).</li>
-<li>Agent - An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity.</li>
+<li>Agent - An agent is something that bears the responsibility identified by the type of participation in the activity taking place, for the existence of an entity, or for another agent's activity. An Agent may be a person, device, system, organization, group, care-team, or identifiable thing.</li>
 <li>Activity - An activity is something that occurs over a time period and acts upon or with entities. It may include consuming, processing, transforming, modifying, relocating, using, or generating entities.</li>
 </ul>
 <p>

--- a/source/provenance/structuredefinition-Provenance.xml
+++ b/source/provenance/structuredefinition-Provenance.xml
@@ -316,6 +316,65 @@
         <map value="Activity.Activity"/>
       </mapping>
     </element>
+    <element id="Provenance.basedOn">
+      <path value="Provenance.basedOn"/>
+      <short value="Workflow authorization within which this event occurred"/>
+      <definition value="Allows tracing of authorizatino for the events and tracking whether proposals/recommendations were acted upon."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CarePlan"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/NutritionOrder"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ServiceRequest"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Event.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.why[x]"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="Act.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w3c.prov"/>
+        <map value="Activity.Activity"/>
+      </mapping>
+    </element>    
+	<element id="Provenance.encounter">
+      <path value="Provenance.encounter"/>
+      <short value="Encounter within which this event occurred or which the event is tightly associated"/>
+      <definition value="This will typically be the encounter the event occurred, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission lab tests)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Encounter"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Event.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.why[x]"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="Act.code"/>
+      </mapping>
+      <mapping>
+        <identity value="w3c.prov"/>
+        <map value="Activity.Activity"/>
+      </mapping>
+    </element>
     <element id="Provenance.agent">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
         <valueCode value="0,200"/>

--- a/source/provenance/structuredefinition-Provenance.xml
+++ b/source/provenance/structuredefinition-Provenance.xml
@@ -355,8 +355,8 @@
       <path value="Provenance.agent.type"/>
       <short value="How the agent participated"/>
       <definition value="The primary act of participation of the agent with respect to the activity."/>
-      <comment value="For example: assembler, author, doctor, nurse, clerk, etc."/>
-      <requirements value="Note: The .type of author could be .role of primary author. Note there are overlapping codes to be used in specific circumstances. See ISO 21298:2018 - Health Informatics - Functional and structural roles."/>
+      <comment value="For example: assembler, author, prescriber, signer, investigator, etc."/>
+      <requirements value="Functional roles reflect functional aspects of relationships between entities. Functional roles are bound to the realization/performance of acts, where actions might be concatenated to an activity or even to a process. This element will hold the functional role that the agent played in the activity that is the focus of this Provenance. Where an agent played multiple functional roles, they will be listed as multiple .agent elements representing each functional participation. See ISO 21298:2018 - Health Informatics - Functional and structural roles, and ISO 22600-2:2014 - Health Informatics - Privilege Management and Access Control - Part 2: formal models."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -391,9 +391,9 @@
     <element id="Provenance.agent.role">
       <path value="Provenance.agent.role"/>
       <short value="What the agents role was"/>
-      <definition value="The functional or structural roles of the agent indicating the agent&#39;s competency. The security role enabling the agent with respect to the activity."/>
-      <comment value="For example: PRIMAUTH, REVIEWER, VERF, etc."/>
-      <requirements value="Note: The .type of author could be .role of primary author. Note there are overlapping codes to be used in specific circumstances. See ISO 21298:2018 - Health Informatics - Functional and structural roles."/>
+      <definition value="The structural roles of the agent indicating the agent&#39;s competency. The security role enabling the agent with respect to the activity."/>
+      <comment value="For example: Chief-of-Radiology, Nurse, Physician, Medical-Student, etc."/>
+      <requirements value="Structural roles reflect the structural aspects of relationships between entities. Structural roles describe prerequisites, feasibilities, or competences for acts. Functional roles reflect functional aspects of relationships between entities. Functional roles are bound to the realization/performance of acts, where actions might be concatenated to an activity or even to a process. See ISO 21298:2018 - Health Informatics - Functional and structural roles, and ISO 22600-2:2014 - Health Informatics - Privilege Management and Access Control - Part 2: formal models.."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/provenance/structuredefinition-Provenance.xml
+++ b/source/provenance/structuredefinition-Provenance.xml
@@ -477,9 +477,8 @@
     </element>
     <element id="Provenance.agent.who">
       <path value="Provenance.agent.who"/>
-      <short value="Who participated"/>
+      <short value="The agent that participated in the event"/>
       <definition value="The individual, device or organization that participated in the event."/>
-      <comment value="whoIdentity should be used when the agent is not a Resource type."/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -507,9 +506,8 @@
     </element>
     <element id="Provenance.agent.onBehalfOf">
       <path value="Provenance.agent.onBehalfOf"/>
-      <short value="Who the agent is representing"/>
-      <definition value="The individual, device, or organization for whom the change was made."/>
-      <comment value="onBehalfOfIdentity should be used when the agent is not a Resource type."/>
+      <short value="The agent that delegated"/>
+      <definition value="The agent that delegated authority to perform the activity performed by the agent.who element."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/terminologies/valueset-participation-role-type.xml
+++ b/source/terminologies/valueset-participation-role-type.xml
@@ -52,6 +52,14 @@
 
   <compose>
     <include>
+      <valueSet value="http://terminology.hl7.org/ValueSet/provenance-agent-type"/>
+	</include>
+    <include>
+	<!-- DICOM codes for AuditEvent agent role -->
+      <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+	  <valueSet value="http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html" />
+    </include>
+    <include>
       <!-- Include all codes from the HL7-defined codesystem contract-signer-type -->
       <system value="http://terminology.hl7.org/CodeSystem/contractsignertypecodes"/>
       <concept>
@@ -269,14 +277,6 @@
       <system value="http://terminology.hl7.org/CodeSystem/extra-security-role-type"/>
     </include>
 
-    <include>
-	<!-- DICOM codes for AuditEvent agent role -->
-      <system value="http://dicom.nema.org/resources/ontology/DCM"/>
-	  <valueSet value="http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html" />
-    </include>
-    <include>
-      <valueSet value="http://hl7.org/fhir/ValueSet/provenance-participant-type"/>
-	</include>
 	</compose>
 
 </ValueSet>

--- a/vscache/dicom.cache
+++ b/vscache/dicom.cache
@@ -176,7 +176,7 @@ e: {
   "status" : "active",
   "experimental" : false,
   "date" : "2020-08-04",
-  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Mon, Apr 5, 2021 16:44-0500",
+  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Mon, Apr 5, 2021 18:15-0500",
   "expansion" : {
     "identifier" : "urn:uuid:5fdc98d8-75d8-4394-b6e5-d0ab18b616b3",
     "timestamp" : "2020-08-06T14:57:44.106Z",
@@ -2746,6 +2746,1326 @@ v: {
   "system" : "http://dicom.nema.org/resources/ontology/DCM",
   "code" : "110154"
 }, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110153",
+    "display" : "Source Role ID"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110153",
+  "display" : "Source Role ID"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110152",
+    "display" : "Destination Role ID"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110152",
+  "display" : "Destination Role ID"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110154",
+    "display" : "Destination Media"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110154",
+  "display" : "Destination Media"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
 v: {
   "display" : "Destination Media",
   "severity" : null,

--- a/vscache/dicom.cache
+++ b/vscache/dicom.cache
@@ -163,7 +163,7 @@ e: {
   },
   "text" : {
     "status" : "generated",
-    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set contains 10 concepts</p><p style=\"border: black 1px dotted; background-color: #EEEEEE; padding: 8px; margin-bottom: 8px\">Expansion based on <a href=\"codesystem-dicom-dcim.html\">DICOM Controlled Terminology Definitions v01 (CodeSystem)</a></p><p>All codes from system <a href=\"codesystem-dicom-dcim.html\"><code>http://dicom.nema.org/resources/ontology/DCM</code></a></p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110010\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110010\">110010</a></td><td>Film</td><td>Film type of output</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110030\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110030\">110030</a></td><td>USB Disk Emulation</td><td>A device that connects using the USB hard drive interface. These may be USB-Sticks, portable hard drives, and other technologies</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110031\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110031\">110031</a></td><td>Email</td><td>Email and email attachments used as a media for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110032\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110032\">110032</a></td><td>CD</td><td>CD-R, CD-ROM, and CD-RW media used for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110033\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110033\">110033</a></td><td>DVD</td><td>DVD, DVD-RAM, and other DVD formatted media used for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110034\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110034\">110034</a></td><td>Compact Flash</td><td>Media that comply with the Compact Flash standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110035\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110035\">110035</a></td><td>Multi-media Card</td><td>Media that comply with the Multi-media Card standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110036\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110036\">110036</a></td><td>Secure Digital Card</td><td>Media that comply with the Secure Digital Card standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110037\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110037\">110037</a></td><td>URI</td><td>URI Identifier for network or other resource, see RFC 3968</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110038\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110038\">110038</a></td><td>Paper Document</td><td>Any paper or similar document</td></tr></table></div>"
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set contains 10 concepts</p><p style=\"border: black 1px dotted; background-color: #EEEEEE; padding: 8px; margin-bottom: 8px\">Expansion based on <a href=\"codesystem-dicom-dcim.html\">DICOM Controlled Terminology Definitions v01 (CodeSystem)</a></p><p>All codes from system <a href=\"http://terminology.hl7.org/2.1.0/CodeSystem-v3-DCM.html\"><code>http://dicom.nema.org/resources/ontology/DCM</code></a></p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110010\"> </a>110010</td><td>Film</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110030\"> </a>110030</td><td>USB Disk Emulation</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110031\"> </a>110031</td><td>Email</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110032\"> </a>110032</td><td>CD</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110033\"> </a>110033</td><td>DVD</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110034\"> </a>110034</td><td>Compact Flash</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110035\"> </a>110035</td><td>Multi-media Card</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110036\"> </a>110036</td><td>Secure Digital Card</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110037\"> </a>110037</td><td>URI</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110038\"> </a>110038</td><td>Paper Document</td><td/></tr></table></div>"
   },
   "url" : "http://hl7.org/fhir/ValueSet/audit-media-type",
   "identifier" : [{
@@ -176,7 +176,7 @@ e: {
   "status" : "active",
   "experimental" : false,
   "date" : "2020-08-04",
-  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Thu, Aug 6, 2020 11:01-0400",
+  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Mon, Apr 5, 2021 16:44-0500",
   "expansion" : {
     "identifier" : "urn:uuid:5fdc98d8-75d8-4394-b6e5-d0ab18b616b3",
     "timestamp" : "2020-08-06T14:57:44.106Z",
@@ -1207,6 +1207,1547 @@ v: {
 }, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
 v: {
   "display" : "Emergency Override Started",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110100",
+  "display" : "Application Activity"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Application Activity",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110120",
+  "display" : "Application Start"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Application Start",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110153",
+  "display" : "Source Role ID"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110122",
+  "display" : "Login"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Login",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110122",
+  "display" : "Login"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/security-source-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code provided (http://dicom.nema.org/resources/ontology/DCM#110122) is not valid in the value set 'AuditEventSourceType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110114",
+  "display" : "User Authentication"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "User Authentication",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110123",
+  "display" : "Logout"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Logout",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110106",
+  "display" : "Export"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Export",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110152",
+  "display" : "Destination Role ID"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110112",
+  "display" : "Query"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Query",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110154",
+  "display" : "Destination Media"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110033",
+  "display" : "DVD"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "DVD",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110113",
+  "display" : "Security Alert"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Security Alert",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110127",
+  "display" : "Emergency Override Started"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Emergency Override Started",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "US"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Ultrasound",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "CT"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Computed Tomography",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "DX"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Digital Radiography",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110153",
+    "display" : "Source Role ID"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110153",
+  "display" : "Source Role ID"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110153"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110152",
+    "display" : "Destination Role ID"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110152",
+  "display" : "Destination Role ID"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110152"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110154",
+    "display" : "Destination Media"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110154",
+  "display" : "Destination Media"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110154"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Media",
   "severity" : null,
   "error" : ""
 }

--- a/vscache/null.cache
+++ b/vscache/null.cache
@@ -13,7 +13,7 @@ e: {
   "resourceType" : "ValueSet",
   "id" : "action-participant-role",
   "meta" : {
-    "lastUpdated" : "2017-02-15T16:33:00.000-07:00",
+    "lastUpdated" : "2017-02-15T17:33:00.000-06:00",
     "profile" : ["http://hl7.org/fhir/StructureDefinition/shareablevalueset"]
   },
   "url" : "http://terminology.hl7.org/ValueSet/action-participant-role",
@@ -23,8 +23,8 @@ e: {
   "experimental" : false,
   "date" : "2017-02-15T16:33:00.000-07:00",
   "expansion" : {
-    "identifier" : "urn:uuid:9e4c2c93-b16b-4c45-9627-fa5c8134a85f",
-    "timestamp" : "2021-03-31T20:43:26.590Z",
+    "identifier" : "urn:uuid:7a0b6472-cabc-4f13-92db-a07e10e7ac98",
+    "timestamp" : "2021-04-05T12:24:20.135Z",
     "parameter" : [{
       "name" : "expansion-source",
       "valueString" : "ValueSet/action-participant-role"
@@ -68,5 +68,275 @@ e: {
   }
 },
   "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "self"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/subscriber-relationship"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"self\"); The code provided (#self) is not valid in the value set 'SubscriberRelationshipCodes' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "logic-library"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/library-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"logic-library\"); The code provided (#logic-library) is not valid in the value set 'LibraryType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "model-definition"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/library-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"model-definition\"); The code provided (#model-definition) is not valid in the value set 'LibraryType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "asset-collection"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/library-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"asset-collection\"); The code provided (#asset-collection) is not valid in the value set 'LibraryType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "proportion"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-scoring"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"proportion\"); The code provided (#proportion) is not valid in the value set 'MeasureScoring' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "process"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"process\"); The code provided (#process) is not valid in the value set 'MeasureType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "initial-population"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-population"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"initial-population\"); The code provided (#initial-population) is not valid in the value set 'MeasurePopulationType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "denominator"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-population"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"denominator\"); The code provided (#denominator) is not valid in the value set 'MeasurePopulationType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "denominator-exclusions"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-population"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"denominator-exclusions\"); The code provided (#denominator-exclusions) is not valid in the value set 'MeasurePopulationType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "numerator"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-population"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"numerator\"); The code provided (#numerator) is not valid in the value set 'MeasurePopulationType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "denominator-exclusion"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-population"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"denominator-exclusion\"); The code provided (#denominator-exclusion) is not valid in the value set 'MeasurePopulationType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "opportunity"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/composite-measure-scoring"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"opportunity\"); The code provided (#opportunity) is not valid in the value set 'CompositeMeasureScoring' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "cohort"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/measure-scoring"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"cohort\"); The code provided (#cohort) is not valid in the value set 'MeasureScoring' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "create"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/action-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"create\"); The code provided (#create) is not valid in the value set 'ActionType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "code" : "clinical-protocol"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/plan-definition-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code system \"\" is not known (encountered paired with code = \"clinical-protocol\"); The code provided (#clinical-protocol) is not valid in the value set 'PlanDefinitionType' (from http://tx.fhir.org/r4)"
 }
 -------------------------------------------------------------------------------------

--- a/vscache/v3-ParticipationType.cache
+++ b/vscache/v3-ParticipationType.cache
@@ -1006,3 +1006,443 @@ v: {
   "error" : ""
 }
 -------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+    "code" : "AUT"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "author (originator)",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+    "code" : "DEV"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "",
+  "severity" : "error",
+  "error" : "The code provided (http://terminology.hl7.org/CodeSystem/v3-ParticipationType#DEV) is not valid in the value set 'ParticipationRoleType' (from http://tx.fhir.org/r4)"
+}
+-------------------------------------------------------------------------------------

--- a/vscache/v3-ParticipationType.cache
+++ b/vscache/v3-ParticipationType.cache
@@ -786,3 +786,223 @@ v: {
   "error" : ""
 }
 -------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+    "code" : "DEV"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://terminology.hl7.org/CodeSystem/contractsignertypecodes",
+      "concept" : [{
+        "code" : "AMENDER"
+      },
+      {
+        "code" : "COAUTH"
+      },
+      {
+        "code" : "CONT"
+      },
+      {
+        "code" : "EVTWIT"
+      },
+      {
+        "code" : "PRIMAUTH"
+      },
+      {
+        "code" : "REVIEWER"
+      },
+      {
+        "code" : "SOURCE"
+      },
+      {
+        "code" : "TRANS"
+      },
+      {
+        "code" : "VALID"
+      },
+      {
+        "code" : "VERF"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+      "concept" : [{
+        "code" : "AFFL"
+      },
+      {
+        "code" : "AGNT"
+      },
+      {
+        "code" : "ASSIGNED"
+      },
+      {
+        "code" : "CLAIM"
+      },
+      {
+        "code" : "COVPTY"
+      },
+      {
+        "code" : "DEPEN"
+      },
+      {
+        "code" : "ECON"
+      },
+      {
+        "code" : "EMP"
+      },
+      {
+        "code" : "GUARD"
+      },
+      {
+        "code" : "INVSBJ"
+      },
+      {
+        "code" : "NAMED"
+      },
+      {
+        "code" : "NOK"
+      },
+      {
+        "code" : "PAT"
+      },
+      {
+        "code" : "PROV"
+      },
+      {
+        "code" : "NOT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "concept" : [{
+        "code" : "CLASSIFIER"
+      },
+      {
+        "code" : "CONSENTER"
+      },
+      {
+        "code" : "CONSWIT"
+      },
+      {
+        "code" : "COPART"
+      },
+      {
+        "code" : "DECLASSIFIER"
+      },
+      {
+        "code" : "DELEGATEE"
+      },
+      {
+        "code" : "DELEGATOR"
+      },
+      {
+        "code" : "DOWNGRDER"
+      },
+      {
+        "code" : "DPOWATT"
+      },
+      {
+        "code" : "EXCEST"
+      },
+      {
+        "code" : "GRANTEE"
+      },
+      {
+        "code" : "GRANTOR"
+      },
+      {
+        "code" : "GT"
+      },
+      {
+        "code" : "GUADLTM"
+      },
+      {
+        "code" : "HPOWATT"
+      },
+      {
+        "code" : "INTPRTER"
+      },
+      {
+        "code" : "POWATT"
+      },
+      {
+        "code" : "RESPRSN"
+      },
+      {
+        "code" : "SPOWATT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+      "filter" : [{
+        "property" : "concept",
+        "op" : "is-a",
+        "value" : "_CitizenRoleType"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationFunction",
+      "concept" : [{
+        "code" : "AUCG"
+      },
+      {
+        "code" : "AULR"
+      },
+      {
+        "code" : "AUTM"
+      },
+      {
+        "code" : "AUWA"
+      },
+      {
+        "code" : "PROMSK"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+      "concept" : [{
+        "code" : "AUT"
+      },
+      {
+        "code" : "CST"
+      },
+      {
+        "code" : "INF"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "LA"
+      },
+      {
+        "code" : "IRCP"
+      },
+      {
+        "code" : "TRC"
+      },
+      {
+        "code" : "WIT"
+      }]
+    },
+    {
+      "system" : "http://terminology.hl7.org/CodeSystem/extra-security-role-type"
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_402.html"]
+    },
+    {
+      "valueSet" : ["http://terminology.hl7.org/ValueSet/provenance-agent-type"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "device",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------


### PR DESCRIPTION
## HL7 FHIR Pull Request

- FHIR-29811 - Provenance Scope contains a circular reference 
- FHIR-28218 - Request to bring back the codes from the R4 Provenance.agent.type provenance-agent-type value set in the new ParticipationRoleType value set 
- FHIR-28184 - Clarify agent.type vs agent.role 
- FHIR-28100 - Add instantiates, basedOn and encounter to AuditEvent and Provenance 
- FHIR-26923 - Add example usage for b3 trace headers in AuditEvent 
- FHIR-25934 -  Provenance.agent.onBehalfOf overlap with Device.owner and PractitionerRole.organization



