### PR TITLE
Patient admin/scheduling updates

### DIFF
--- a/source/account/codesystem-account-billing-status.xml
+++ b/source/account/codesystem-account-billing-status.xml
@@ -42,37 +42,37 @@
   <valueSet value="http://hl7.org/fhir/ValueSet/account-billing-status"/>
   <content value="complete"/>
   <concept>
-    <code value="Open"/>
+    <code value="open"/>
     <display value="Open"/>
     <definition value="The account is open for charging transactions (account.status is active)"/>
   </concept>
   <concept>
-    <code value="CareComplete-NotBilled"/>
+    <code value="carecomplete-notbilled"/>
     <display value="CareComplete/Not Billed"/>
     <definition value="The account.status is still active and may have charges recorded against it (only for events in the servicePeriod), however the encounters associated are completed. (Also known as Discharged not billed) This BillingStatus is often not used in ongoing accounts. (account.status is active)"/>
   </concept>
   <concept>
-    <code value="Billing"/>
+    <code value="billing"/>
     <display value="Billing"/>
     <definition value="Indicates that all transactions are recorded and the finance system can perform the billing process, including preparing insurance claims, scrubbing charges, invoicing etc. During this time any new charges will not be included in the current billing run/cycle. (account.status is active)"/>
   </concept>
   <concept>
-    <code value="Closed-BadDebt"/>
+    <code value="closed-baddebt"/>
     <display value="Closed-Bad Debt"/>
     <definition value="The balance of this debt has not been able to be recovered, and the organization has decided not to persue debt recovery. (account.status is in-active)"/>
   </concept>
   <concept>
-    <code value="Closed-Voided"/>
+    <code value="closed-voided"/>
     <display value="Closed-Voided"/>
     <definition value="The account was not created in error, however the organization has decided that it will not be charging any transactions associated. (account.status is i n-active)"/>
   </concept>
   <concept>
-    <code value="Closed-Completed"/>
+    <code value="closed-completed"/>
     <display value="Closed-Completed"/>
     <definition value="The account is closed and all charges are processed and accounted for. (account.status is i n-active)"/>
   </concept>
   <concept>
-    <code value="Closed-Combined"/>
+    <code value="closed-combined"/>
     <display value="Closed-Combined"/>
     <definition value="This account has been merged into another account, all charged have been migrated. This account should no longer be used, and will not be billed. (account.status is i n-active)"/>
   </concept>

--- a/source/account/codesystem-account-billing-status.xml
+++ b/source/account/codesystem-account-billing-status.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="account-billing-status"/>
+  <meta>
+    <lastUpdated value="2021-01-05T10:01:24.148+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="pa"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <url value="http://hl7.org/fhir/account-billing-status"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.1.1539"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="AccountBillingStatus"/>
+  <title value="Example Account Billing Statuses"/>
+  <status value="draft"/>
+  <experimental value="true"/>
+  <date value="2021-05-26"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Indicates whether the account is available to be used for billing purposes."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/account-billing-status"/>
+  <content value="complete"/>
+  <concept>
+    <code value="Open"/>
+    <display value="Open"/>
+    <definition value="The account is open for charging transactions (account.status is active)"/>
+  </concept>
+  <concept>
+    <code value="CareComplete-NotBilled"/>
+    <display value="CareComplete/Not Billed"/>
+    <definition value="The account.status is still active and may have charges recorded against it (only for events in the servicePeriod), however the encounters associated are completed. (Also known as Discharged not billed) This BillingStatus is often not used in ongoing accounts. (account.status is active)"/>
+  </concept>
+  <concept>
+    <code value="Billing"/>
+    <display value="Billing"/>
+    <definition value="Indicates that all transactions are recorded and the finance system can perform the billing process, including preparing insurance claims, scrubbing charges, invoicing etc. During this time any new charges will not be included in the current billing run/cycle. (account.status is active)"/>
+  </concept>
+  <concept>
+    <code value="Closed-BadDebt"/>
+    <display value="Closed-Bad Debt"/>
+    <definition value="The balance of this debt has not been able to be recovered, and the organization has decided not to persue debt recovery. (account.status is in-active)"/>
+  </concept>
+  <concept>
+    <code value="Closed-Voided"/>
+    <display value="Closed-Voided"/>
+    <definition value="The account was not created in error, however the organization has decided that it will not be charging any transactions associated. (account.status is i n-active)"/>
+  </concept>
+  <concept>
+    <code value="Closed-Completed"/>
+    <display value="Closed-Completed"/>
+    <definition value="The account is closed and all charges are processed and accounted for. (account.status is i n-active)"/>
+  </concept>
+  <concept>
+    <code value="Closed-Combined"/>
+    <display value="Closed-Combined"/>
+    <definition value="This account has been merged into another account, all charged have been migrated. This account should no longer be used, and will not be billed. (account.status is i n-active)"/>
+  </concept>
+</CodeSystem>

