### PR TITLE
Feature/bp appointments

### DIFF
--- a/source/appointment/appointment-example-request.xml
+++ b/source/appointment/appointment-example-request.xml
@@ -47,7 +47,9 @@
 		<reference value="Slot/example" />
 	</slot>
 	<created value="2015-12-02" />
-	<comment value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
+	<note>
+		<text value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
+	</note>
 	<participant>
 		<actor>
 			<reference value="Patient/example" />

--- a/source/appointment/appointment-example-request.xml
+++ b/source/appointment/appointment-example-request.xml
@@ -50,12 +50,16 @@
 	<note>
 		<text value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
 	</note>
+	<subject>
+		<reference value="Patient/example" />
+		<display value="Peter James Chalmers" />
+	</subject>
 	<participant>
 		<actor>
 			<reference value="Patient/example" />
 			<display value="Peter James Chalmers" />
 		</actor>
-		<required value="required" />
+		<required value="true" />
 		<status value="needs-action" />
 	</participant>
 	<participant>
@@ -65,7 +69,7 @@
 				<code value="ATND"/>
 			</coding>
 		</type>
-		<required value="required" />
+		<required value="true" />
 		<status value="needs-action" />
 	</participant>
 	<participant>
@@ -74,7 +78,7 @@
 			<display value="South Wing, second floor" />
 		</actor>
 		<!-- This resource auto accepts, so doesn't need negotiation -->
-		<required value="required" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 	<requestedPeriod>

--- a/source/appointment/appointment-example.xml
+++ b/source/appointment/appointment-example.xml
@@ -47,6 +47,11 @@
 	<note>
 		<text value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
 	</note>
+	<patientInstruction>
+		<concept>
+			<text value="Please avoid excessive travel (specifically flying) before this appointment"/>
+		</concept>
+	</patientInstruction>
 	<basedOn>
 		<reference value="ServiceRequest/myringotomy"/>
 	</basedOn>

--- a/source/appointment/appointment-example.xml
+++ b/source/appointment/appointment-example.xml
@@ -55,12 +55,16 @@
 	<basedOn>
 		<reference value="ServiceRequest/myringotomy"/>
 	</basedOn>
+	<subject>
+		<reference value="Patient/example" />
+		<display value="Peter James Chalmers" />
+	</subject>
 	<participant>
 		<actor>
 			<reference value="Patient/example" />
 			<display value="Peter James Chalmers" />
 		</actor>
-		<required value="required" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 	<participant>
@@ -74,7 +78,7 @@
 			<reference value="Practitioner/example" />
 			<display value="Dr Adam Careful" />
 		</actor>
-		<required value="required" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 	<participant>
@@ -82,7 +86,7 @@
 			<reference value="Location/1" />
 			<display value="South Wing, second floor" />
 		</actor>
-		<required value="required" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 </Appointment>

--- a/source/appointment/appointment-example.xml
+++ b/source/appointment/appointment-example.xml
@@ -44,7 +44,9 @@
 	<start value="2013-12-10T09:00:00Z" />
 	<end value="2013-12-10T11:00:00Z" />
 	<created value="2013-10-10" />
-	<comment value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
+	<note>
+		<text value="Further expand on the results of the MRI and determine the next actions that may be appropriate." />
+	</note>
 	<basedOn>
 		<reference value="ServiceRequest/myringotomy"/>
 	</basedOn>

--- a/source/appointment/appointment-example2doctors.xml
+++ b/source/appointment/appointment-example2doctors.xml
@@ -40,7 +40,9 @@
   </supportingInformation>
 	<start value="2013-12-09T09:00:00Z" />
 	<end value="2013-12-09T11:00:00Z" />
-	<comment value="Clarify the results of the MRI to ensure context of test was correct" />
+	<note>
+		<text value="Clarify the results of the MRI to ensure context of test was correct" />
+	</note>
 	<participant>
 		<actor>
 			<reference value="Patient/example" />

