### PR TITLE
Patient admin/search and typos

### DIFF
--- a/source/appointment/appointment-introduction.xml
+++ b/source/appointment/appointment-introduction.xml
@@ -61,7 +61,7 @@
 			<li>
 				<b>Replying to the request</b>
 				<p>
-					The reply process is simply performed by the person/system handing the requests, updating
+					The reply process is simply performed by the person/system handling the requests, updating
 					the participant statuses on the appointment as needed. If there are multiple systems involved, then these
 					will create AppointmentResponse entries with the desired statuses.
 				</p>

--- a/source/appointmentresponse/appointmentresponse-introduction.xml
+++ b/source/appointmentresponse/appointmentresponse-introduction.xml
@@ -34,7 +34,7 @@
 			<li>
 				<b>Replying to the request</b>
 				<p>
-					The reply process is simply performed by the person/system handing the requests updating
+					The reply process is simply performed by the person/system handling the requests updating
 					the participant statuses as needed. If there are multiple systems involved, then these
 					will create AppointmentResponse entries with the desired statuses.
 				</p>

--- a/source/clinicalimpression/bundle-ClinicalImpression-search-params.xml
+++ b/source/clinicalimpression/bundle-ClinicalImpression-search-params.xml
@@ -113,7 +113,7 @@
           <valueString value="ClinicalImpression.subject"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ClinicalImpression-patient"/>
-        <description value="Patient or group assessed"/>
+        <description value="Patient assessed"/>
         <code value="patient"/>
         <type value="reference"/>
         <expression value="ClinicalImpression.subject.where(resolve() is Patient)"/>

--- a/source/encounter/bundle-Encounter-search-params.xml
+++ b/source/encounter/bundle-Encounter-search-params.xml
@@ -293,7 +293,7 @@
           <valueString value="Encounter.subject"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Encounter-patient"/>
-        <description value="The patient or group present at the encounter"/>
+        <description value="The patient present at the encounter"/>
         <code value="patient"/>
         <type value="reference"/>
         <expression value="Encounter.subject.where(resolve() is Patient)"/>

--- a/source/location/bundle-Location-search-params.xml
+++ b/source/location/bundle-Location-search-params.xml
@@ -193,7 +193,7 @@
           <valueString value="Location.position"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Location-near"/>
-        <description value="Search for locations where the location.position is near to, or within a specified distance of, the provided coordinates expressed as [latitude]|[longitude]|[distance]|[units] (using the WGS84 datum, see notes).&#xA;If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant)&#xA;&#xA;Servers may search using various techniques that might have differing accuracies, depending on implementation efficiency.&#xA;&#xA;Requires the near-distance parameter to be provided also"/>
+        <description value="Search for locations where the location.position is near to, or within a specified distance of, the provided coordinates expressed as [latitude]|[longitude]|[distance]|[units] (using the WGS84 datum, see notes).&#xA;If the units are omitted, then kms should be assumed. If the distance is omitted, then the server can use its own discretion as to what distances should be considered near (and units are irrelevant)&#xA;&#xA;Servers may search using various techniques that might have differing accuracies, depending on implementation efficiency."/>
         <code value="near"/>
         <type value="special"/>
         <expression value="Location.position"/>

--- a/source/patient/bundle-Patient-search-params.xml
+++ b/source/patient/bundle-Patient-search-params.xml
@@ -193,7 +193,7 @@
           <valueString value="Patient.deceased[x]"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Patient-deceased"/>
-        <description value="This patient has been marked as deceased, or as a death date entered"/>
+        <description value="This patient has been marked as deceased, or has a death date entered"/>
         <code value="deceased"/>
         <type value="token"/>
         <expression value="Patient.deceased.exists() and Patient.deceased != false"/>
@@ -373,7 +373,7 @@
           <valueString value="Patient.name"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Patient-name"/>
-        <description value="A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text"/>
+        <description value="A server defined search that may match any of the string fields in the HumanName, including family, given, prefix, suffix, and/or text"/>
         <code value="name"/>
         <type value="string"/>
         <expression value="Patient.name"/>

--- a/source/patient/patient-example-a.xml
+++ b/source/patient/patient-example-a.xml
@@ -24,8 +24,8 @@
   <active value="true"/>
   <name>
     <use value="official"/>
-    <family value="Donald"/>
-    <given value="Duck"/>
+    <family value="Duck"/>
+    <given value="Donald"/>
   </name>
   <gender value="male"/>
   <photo>

--- a/source/patient/structuredefinition-Patient.xml
+++ b/source/patient/structuredefinition-Patient.xml
@@ -832,8 +832,8 @@
         <valueCode value="380,90"/>
       </extension>
       <path value="Patient.link"/>
-      <short value="Link to another patient resource that concerns the same actual person"/>
-      <definition value="Link to another patient resource that concerns the same actual patient."/>
+      <short value="Link to other Patient or RelatedPerson resource(s) that concerns the same actual person"/>
+      <definition value="Link to another patient or RelatedPErson resource that concerns the same actual patient."/>
       <comment value="There is no assumption that linked patient records have mutual links."/>
       <requirements value="There are multiple use cases:   &#xA;&#xA;* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and &#xA;* Distribution of patient information across multiple servers."/>
       <min value="0"/>

--- a/source/person/bundle-Person-search-params.xml
+++ b/source/person/bundle-Person-search-params.xml
@@ -385,6 +385,46 @@
   <entry>
     <resource>
       <SearchParameter>