--- a/source/account/structuredefinition-Account.xml
+++ b/source/account/structuredefinition-Account.xml
@@ -128,6 +128,25 @@
         <map value=".statusCode"/>
       </mapping>
     </element>
+    <element id="Account.billingStatus">
+      <path value="Account.billingStatus"/>
+      <short value="Tracks the lifecycle of the account through the billing process"/>
+      <definition value="The BillingStatus tracks the lifecycle of the account through the billing process. It indicates how transactions are treated when they are allocated to the account."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="AccountBillingStatus"/>
+        </extension>
+        <strength value="example"/>
+        <description value="Indicates whether the account is available to be used for billing purposes."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/account-billing-status"/>
+      </binding>
+    </element>
     <element id="Account.type">
       <path value="Account.type"/>
       <short value="E.g. patient, expense, depreciation"/>

--- a/source/account/valueset-account-billing-status.xml
+++ b/source/account/valueset-account-billing-status.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="account-billing-status"/>
+  <meta>
+    <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="pa"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="2"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/account-billing-status"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.0"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="AccountBillingStatus"/>
+  <title value="Example Account Billing Statuses"/>
+  <status value="draft"/>
+  <experimental value="true"/>
+  <date value="2021-05-26"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Indicates whether the account is available to be used for billing purposes."/>
+  <immutable value="true"/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/account-billing-status"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -224,33 +224,6 @@
         <map value="n/a"/>
       </mapping>
     </element>