--- a/source/appointment/appointment-example2doctors.xml
+++ b/source/appointment/appointment-example2doctors.xml
@@ -43,20 +43,16 @@
 	<note>
 		<text value="Clarify the results of the MRI to ensure context of test was correct" />
 	</note>
-	<participant>
-		<actor>
-			<reference value="Patient/example" />
-			<display value="Peter James Chalmers" />
-		</actor>
-		<required value="information-only" />
-		<status value="accepted" />
-	</participant>
+	<subject>
+		<reference value="Patient/example" />
+		<display value="Peter James Chalmers" />
+	</subject>
 	<participant>
 		<actor>
 			<reference value="Practitioner/example" />
 			<display value="Dr Adam Careful" />
 		</actor>
-		<required value="required" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 	<participant>
@@ -64,14 +60,7 @@
 			<reference value="Practitioner/f202" />
 			<display value="Luigi Maas" />
 		</actor>
-		<required value="required" />
-		<status value="accepted" />
-	</participant>
-	<participant>
-		<actor>
-			<display value="Phone Call" />
-		</actor>
-		<required value="information-only" />
+		<required value="true" />
 		<status value="accepted" />
 	</participant>
 </Appointment>

--- a/source/appointment/appointment-introduction.xml
+++ b/source/appointment/appointment-introduction.xml
@@ -7,7 +7,7 @@
 			a planned meeting that may be in the future or past. The resource only describes a single meeting,
 			a series of repeating visits would require multiple appointment resources to be created for each instance.
 			Examples include a scheduled surgery, a follow-up for a
-			clinical visit, a scheduled conference call between clinicians to discuss a case, the reservation
+			clinical visit, a scheduled conference call between clinicians to discuss a case (where the patient is a subject, but not a participant), the reservation
 			of a piece of diagnostic equipment for a particular use, etc.
 			The visit scheduled by an appointment
 			may be in person or remote (by phone, video conference, etc.)  All that matters is that the time and

--- a/source/appointment/bundle-Appointment-search-params.xml
+++ b/source/appointment/bundle-Appointment-search-params.xml
@@ -76,7 +76,7 @@
         <description value="Appointment date/time."/>
         <code value="date"/>
         <type value="date"/>
-        <expression value="Appointment.start"/>
+        <expression value="(start | requestedPeriod.start).first()"/>
         <xpath value="f:Appointment/f:start"/>
         <xpathUsage value="normal"/>
       </SearchParameter>

--- a/source/appointment/bundle-Appointment-search-params.xml
+++ b/source/appointment/bundle-Appointment-search-params.xml
@@ -145,6 +145,26 @@
   <entry>
     <resource>
       <SearchParameter>
+        <id value="Appointment-subject"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Appointment.subject"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Appointment-subject"/>
+        <description value="One of the individuals of the appointment is this patient"/>
+        <code value="subject"/>
+        <type value="reference"/>
+        <expression value="Appointment.subject"/>
+        <xpath value="f:Appointment/f:participant/f:actor"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
         <id value="Appointment-patient"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>

--- a/source/appointment/bundle-Appointment-search-params.xml
+++ b/source/appointment/bundle-Appointment-search-params.xml
@@ -156,7 +156,27 @@
         <description value="One of the individuals of the appointment is this patient"/>
         <code value="patient"/>
         <type value="reference"/>
-        <expression value="Appointment.participant.actor.where(resolve() is Patient)"/>
+        <expression value="Appointment.participant.actor.where(resolve() is Patient) | Appointment.subject.where(resolve() is Patient)"/>
+        <xpath value="f:Appointment/f:participant/f:actor"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Appointment-group"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Appointment.participant.actor"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Appointment-group"/>
+        <description value="One of the individuals of the appointment is this patient"/>
+        <code value="group"/>
+        <type value="reference"/>
+        <expression value="Appointment.participant.actor.where(resolve() is Group) | Appointment.subject.where(resolve() is Group)"/>
         <xpath value="f:Appointment/f:participant/f:actor"/>
         <xpathUsage value="normal"/>
       </SearchParameter>

