### PR TITLE
J# 33266

### DIFF
--- a/source/evidencevariable/codesystem-evidence-variable-event.xml
+++ b/source/evidencevariable/codesystem-evidence-variable-event.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="evidence-variable-event"/>
+  <meta>
+    <lastUpdated value="2021-01-05T10:01:24.148+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>This code system http://hl7.org/fhir/evidence-variable-event defines the following codes:</p>
+      
+      <table class="codes">
+        
+        <tr>
+          
+          <td style="white-space:nowrap">
+            
+            <b>Code</b>
+          
+          </td>
+          
+          <td>
+            
+            <b>Display</b>
+          
+          </td>
+          
+          <td>
+            
+            <b>Definition</b>
+          
+          </td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">study-start
+            
+            <a name="evidence-variable-event-study-start"> </a>
+          
+          </td>
+          
+          <td>Study Start</td>
+          
+          <td>The time of enrollment for the study participant</td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">hospital-admission
+            
+            <a name="evidence-variable-event-hospital-admission"> </a>
+          
+          </td>
+          
+          <td>Hospital Admission</td>
+          
+          <td>The time of admission to the hospital</td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">hospital-discharge
+            
+            <a name="evidence-variable-event-hospital-discharge"> </a>
+          
+          </td>
+          
+          <td>Hospital Discharge</td>
+          
+          <td>The time of discharge from the hospital</td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">operative-procedure
+            
+            <a name="evidence-variable-event-operative-procedure"> </a>
+          
+          </td>
+          
+          <td>Operative Procedure</td>
+          
+          <td>The time of surgery</td>
+        
+        </tr>
+      
+      </table>
+    
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="5"/>
+  </extension>
+  <url value="http://hl7.org/fhir/evidence-variable-event"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.1.0"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="EvidenceVariableEvent"/>
+  <title value="EvidenceVariableEvent"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2021-01-05T10:01:24+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="The event used as a base point (reference point) in time."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/evidence-variable-event"/>
+  <content value="complete"/>
+  <concept>
+    <code value="study-start"/>
+    <display value="Study Start"/>
+    <definition value="The time of enrollment for the study participant"/>
+  </concept>
+  <concept>
+    <code value="hospital-admission"/>
+    <display value="Hospital Admission"/>
+    <definition value="The time of admission to the hospital"/>
+  </concept>
+  <concept>
+    <code value="hospital-discharge"/>
+    <display value="Hospital Discharge"/>
+    <definition value="The time of discharge from the hospital"/>
+  </concept>
+  <concept>
+    <code value="operative-procedure"/>
+    <display value="Operative Procedure"/>
+    <definition value="The time of surgery"/>
+  </concept>
+</CodeSystem>

--- a/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
@@ -45,6 +45,13 @@
     </definitionCodeableConcept>
     <exclude value="true"/>
     <timeFromEvent>
+	  <event>
+		<coding>
+			<system value="http://hl7.org/fhir/evidence-variable-event"/>
+			<code value="study-start"/>
+			<display value="Study Start"/>
+		</coding>
+	  </event>
       <quantity>
         <value value="90"/>
         <unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
@@ -25,14 +25,14 @@
       </coding>
     </definitionCodeableConcept>
     <exclude value="true"/>
-    <timeFromStart>
+    <timeFromEvent>
       <quantity>
         <value value="90"/>
         <unit value="day"/>
         <system value="http://unitsofmeasure.org"/>
         <code value="d"/>
       </quantity>
-    </timeFromStart>
+    </timeFromEvent>
   </characteristic>
   <characteristic>
     <description value="alive at 90 days"/>
@@ -44,14 +44,14 @@
       </coding>
     </definitionCodeableConcept>
     <exclude value="true"/>
-    <timeFromStart>
+    <timeFromEvent>
       <quantity>
         <value value="90"/>
         <unit value="day"/>
         <system value="http://unitsofmeasure.org"/>
         <code value="d"/>
       </quantity>
-    </timeFromStart>
+    </timeFromEvent>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
@@ -25,6 +25,13 @@
 			</coding>
 		</definitionCodeableConcept>
 		<timeFromEvent>
+			<event>
+				<coding>
+					<system value="http://hl7.org/fhir/evidence-variable-event"/>
+					<code value="study-start"/>
+					<display value="Study Start"/>
+				</coding>
+			</event>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
@@ -24,14 +24,14 @@
 				<display value="Functionally dependent (finding)"/>
 			</coding>
 		</definitionCodeableConcept>
-		<timeFromStart>
+		<timeFromEvent>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>
 				<system value="http://unitsofmeasure.org"/>
 				<code value="d"/>
 			</quantity>
-		</timeFromStart>
+		</timeFromEvent>
   </characteristic>
   <characteristic>
 		<description value="dead at 90 days"/>
@@ -42,14 +42,14 @@
 				<display value="Dead (finding)"/>
 			</coding>
 		</definitionCodeableConcept>
-		<timeFromStart>
+		<timeFromEvent>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>
 				<system value="http://unitsofmeasure.org"/>
 				<code value="d"/>
 			</quantity>
-		</timeFromStart>
+		</timeFromEvent>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -29,6 +29,13 @@
     </definitionCodeableConcept>
     <timeFromEvent>
 			<description value="within 7 days"/>
+			<event>
+				<coding>
+					<system value="http://hl7.org/fhir/evidence-variable-event"/>
+					<code value="study-start"/>
+					<display value="Study Start"/>
+				</coding>
+			</event>
 			<range>
 				<low>
 					<value value="0"/>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -27,7 +27,7 @@
 				<display value="Intracranial hemorrhage (disorder)"/>
 			</coding>
     </definitionCodeableConcept>
-    <timeFromStart>
+    <timeFromEvent>
 			<description value="within 7 days"/>
 			<range>
 				<low>