+        <id value="Person-family"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Person.name.family"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Person-family"/>
+        <description value="A portion of the family name of the person"/>
+        <code value="family"/>
+        <type value="string"/>
+        <expression value="Person.name.family"/>
+        <xpath value="f:Person/f:name/f:family"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Person-given"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Person.name.given"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Person-given"/>
+        <description value="A portion of the given name of the person"/>
+        <code value="given"/>
+        <type value="string"/>
+        <expression value="Person.name.given"/>
+        <xpath value="f:Person/f:name/f:given"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
         <id value="Person-death-date"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>

--- a/source/person/bundle-Person-search-params.xml
+++ b/source/person/bundle-Person-search-params.xml
@@ -382,4 +382,44 @@
       </SearchParameter>
     </resource>
   </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Person-death-date"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Person.deceasedDateTime"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Person-death-date"/>
+        <description value="The date of death has been provided and satisfies this search value"/>
+        <code value="death-date"/>
+        <type value="date"/>
+        <expression value="(Person.deceased as dateTime)"/>
+        <xpath value="f:Person/f:deceasedDateTime"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Person-deceased"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Person.deceased[x]"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Person-deceased"/>
+        <description value="This person has been marked as deceased, or as a death date entered"/>
+        <code value="deceased"/>
+        <type value="token"/>
+        <expression value="Person.deceased.exists() and Person.deceased != false"/>
+        <xpath value="f:Person/f:deceasedBoolean | f:Person/f:deceasedDateTime"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
 </Bundle>

--- a/source/person/bundle-Person-search-params.xml
+++ b/source/person/bundle-Person-search-params.xml
@@ -413,7 +413,7 @@
           <valueString value="Person.deceased[x]"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/Person-deceased"/>
-        <description value="This person has been marked as deceased, or as a death date entered"/>
+        <description value="This person has been marked as deceased, or has a death date entered"/>
         <code value="deceased"/>
         <type value="token"/>
         <expression value="Person.deceased.exists() and Person.deceased != false"/>

--- a/source/practitioner/bundle-Practitioner-search-params.xml
+++ b/source/practitioner/bundle-Practitioner-search-params.xml
@@ -342,4 +342,44 @@
       </SearchParameter>
     </resource>
   </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Practitioner-death-date"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Practitioner.deceasedDateTime"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Practitioner-death-date"/>
+        <description value="The date of death has been provided and satisfies this search value"/>
+        <code value="death-date"/>
+        <type value="date"/>
+        <expression value="(Practitioner.deceased as dateTime)"/>
+        <xpath value="f:Practitioner/f:deceasedDateTime"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Practitioner-deceased"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Practitioner.deceased[x]"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Practitioner-deceased"/>
+        <description value="This Practitioner has been marked as deceased, or has a death date entered"/>
+        <code value="deceased"/>
+        <type value="token"/>
+        <expression value="Practitioner.deceased.exists() and Practitioner.deceased != false"/>
+        <xpath value="f:Practitioner/f:deceasedBoolean | f:Practitioner/f:deceasedDateTime"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
 </Bundle>

--- a/source/practitioner/structuredefinition-Practitioner.xml
+++ b/source/practitioner/structuredefinition-Practitioner.xml
@@ -221,6 +221,25 @@
         <map value="./ContactPoints"/>
       </mapping>
     </element>
+    <element id="Practitioner.deceased[x]">
+      <path value="Practitioner.deceased[x]"/>
+      <short value="Indicates if the practitioner is deceased or not"/>
+      <definition value="Indicates if the practitioner is deceased or not."/>
+      <comment value="If there&#39;s no value in the instance, it means there is no statement on whether or not the practitioner is deceased. Most systems will interpret the absence of a value as a sign of the person being alive."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+      <type>
+        <code value="dateTime"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value="player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"/>
+      </mapping>
+    </element>
     <element id="Practitioner.address">
       <path value="Practitioner.address"/>
       <short value="Address(es) of the practitioner that are not role specific (typically home address)"/>

--- a/source/practitioner/structuredefinition-Practitioner.xml
+++ b/source/practitioner/structuredefinition-Practitioner.xml
@@ -371,7 +371,7 @@
       </extension>
       <path value="Practitioner.qualification"/>
       <short value="Certification, licenses, or training pertaining to the provision of care"/>
-      <definition value="The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality."/>
+      <definition value="The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certain locality."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/relatedperson/bundle-RelatedPerson-search-params.xml
+++ b/source/relatedperson/bundle-RelatedPerson-search-params.xml
@@ -245,6 +245,46 @@
   <entry>
     <resource>
       <SearchParameter>
+        <id value="RelatedPerson-family"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="RelatedPerson.name.family"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/RelatedPerson-family"/>
+        <description value="A portion of the family name of the related person"/>
+        <code value="family"/>
+        <type value="string"/>
+        <expression value="RelatedPerson.name.family"/>
+        <xpath value="f:RelatedPerson/f:name/f:family"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="RelatedPerson-given"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="RelatedPerson.name.given"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/RelatedPerson-given"/>
+        <description value="A portion of the given name of the related person"/>
+        <code value="given"/>
+        <type value="string"/>
+        <expression value="RelatedPerson.name.given"/>
+        <xpath value="f:RelatedPerson/f:name/f:given"/>
+        <xpathUsage value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
         <id value="RelatedPerson-patient"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>


### PR DESCRIPTION
PA Misc Search and typos
#FHIR-29820 deceased search parameter added to person
#FHIR-28424 typo
#FHIR-13601 clarification in description of patient search parameter
#FHIR-25446 search parameter description typo
#FHIR-17634 Add deceased property and search parameter to Practitioner
#FHIR-26590 Add deceased property and search parameter to Practitioner
#FHIR-17627 update example resource
#FHIR-22749 search parameter clarification (no londer requires near-distance)
#FHIR-20418 typo - spelling
#FHIR-23009 clarification of link narrative text
#FHIR-26371 added given and family search parameters to Person and RelatedPerson