--- a/source/appointment/bundle-Appointment-search-params.xml
+++ b/source/appointment/bundle-Appointment-search-params.xml
@@ -67,7 +67,7 @@
       <SearchParameter>
         <id value="Appointment-date"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
+          <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="Appointment.start"/>
@@ -127,7 +127,7 @@
       <SearchParameter>
         <id value="Appointment-part-status"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
+          <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="Appointment.participant.status"/>
@@ -307,7 +307,7 @@
       <SearchParameter>
         <id value="Appointment-status"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
+          <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="Appointment.status"/>
@@ -338,6 +338,26 @@
         <type value="reference"/>
         <expression value="Appointment.supportingInformation"/>
         <xpath value="f:Appointment/f:supportingInformation"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Appointment-requested-period"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Appointment.requestedPeriod"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Appointment-requestedPeriod"/>
+        <description value="During what period was the Appointment requested to take place"/>
+        <code value="requested-period"/>
+        <type value="date"/>
+        <expression value="requestedPeriod"/>
+        <xpath value="f:Appointment/f:requestedPeriod"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -669,31 +669,6 @@
       </mapping>
       <mapping>
         <identity value="v2"/>
-        <map value="PID-3-Patient ID List | AIL-3 | AIG-3 | AIP-3"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value="subject.patient"/>
-      </mapping>
-    </element>
-    <element id="Appointment.participant.actor">
-      <path value="Appointment.participant.actor"/>
-      <short value="Person, Location/HealthcareService or Device"/>
-      <definition value="A Person, Location/HealthcareService or Device that is participating in the appointment."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.who"/>
-      </mapping>
-      <mapping>
-        <identity value="v2"/>
         <map value="PID-3-Patient ID List"/>
       </mapping>
       <mapping>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -579,7 +579,7 @@
       <path value="Appointment.note"/>
       <short value="Additional comments"/>
       <definition value="Additional notes/comments about the appointment."/>
-      <comment value="Additional text to aid in facilitating the appointment. For instance, a note might be, &quot;patient should proceed immediately to infusion room upon arrival&quot;&#xD;&#xD;Where this is a planned appointment and the start/end dates are not set then this field can be used to provide additional guidance on the details of the appointment request, including any restrictions on when to book it."/>
+      <comment value="Additional text to aid in facilitating the appointment. For instance, a note might be, &quot;patient should proceed immediately to infusion room upon arrival&quot;&#xD;&#xD;Where this is a planned appointment and the start/end dates are not set then this field can be used to provide additional guidance on the details of the appointment request, including any restrictions on when to book it.&#xD;&#xD;Typically only the concept.text will be used, however occasionally a reference to some generic documentation (or specific) and also supports coded instructions if/when they are required."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -607,9 +607,12 @@
       <short value="Detailed information and instructions for the patient"/>
       <definition value="While Appointment.note contains information for internal use, Appointment.patientInstructions is used to capture patient facing information about the Appointment (e.g. please bring your referral or fast from 8pm night before)."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
-        <code value="string"/>
+        <code value="CodeableReference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Binary"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Communication"/>
       </type>
       <mapping>
         <identity value="v2"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -575,15 +575,15 @@
         <map value="CREATED"/>
       </mapping>
     </element>
-    <element id="Appointment.comment">
-      <path value="Appointment.comment"/>
+    <element id="Appointment.note">
+      <path value="Appointment.note"/>
       <short value="Additional comments"/>
-      <definition value="Additional comments about the appointment."/>
-      <comment value="Additional text to aid in facilitating the appointment. For instance, a comment might be, &quot;patient should proceed immediately to infusion room upon arrival&quot;&#xD;&#xD;Where this is a planned appointment and the start/end dates are not set then this field can be used to provide additional guidance on the details of the appointment request, including any restrictions on when to book it."/>
+      <definition value="Additional notes/comments about the appointment."/>
+      <comment value="Additional text to aid in facilitating the appointment. For instance, a note might be, &quot;patient should proceed immediately to infusion room upon arrival&quot;&#xD;&#xD;Where this is a planned appointment and the start/end dates are not set then this field can be used to provide additional guidance on the details of the appointment request, including any restrictions on when to book it."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
-        <code value="string"/>
+        <code value="Annotation"/>
       </type>
       <mapping>
         <identity value="workflow"/>