@@ -43,7 +43,7 @@
 					<code value="d"/>
 				</high>
 			</range>
-    </timeFromStart>
+    </timeFromEvent>
   </characteristic>
   <characteristic>
 		<description value="death within 7 days"/>
@@ -54,7 +54,7 @@
 				<display value="Death (event)"/>
 			</coding>
 		</definitionCodeableConcept>
-		<timeFromStart>
+		<timeFromEvent>
 			<description value="within 7 days"/>
 			<range>
 				<low>
@@ -70,7 +70,7 @@
 					<code value="d"/>
 				</high>
 			</range>
-		</timeFromStart>
+		</timeFromEvent>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
@@ -20,6 +20,13 @@
       <expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 0 and 2"/>
     </definitionExpression>
     <timeFromEvent>
+	  <event>
+		<coding>
+			<system value="http://hl7.org/fhir/evidence-variable-event"/>
+			<code value="study-start"/>
+			<display value="Study Start"/>
+		</coding>
+	  </event>
       <quantity>
         <value value="90"/>
         <unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
@@ -19,14 +19,14 @@
       <language value="text/cql"/>
       <expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 0 and 2"/>
     </definitionExpression>
-    <timeFromStart>
+    <timeFromEvent>
       <quantity>
         <value value="90"/>
         <unit value="day"/>
         <system value="http://unitsofmeasure.org"/>
         <code value="d"/>
       </quantity>
-    </timeFromStart>
+    </timeFromEvent>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
@@ -20,6 +20,13 @@
 			<expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 3 and 6"/>
 		</definitionExpression>
 		<timeFromEvent>
+			<event>
+				<coding>
+					<system value="http://hl7.org/fhir/evidence-variable-event"/>
+					<code value="study-start"/>
+					<display value="Study Start"/>
+				</coding>
+			</event>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
@@ -19,14 +19,14 @@
 			<language value="text/cql"/>
 			<expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 3 and 6"/>
 		</definitionExpression>
-		<timeFromStart>
+		<timeFromEvent>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>
 				<system value="http://unitsofmeasure.org"/>
 				<code value="d"/>
 			</quantity>
-		</timeFromStart>
+		</timeFromEvent>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -576,56 +576,6 @@
       </type>
       <meaningWhenMissing value="False"/>
     </element>
-    <element id="EvidenceVariable.characteristic.timeFromStart">
-      <path value="EvidenceVariable.characteristic.timeFromStart"/>
-      <short value="Observation time from study start"/>
-      <definition value="Indicates duration, period, or point of observation from the participant&#39;s study entry."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="BackboneElement"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.characteristic.timeFromStart.description">
-      <path value="EvidenceVariable.characteristic.timeFromStart.description"/>
-      <short value="Human readable description"/>
-      <definition value="A short, natural language description."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.characteristic.timeFromStart.quantity">
-      <path value="EvidenceVariable.characteristic.timeFromStart.quantity"/>
-      <short value="Used to express the observation at a defined amount of time after the study start"/>
-      <definition value="Used to express the observation at a defined amount of time after the study start."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Quantity"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.characteristic.timeFromStart.range">
-      <path value="EvidenceVariable.characteristic.timeFromStart.range"/>
-      <short value="Used to express the observation within a period after the study start"/>
-      <definition value="Used to express the observation within a period after the study start."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Range"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.characteristic.timeFromStart.note">
-      <path value="EvidenceVariable.characteristic.timeFromStart.note"/>
-      <short value="Used for footnotes or explanatory notes"/>
-      <definition value="A human-readable string to clarify or explain concepts about the resource."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="Annotation"/>
-      </type>
-    </element>
     <element id="EvidenceVariable.characteristic.timeFromEvent">
       <path value="EvidenceVariable.characteristic.timeFromEvent"/>
       <short value="Observation time from study specified event"/>
@@ -646,7 +596,7 @@
     </element>
     <element id="EvidenceVariable.characteristic.timeFromEvent.event">
       <path value="EvidenceVariable.characteristic.timeFromEvent.event"/>
-      <short value="The type of event where the observation started"/>
+      <short value="The event used as a base point (reference point) in time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -654,10 +604,10 @@
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ProcedureCodes"/>
+          <valueString value="EvidenceVariableEvent"/>
         </extension>
         <strength value="example"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/procedure-code"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/evidence-variable-event"/>
       </binding>
     </element>
     <element id="EvidenceVariable.characteristic.timeFromEvent.quantity">

--- a/source/evidencevariable/valueset-evidence-variable-event.xml
+++ b/source/evidencevariable/valueset-evidence-variable-event.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="evidence-variable-event"/>
+  <meta>
+    <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <ul>
+        <li>Include all codes defined in 
+          <a href="codesystem-evidence-variable-event.html">
+            <code>http://hl7.org/fhir/ValueSet/evidence-variable-event</code>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="fhir"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="5"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/evidence-variable-event"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.0"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="EvidenceVariableEvent"/>
+  <title value="EvidenceVariableEvent"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2020-12-28T16:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="The event used as a base point (reference point) in time."/>
+  <immutable value="true"/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/evidence-variable-event"/>
+    </include>
+  </compose>
+</ValueSet>


### PR DESCRIPTION
1. Removed the EvidenceVariable.characteristic.timeFromStart element
2. Added EvidenceVariableEvent codesytem/valueset for EvidenceVariable.characteristic.timeFromEvent.event to use
3. Updated the description for EvidenceVariable.characteristic.timeFromEvent.event
4. Updated EvidenceVariable examples to use timeFromEvent instead of timeFromStart, and it now uses the study-start code for EvidenceVariable.characteristic.timeFromEvent.event (system, code, and display for examples that use timeFromEvent)