-    <element id="Appointment.replaces">
-      <path value="Appointment.replaces"/>
-      <short value="Appointment replaced by this Appointment"/>
-      <definition value="Appointment replaced by this Appointment in cases where there is a cancellation, the details of the cancellation can be found in the cancellationReason property (on the referenced resource)."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Appointment"/>
-      </type>
-      <mapping>
-        <identity value="workflow"/>
-        <map value="Request.replaces"/>
-      </mapping>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.context"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".inboundRelationship[@typeCode = &#39;SPRT&#39;].observation"/>
-      </mapping>
-      <mapping>
-        <identity value="ical"/>
-        <map value="ATTACH"/>
-      </mapping>
-    </element>
     <element id="Appointment.serviceCategory">
       <path value="Appointment.serviceCategory"/>
       <short value="A broad categorization of the service that is to be performed during this appointment"/>
@@ -460,6 +433,33 @@
       <mapping>
         <identity value="ical"/>
         <map value="SUMMARY"/>
+      </mapping>
+    </element>
+    <element id="Appointment.replaces">
+      <path value="Appointment.replaces"/>
+      <short value="Appointment replaced by this Appointment"/>
+      <definition value="Appointment replaced by this Appointment in cases where there is a cancellation, the details of the cancellation can be found in the cancellationReason property (on the referenced resource)."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Appointment"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Request.replaces"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.context"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".inboundRelationship[@typeCode = &#39;SPRT&#39;].observation"/>
+      </mapping>
+      <mapping>
+        <identity value="ical"/>
+        <map value="ATTACH"/>
       </mapping>
     </element>
     <element id="Appointment.supportingInformation">

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -91,8 +91,8 @@
       <constraint>
         <key value="app-4"/>
         <severity value="error"/>
-        <human value="Cancelation reason is only used for appointments that have been cancelled, or no-show"/>
-        <expression value="cancelationReason.exists() implies (status=&#39;no-show&#39; or status=&#39;cancelled&#39;)"/>
+        <human value="Cancellation reason is only used for appointments that have been cancelled, or no-show"/>
+        <expression value="cancellationReason.exists() implies (status=&#39;no-show&#39; or status=&#39;cancelled&#39;)"/>
         <xpath value="not(exists(f:cancellationReason)) or f:status/@value=(&#39;no-show&#39;, &#39;cancelled&#39;)"/>
         <source value="http://hl7.org/fhir/StructureDefinition/Appointment"/>
       </constraint>
@@ -202,8 +202,8 @@
         <map value="STATUS"/>
       </mapping>
     </element>
-    <element id="Appointment.cancelationReason">
-      <path value="Appointment.cancelationReason"/>
+    <element id="Appointment.cancellationReason">
+      <path value="Appointment.cancellationReason"/>
       <short value="The coded reason for the appointment being cancelled"/>
       <definition value="The coded reason for the appointment being cancelled. This is often used in reporting/billing/futher processing to determine if further actions are required, or specific fees apply."/>
       <min value="0"/>
@@ -214,7 +214,7 @@
       <isSummary value="true"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="cancelation-reason"/>
+          <valueString value="cancellation-reason"/>
         </extension>
         <strength value="example"/>
         <valueSet value="http://hl7.org/fhir/ValueSet/appointment-cancellation-reason"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -224,6 +224,33 @@
         <map value="n/a"/>
       </mapping>
     </element>
+    <element id="Appointment.replaces">
+      <path value="Appointment.replaces"/>
+      <short value="Appointment replaced by this Appointment"/>
+      <definition value="Appointment replaced by this Appointment in cases where there is a cancellation, the details of the cancellation can be found in the cancellationReason property (on the referenced resource)."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Appointment"/>
+      </type>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Request.replaces"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.context"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".inboundRelationship[@typeCode = &#39;SPRT&#39;].observation"/>
+      </mapping>
+      <mapping>
+        <identity value="ical"/>
+        <map value="ATTACH"/>
+      </mapping>
+    </element>
     <element id="Appointment.serviceCategory">
       <path value="Appointment.serviceCategory"/>
       <short value="A broad categorization of the service that is to be performed during this appointment"/>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -591,6 +591,22 @@
         <map value=".outboundRelationship[@typeCode = &#39;REFR&#39;].act[@classCode = &#39;ACT&#39;][@moodCode = &#39;SLOT&#39;]"/>
       </mapping>
     </element>
+    <element id="Appointment.account">
+      <path value="Appointment.account"/>
+      <short value="The set of accounts that may be used for billing for this Appointment"/>
+      <definition value="The set of accounts that is expected to be used for billing the activities that result from this Appointment."/>
+      <comment value="The specified account(s) could be those identified during pre-registration workflows in preparation for an upcoming Encounter."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Account"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".pertains.A_Account"/>
+      </mapping>
+    </element>
     <element id="Appointment.created">
       <path value="Appointment.created"/>
       <short value="The date that this appointment was initially created"/>

--- a/source/encounter/bundle-Encounter-search-params.xml
+++ b/source/encounter/bundle-Encounter-search-params.xml
@@ -250,14 +250,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="Encounter.participant.individual"/>
+          <valueString value="Encounter.participant.actor"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Encounter-participant"/>
         <description value="Persons involved in the encounter other than the patient"/>
         <code value="participant"/>
         <type value="reference"/>
-        <expression value="Encounter.participant.individual"/>
-        <xpath value="f:Encounter/f:participant/f:individual"/>
+        <expression value="Encounter.participant.actor"/>
+        <xpath value="f:Encounter/f:participant/f:actor"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -310,14 +310,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="Encounter.participant.individual"/>
+          <valueString value="Encounter.participant.actor"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Encounter-practitioner"/>
         <description value="Persons involved in the encounter other than the patient"/>
         <code value="practitioner"/>
         <type value="reference"/>
-        <expression value="Encounter.participant.individual.where(resolve() is Practitioner)"/>
-        <xpath value="f:Encounter/f:participant/f:individual"/>
+        <expression value="Encounter.participant.actor.where(resolve() is Practitioner)"/>
+        <xpath value="f:Encounter/f:participant/f:actor"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/encounter/encounter-example-f001-heart.xml
+++ b/source/encounter/encounter-example-f001-heart.xml
@@ -31,10 +31,10 @@
         <display value="P. van de Heuvel"/>
     </subject>
     <participant>
-        <individual>
+        <actor>
             <reference value="Practitioner/f002"/>
             <display value="P. Voigt"/>
-        </individual>
+        </actor>
     </participant>
     <length>
         <value value="140"/>

--- a/source/encounter/encounter-example-f002-lung.xml
+++ b/source/encounter/encounter-example-f002-lung.xml
@@ -32,10 +32,10 @@
         <display value="P. van de Heuvel"/>
     </subject>
     <participant>
-        <individual>
+        <actor>
             <reference value="Practitioner/f003"/>
             <display value="M.I.M Versteegh"/>
-        </individual>
+        </actor>
     </participant>
     <length>
         <value value="140"/>

--- a/source/encounter/encounter-example-f003-abscess.xml
+++ b/source/encounter/encounter-example-f003-abscess.xml
@@ -32,10 +32,10 @@
 		<display value="P. van de Heuvel"/>
 	</subject>
 	<participant>
-		<individual>
+		<actor>
 			<reference value="Practitioner/f001"/>
 			<display value="E.M. van den Broek"/>
-		</individual>
+		</actor>
 	</participant>
 	<length>
 		<value value="90"/>

--- a/source/encounter/encounter-example-f201-20130404.xml
+++ b/source/encounter/encounter-example-f201-20130404.xml
@@ -30,9 +30,9 @@
      <display value="Roel"/>
  </subject>
  <participant>
-     <individual    >
+     <actor>
          <reference value="Practitioner/f201"/>
-    </individual>
+    </actor>
  </participant>
  <reason>
    <concept>

--- a/source/encounter/encounter-example-f202-20130128.xml
+++ b/source/encounter/encounter-example-f202-20130128.xml
@@ -34,9 +34,9 @@
 		<display value="Roel"/>
 	</subject>
 	<participant>
-		<individual>
+		<actor>
 			<reference value="Practitioner/f201"/>
-		</individual>
+		</actor>
 	</participant>
 	<length>
 		<value value="56"/>

--- a/source/encounter/encounter-example-f203-20130311.xml
+++ b/source/encounter/encounter-example-f203-20130311.xml
@@ -52,9 +52,9 @@
                 <code value="PART"/>
             </coding>
         </type>
-        <individual>
+        <actor>
             <reference value="Practitioner/f201"/>
-        </individual>
+        </actor>
     </participant>
     <appointment>
         <reference value="Appointment/example"/>

--- a/source/encounter/encounter-example-home.xml
+++ b/source/encounter/encounter-example-home.xml
@@ -30,10 +30,10 @@
 			<start value="2015-01-17T16:00:00+10:00"/>
 			<end value="2015-01-17T16:30:00+10:00"/>
 		</period>
-		<individual>
+		<actor>
 			<reference value="Practitioner/example"/>
 			<display value="Dr Adam Careful"/>
-		</individual>
+		</actor>
 	</participant>
 	<period>
 		<start value="2015-01-17T16:00:00+10:00"/>

--- a/source/encounter/encounter-example-xcda.xml
+++ b/source/encounter/encounter-example-xcda.xml
@@ -16,9 +16,9 @@
     <reference value="Patient/xcda"/>
   </subject>
   <participant>
-    <individual>
+    <actor>
       <reference value="Practitioner/xcda1"/>
-    </individual>
+    </actor>
   </participant>
   <reason>
     <concept>

--- a/source/encounter/structuredefinition-Encounter.xml
+++ b/source/encounter/structuredefinition-Encounter.xml
@@ -532,7 +532,7 @@
       <path value="Encounter.participant.type"/>
       <short value="Role of participant in encounter"/>
       <definition value="Role of participant in encounter."/>
-      <comment value="The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc."/>
+      <comment value="The participant type indicates how an individual actor participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -578,17 +578,19 @@
         <map value=".time"/>
       </mapping>
     </element>
-    <element id="Encounter.participant.individual">
-      <path value="Encounter.participant.individual"/>
-      <short value="Persons involved in the encounter other than the patient"/>
-      <definition value="Persons involved in the encounter other than the patient."/>
+    <element id="Encounter.participant.actor">
+      <path value="Encounter.participant.actor"/>
+      <short value="Persons involved in the encounter (including patient)"/>
+      <definition value="Persons involved in the encounter, the patient/group is also included here to indicate that the patient was actually participating in the encounter. Not including the patient here covers use cases such as a case meeting between practitioners about a patient - non contact times"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>
       </type>

--- a/source/encounter/structuredefinition-Encounter.xml
+++ b/source/encounter/structuredefinition-Encounter.xml
@@ -581,7 +581,7 @@
     <element id="Encounter.participant.actor">
       <path value="Encounter.participant.actor"/>
       <short value="Persons involved in the encounter (including patient)"/>
-      <definition value="Persons involved in the encounter, the patient/group is also included here to indicate that the patient was actually participating in the encounter. Not including the patient here covers use cases such as a case meeting between practitioners about a patient - non contact times"/>
+      <definition value="Persons involved in the encounter, the patient/group is also included here to indicate that the patient was actually participating in the encounter. Not including the patient here covers use cases such as a case meeting between practitioners about a patient - non contact times."/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
PA Scheduling/Accounts tracker items
#FHIR-32768 Typo on property name cancelationReason
#FHIR-26965 Add replaces property to Appointment
#FHIR-24078 Include account reference on patient
#FHIR-14963 Add a billing status to Account
#FHIR-22696 Update encounter participant from individual to actor and support inclusion of patient/group as reference types, indicating that if the patient is present during the encounter, then they should be listed in both places