@@ -605,7 +605,7 @@
     <element id="Appointment.patientInstruction">
       <path value="Appointment.patientInstruction"/>
       <short value="Detailed information and instructions for the patient"/>
-      <definition value="While Appointment.comment contains information for internal use, Appointment.patientInstructions is used to capture patient facing information about the Appointment (e.g. please bring your referral or fast from 8pm night before)."/>
+      <definition value="While Appointment.note contains information for internal use, Appointment.patientInstructions is used to capture patient facing information about the Appointment (e.g. please bring your referral or fast from 8pm night before)."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -651,6 +651,56 @@
         <map value=".outboundRelationship[@typeCode = &#39;FLFS&#39;].act[@classCode &lt; &#39;ActCareProvisionRequestType&#39;][@moodCode = &#39;RQO&#39;]"/>
       </mapping>
     </element>
+    <element id="Appointment.subject">
+      <path value="Appointment.subject"/>
+      <short value="The patient or group associated with the appointment"/>
+      <definition value="The patient or group associated with the appointment, if they are to be present (usually) then they should also be included in the participant backbone element."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.who"/>
+      </mapping>
+      <mapping>
+        <identity value="v2"/>
+        <map value="PID-3-Patient ID List | AIL-3 | AIG-3 | AIP-3"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="subject.patient"/>
+      </mapping>
+    </element>
+    <element id="Appointment.participant.actor">
+      <path value="Appointment.participant.actor"/>
+      <short value="Person, Location/HealthcareService or Device"/>
+      <definition value="A Person, Location/HealthcareService or Device that is participating in the appointment."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.who"/>
+      </mapping>
+      <mapping>
+        <identity value="v2"/>
+        <map value="PID-3-Patient ID List"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value="subject.patient"/>
+      </mapping>
+    </element>
     <element id="Appointment.participant">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/uml-dir">
         <valueCode value="right"/>
@@ -720,6 +770,20 @@
         <map value="n/a"/>
       </mapping>
     </element>
+    <element id="Appointment.participant.period">
+      <path value="Appointment.participant.period"/>
+      <short value="Participation period of the actor"/>
+      <definition value="Participation period of the actor."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Period"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="n/a"/>
+      </mapping>
+    </element>
     <element id="Appointment.participant.actor">
       <path value="Appointment.participant.actor"/>
       <short value="Person, Location/HealthcareService or Device"/>
@@ -729,6 +793,7 @@
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
@@ -756,22 +821,15 @@
     </element>
     <element id="Appointment.participant.required">
       <path value="Appointment.participant.required"/>
-      <short value="required | optional | information-only"/>
-      <definition value="Whether this participant is required to be present at the meeting. This covers a use-case where two doctors need to meet to discuss the results for a specific patient, and the patient is not required to be present."/>
+      <short value="required"/>
+      <definition value="Whether this participant is required to be present at the meeting. If false, the participant is optional."/>
+      <comment value="For the use-case where two doctors need to meet to discuss the results for a specific patient, and the patient is not required to be present include the patient in the subject field, but do not include them as a participant - this was formerly done prior to R5 with required='information-only'."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="code"/>
+        <code value="boolean"/>
       </type>
       <isSummary value="true"/>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ParticipantRequired"/>
-        </extension>
-        <strength value="required"/>
-        <description value="Is the Participant required to attend the appointment."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/participantrequired"/>
-      </binding>
       <mapping>
         <identity value="rim"/>
         <map value="(performer | reusableDevice | subject | location).@performInd"/>
@@ -810,20 +868,6 @@
       <mapping>
         <identity value="ical"/>
         <map value="ATTENDEE;CN=&quot;John Doe&quot;;RSVP=TRUE:mailto:john@doe.com (rsvpparam | partstatparam)"/>
-      </mapping>
-    </element>
-    <element id="Appointment.participant.period">
-      <path value="Appointment.participant.period"/>
-      <short value="Participation period of the actor"/>
-      <definition value="Participation period of the actor."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Period"/>
-      </type>
-      <mapping>
-        <identity value="rim"/>
-        <map value="n/a"/>
       </mapping>
     </element>
     <element id="Appointment.requestedPeriod">

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -84,7 +84,7 @@
         <key value="app-4"/>
         <severity value="error"/>
         <human value="Cancelation reason is only used for appointments that have been cancelled, or no-show"/>
-        <expression value="Appointment.cancelationReason.exists() implies (Appointment.status=&#39;no-show&#39; or Appointment.status=&#39;cancelled&#39;)"/>
+        <expression value="cancelationReason.exists() implies (status=&#39;no-show&#39; or status=&#39;cancelled&#39;)"/>
         <xpath value="not(exists(f:cancellationReason)) or f:status/@value=(&#39;no-show&#39;, &#39;cancelled&#39;)"/>
         <source value="http://hl7.org/fhir/StructureDefinition/Appointment"/>
       </constraint>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -80,6 +80,14 @@
       <definition value="A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a specific date/time. This may result in one or more Encounter(s)."/>
       <min value="0"/>
       <max value="*"/>
+			<constraint>
+				<key value="app-5"/>
+				<severity value="error"/>
+				<human value="The start must be less than or equal to the end"/>
+        <expression value="start.exists() implies start &lt;= end"/>
+        <xpath value="f:start &lt;= f:end or not(start.exists() and end.exists())"/>
+				<source value="http://hl7.org/fhir/StructureDefinition/Questionnaire"/>
+			</constraint>
       <constraint>
         <key value="app-4"/>
         <severity value="error"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -265,6 +265,10 @@
         <map value="Request.code"/>
       </mapping>
       <mapping>
+        <identity value="v2"/>
+        <map value="ARQ-8, SCH-8"/>
+      </mapping>
+      <mapping>
         <identity value="rim"/>
         <map value="n/a, might be inferred from the ServiceDeliveryLocation"/>
       </mapping>
@@ -314,7 +318,7 @@
       </binding>
       <mapping>
         <identity value="v2"/>
-        <map value="ARQ-7"/>
+        <map value="ARQ-7, SCH-7"/>
       </mapping>
       <mapping>
         <identity value="rim"/>
@@ -353,7 +357,7 @@
       </mapping>
       <mapping>
         <identity value="v2"/>
-        <map value="AIS-3, SCH-7"/>
+        <map value="AIS-3"/>
       </mapping>
       <mapping>
         <identity value="rim"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -806,7 +806,7 @@
     </element>
     <element id="Appointment.participant.required">
       <path value="Appointment.participant.required"/>
-      <short value="required"/>
+      <short value="The participant is required to attend (optional when false)"/>
       <definition value="Whether this participant is required to be present at the meeting. If false, the participant is optional."/>
       <comment value="For the use-case where two doctors need to meet to discuss the results for a specific patient, and the patient is not required to be present include the patient in the subject field, but do not include them as a participant - this was formerly done prior to R5 with required='information-only'."/>
       <min value="0"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -763,6 +763,7 @@
       <path value="Appointment.participant.actor"/>
       <short value="Person, Location/HealthcareService or Device"/>
       <definition value="A Person, Location/HealthcareService or Device that is participating in the appointment."/>
+      <comment value="Where a CareTeam is provided, this does not imply that the entire team is included, just a single member from the group with the appropriate role. Where multiple members are required, please include the CareTeam the required number of times."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -771,6 +772,7 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>

--- a/source/appointmentresponse/bundle-AppointmentResponse-search-params.xml
+++ b/source/appointmentresponse/bundle-AppointmentResponse-search-params.xml
@@ -125,6 +125,26 @@
   <entry>
     <resource>
       <SearchParameter>
+        <id value="AppointmentResponse-group"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="AppointmentResponse.actor"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/AppointmentResponse-group"/>
+        <description value="This Response is for this Group"/>
+        <code value="group"/>
+        <type value="reference"/>
+        <expression value="AppointmentResponse.actor.where(resolve() is Group)"/>
+        <xpath value="f:AppointmentResponse/f:actor"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
         <id value="AppointmentResponse-practitioner"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>

--- a/source/appointmentresponse/structuredefinition-AppointmentResponse.xml
+++ b/source/appointmentresponse/structuredefinition-AppointmentResponse.xml
@@ -94,7 +94,7 @@
       </mapping>
       <mapping>
         <identity value="rim"/>
-        <map value="Appointment[@moodCode &amp;lt;= &#39;PRMS&#39;]"/>
+        <map value="Act[@moodCode &amp;lt;= &#39;PRMS&#39;]"/>
       </mapping>
       <mapping>
         <identity value="ical"/>

--- a/source/appointmentresponse/structuredefinition-AppointmentResponse.xml
+++ b/source/appointmentresponse/structuredefinition-AppointmentResponse.xml
@@ -237,13 +237,14 @@
     </element>
     <element id="AppointmentResponse.actor">
       <path value="AppointmentResponse.actor"/>
-      <short value="Person, Location, HealthcareService, or Device"/>
+      <short value="Person(s), Location, HealthcareService, or Device"/>
       <definition value="A Person, Location, HealthcareService, or Device that is participating in the appointment."/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>

--- a/source/encounter/structuredefinition-Encounter.xml
+++ b/source/encounter/structuredefinition-Encounter.xml
@@ -589,6 +589,8 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>
       </type>
       <isSummary value="true"/>
       <mapping>

--- a/source/schedule/structuredefinition-Schedule.xml
+++ b/source/schedule/structuredefinition-Schedule.xml
@@ -208,6 +208,7 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>

--- a/source/slot/structuredefinition-Slot.xml
+++ b/source/slot/structuredefinition-Slot.xml
@@ -168,7 +168,7 @@
     <element id="Slot.appointmentType">
       <path value="Slot.appointmentType"/>
       <short value="The style of appointment or patient that may be booked in the slot (not service type)"/>
-      <definition value="The style of appointment or patient that may be booked in the slot (not service type). "/>
+      <definition value="The style of appointment or patient that may be booked in the slot (not service type)."/>
       <comment value="A slot may be allow multiple appointment types, but when booked, would only be used for one of the given appointment types."/>
       <min value="0"/>
       <max value="*"/>

--- a/source/slot/structuredefinition-Slot.xml
+++ b/source/slot/structuredefinition-Slot.xml
@@ -168,9 +168,10 @@
     <element id="Slot.appointmentType">
       <path value="Slot.appointmentType"/>
       <short value="The style of appointment or patient that may be booked in the slot (not service type)"/>
-      <definition value="The style of appointment or patient that may be booked in the slot (not service type)."/>
+      <definition value="The style of appointment or patient that may be booked in the slot (not service type). "/>
+      <comment value="A slot may be allow multiple appointment types, but when booked, would only be used for one of the given appointment types."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
         <code value="CodeableConcept"/>
       </type>


### PR DESCRIPTION
PA Appointment Scheduling trackers
#22121 Update RIM mapping for AppointmentResponse
#23075 Update schedule to also permit CareTeam scheduling
#FHIR-32661 - update cardinality on Slot.AppointmentType
#FHIR-28578 Appointment start <= end invariant
#FHIR-26070 update invariant definition
#FHIR-28588 Appointment Participant now includes CareTeam
#FHIR-22696 Appointment/encounter consistency and handling patient-less appointments clarified
#FHIR-13861 Update appointment v2 mappings
#27849 Appointment patientInstruction datatype and cardinality change
#19521 appointment notes should be updated to multi-cardinality Annotations to support notes and align with the workflow pattern
#FHIR-20532 include the requestedPeriod search parameter
(and update the search parameter standards status to all be trial use, as none are normative in here)
#FHIR-25419 Updated start search parameter