### PR TITLE
Moehrke audit event

### DIFF
--- a/guides/ehrsrle/auditevent-profile-ehrs-rle-spreadsheet.xml
+++ b/guides/ehrsrle/auditevent-profile-ehrs-rle-spreadsheet.xml
@@ -1185,7 +1185,7 @@
     <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.purposeOfEvent</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.authorization</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><Data ss:Type="String">!0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -1523,7 +1523,7 @@
     <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.agent.purposeOfUse</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.agent.authorization</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><Data ss:Type="String">!0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -1701,32 +1701,7 @@
     <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s112"><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
-   <Row ss:AutoFitHeight="0">
-    <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.entity.type</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><Data ss:Type="String">!0..1</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><Data ss:Type="String">Y</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s109"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s110"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s109"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s110"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s112"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-   </Row>
+
    <Row ss:AutoFitHeight="0">
     <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -1753,32 +1728,7 @@
     <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s112"><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
-   <Row ss:AutoFitHeight="0">
-    <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">AuditEvent.entity.lifecycle</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><Data ss:Type="String">!0..1</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><Data ss:Type="String">Y</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s109"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s110"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s109"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s110"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s111"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s112"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-   </Row>
+
    <Row ss:AutoFitHeight="0">
     <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/guides/ehrsrle/provenance-profile-ehrs-rle-spreadsheet.xml
+++ b/guides/ehrsrle/provenance-profile-ehrs-rle-spreadsheet.xml
@@ -1123,7 +1123,7 @@
     <Cell ss:StyleID="s105"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">Provenance.reason</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s107"><Data ss:Type="String">Provenance.authorization</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><Data ss:Type="String">!0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s108"><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/source/auditevent/audit-event-example-create-traceID.xml
+++ b/source/auditevent/audit-event-example-create-traceID.xml
@@ -2,14 +2,18 @@
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-rest-create-traceID"/>
 	<type>
+	   <coding>
 		<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
 		<code value="rest"/>
 		<display value="Restful Operation"/>
+	   </coding>
 	</type>
 	<subtype>
+	   <coding>
 		<system value="http://hl7.org/fhir/restful-interaction"/>
 		<code value="create"/>
 		<display value="create"/>
+	   </coding>
 	</subtype>
 	<action value="C"/>
 	<recorded value="2019-12-04T11:59:28.646+00:00"/>
@@ -35,12 +39,18 @@
 				<value value="95"/>
 			</identifier>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<agent>
 		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+			  <type>
+				<text value="process ID"/>
+			  </type>
+			  <value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
@@ -54,7 +64,6 @@
 				<value value="2.16.840.1.113883.4.2"/> 
 			</identifier>
 		</who>
-		<altId value="6580"/> 
 		<requestor value="false"/> 
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
@@ -62,31 +71,30 @@
 		</network> 
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
 		<identifier>
 			<value value="hl7connect.healthintersections.com.au"/>
 			</identifier>
 		</observer>
 		<type>
+	   <coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="3"/>
 			<display value="Web Server"/>
+	   </coding>
 		</type>
 	</source>
 	<entity>
 		<what>
 			<reference value="Patient/example/_history/1"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
+
 		<role>
+	   <coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="1"/>
 			<display value="Patient"/>
+	   </coding>
 		</role>
 	</entity>
 	<entity>
@@ -100,15 +108,13 @@
 				<value value="6b507ee2d716780372c255df69ece653"/>
 			</identifier>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
+
 		<role>
+	   <coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="21"/>
 			<display value="Job Stream"/>
+	   </coding>
 		</role>
 	</entity>
 </AuditEvent>

--- a/source/auditevent/audit-event-example-login.xml
+++ b/source/auditevent/audit-event-example-login.xml
@@ -2,14 +2,18 @@
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-login"/>
 	<type>
+		<coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110114"/>
 		<display value="User Authentication"/>
+		</coding>
 	</type>
 	<subtype>
+		<coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110122"/>
 		<display value="Login"/>
+		</coding>
 	</subtype>
 	<action value="E"/>
 	<recorded value="2013-06-20T23:41:23Z"/>
@@ -33,9 +37,8 @@
 			<identifier>
 				<value value="95"/>
 			</identifier>
+		<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 		<network>
 			<address value="127.0.0.1"/>
@@ -44,6 +47,14 @@
 	</agent>
 	<agent>
 		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+			  <type>
+				<text value="process ID"/>
+			  </type>
+			  <value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
@@ -57,7 +68,6 @@
 				<value value="2.16.840.1.113883.4.2"/> 
 			</identifier>
 		</who>
-		<altId value="6580"/> 
 		<requestor value="false"/> 
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
@@ -65,16 +75,18 @@
 		</network> 
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
 			<identifier>
 				<value value="hl7connect.healthintersections.com.au"/>
 			</identifier>
+		<display value="Cloud"/>
 		</observer>
 		<type>
+		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="3"/>
 			<display value="Web Server"/>
+			</coding>
 		</type>
 	</source>
 </AuditEvent>

--- a/source/auditevent/audit-event-example-logout.xml
+++ b/source/auditevent/audit-event-example-logout.xml
@@ -2,14 +2,18 @@
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-logout"/>
 	<type>
+		<coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110114"/>
 		<display value="User Authentication"/>
+		</coding>
 	</type>
 	<subtype>
+		<coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110123"/>
 		<display value="Logout"/>
+		</coding>
 	</subtype>
 	<action value="E"/>
 	<recorded value="2013-06-20T23:46:41Z"/>
@@ -33,9 +37,8 @@
 			<identifier>
 				<value value="95"/>
 			</identifier>
+		<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 		<network>
 			<address value="127.0.0.1"/>
@@ -44,6 +47,14 @@
 	</agent>
 	<agent>
 		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+			  <type>
+				<text value="process ID"/>
+			  </type>
+			  <value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
@@ -57,7 +68,6 @@
 				<value value="2.16.840.1.113883.4.2"/> 
 			</identifier>
 		</who>
-		<altId value="6580"/> 
 		<requestor value="false"/> 
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
@@ -65,16 +75,18 @@
 		</network> 
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
 			<identifier>
 				<value value="hl7connect.healthintersections.com.au"/>
 			</identifier>
+		<display value="Cloud"/>
 		</observer>
 		<type>
+		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="3"/>
 			<display value="Web Server"/>
+		</coding>
 		</type>
 	</source>
 </AuditEvent>

--- a/source/auditevent/audit-event-example-media.xml
+++ b/source/auditevent/audit-event-example-media.xml
@@ -1,16 +1,19 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-media"/>
-
 	<type>
-		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
-		<code value="110106"/>
-		<display value="Export"/>
+		<coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="110106"/>
+			<display value="Export"/>
+		</coding>
 	</type>
 	<subtype>
-		<system value="urn:ihe:event-type-code"/>
-		<code value="ITI-32"/>
-		<display value="Distribute Document Set on Media"/>
+		<coding>
+			<system value="urn:ihe:event-type-code"/>
+			<code value="ITI-32"/>
+			<display value="Distribute Document Set on Media"/>
+		</coding>
 	</subtype>
 	<action value="R"/>
 	<recorded value="2015-08-27T23:42:24Z"/>
@@ -20,8 +23,7 @@
 			<code value="0"/>
 			<display value="Success"/>
 		</coding>
-	</outcome> 
-
+	</outcome>
 	<agent>
 		<!-- Source active participant, the software making the PIX query
   UserId - The identity of the Patient Identifier Cross-reference Consumer Actor facility and sending application from the HL7 message; 
@@ -48,14 +50,13 @@
 				<code value="humanuser"/>
 				<display value="human user"/>
 			</coding>
-		</type> 
+		</type>
 		<who>
 			<identifier>
 				<value value="95"/>
 			</identifier>
+			<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<agent>
@@ -66,18 +67,25 @@
 				<code value="110154"/>
 				<display value="Destination Media"/>
 			</coding>
-		</type> 
-		<name value="Media title: Hello World"/>
+		</type>
+		<who>
+			<display value="Media title: Hello World"/>
+		</who>
 		<requestor value="false"/>
 		<media>
-			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
-			<code value="110033"/>
-			<display value="DVD"/>
+			<coding>
+				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+				<code value="110033"/>
+				<display value="DVD"/>
+			</coding>
 		</media>
 	</agent>
 	<source>
 		<observer>
-			<display value="hl7connect.healthintersections.com.au"/>
+			<identifier>
+				<value value="hl7connect.healthintersections.com.au"/>
+			</identifier>
+			<display value="Cloud"/>
 		</observer>
 	</source>
 	<entity>
@@ -89,15 +97,12 @@
 				<value value="e3cdfc81a0d24bd^^^&amp;2.16.840.1.113883.4.2&amp;ISO"/>
 			</identifier>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
 		<role>
-			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
-			<code value="1"/>
-			<display value="Patient"/>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+				<code value="1"/>
+				<display value="Patient"/>
+			</coding>
 		</role>
 	</entity>
 	<entity>
@@ -114,15 +119,12 @@
 				<value value="e3cdfc81a0d24bd^^^&amp;2.16.840.1.113883.4.2&amp;ISO"/>
 			</identifier>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
 		<role>
-			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
-			<code value="20"/>
-			<display value="Job"/>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+				<code value="20"/>
+				<display value="Job"/>
+			</coding>
 		</role>
 	</entity>
 	<entity>
@@ -130,10 +132,5 @@
 		<what>
 			<reference value="DocumentManifest/example"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
 	</entity>
 </AuditEvent>

--- a/source/auditevent/audit-event-example-pixQuery.xml
+++ b/source/auditevent/audit-event-example-pixQuery.xml
@@ -3,14 +3,18 @@
 	<id value="example-pixQuery"/>
 
 	<type>
+			<coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110112"/>
 		<display value="Query"/>
+			</coding>
 	</type>
 	<subtype>
+			<coding>
 		<system value="urn:oid:1.3.6.1.4.1.19376.1.2"/>
 		<code value="ITI-9"/>
 		<display value="PIX Query"/>
+			</coding>
 	</subtype>
 	<action value="E"/>
 	<recorded value="2015-08-26T23:42:24Z"/>
@@ -28,6 +32,14 @@
   concatenated together, separated by the | character. 
   AlternativeUserId - Process ID
   -->
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+			  <type>
+				<text value="process ID"/>
+			  </type>
+			  <value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
@@ -41,7 +53,6 @@
 				<value value="2.16.840.1.113883.4.2"/> 
 			</identifier>
 		</who>
-		<altId value="6580"/>
 		<requestor value="false"/>
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
@@ -50,6 +61,7 @@
 	</agent>
 	<agent>
 		<!--  The Human using the software, if known  -->
+
 		<type>
 			<coding>
 				<system value="http://terminology.hl7.org/CodeSystem/extra-security-role-type"/>
@@ -62,9 +74,8 @@
 			<identifier>
 				<value value="95"/>
 			</identifier>
+		<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<source>
@@ -81,34 +92,34 @@
 				<value value="e3cdfc81a0d24bd^^^&amp;2.16.840.1.113883.4.2&amp;ISO"/>
 			</identifier>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
+
 		<role>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="1"/>
 			<display value="Patient"/>
+			</coding>
 		</role>
 	</entity>
 	<entity>
 		<!-- The PIX Query Parameters -->
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
+
 		<role>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="24"/>
 			<display value="Query"/>
+			</coding>
 		</role>
 		<!-- The complete query message (including MSH and QPD segments), base64 encoded -->
 		<query value="PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFBSUEFfSU4yMDEzMDlVVjAyIElUU1ZlcnNpb249IlhNTF8xLjAiIHhtbG5zPSJ1cm46aGw3LW9yZzp2MyI+CiAgPGlkIGV4dGVuc2lvbj0iMzU0MjMiIHJvb3Q9IjEuMi44NDAuMTE0MzUwLjEuMTMuMC4xLjcuMS4xIi8+CiAgPGNyZWF0aW9uVGltZSB2YWx1ZT0iMjAxNDA1MDgxNjQ5MjUiLz4KICA8aW50ZXJhY3Rpb25JZCBleHRlbnNpb249IlBSUEFfSU4yMDEzMDVVVjAyIiByb290PSIyLjE2Ljg0MC4xLjExMzg4My4xLjYiLz4KICA8cHJvY2Vzc2luZ0NvZGUgY29kZT0iVCIvPgogIDxwcm9jZXNzaW5nTW9kZUNvZGUgY29kZT0iVCIvPgogIDxhY2NlcHRBY2tDb2RlIGNvZGU9IkFMIi8+CiAgPHJlY2VpdmVyIHR5cGVDb2RlPSJSQ1YiPgogICAgPGRldmljZSBjbGFzc0NvZGU9IkRFViIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgPGlkIHJvb3Q9IkVIUl9NSVNZUyIvPgogICAgICA8YXNBZ2VudCBjbGFzc0NvZGU9IkFHTlQiPgogICAgICAgIDxyZXByZXNlbnRlZE9yZ2FuaXphdGlvbiBjbGFzc0NvZGU9Ik9SRyIgZGV0ZXJtaW5lckNvZGU9IklOU1RBTkNFIj4KICAgICAgICAgIDxpZCByb290PSJNSVNZUyIvPgogICAgICAgIDwvcmVwcmVzZW50ZWRPcmdhbml6YXRpb24+CiAgICAgIDwvYXNBZ2VudD4KICAgIDwvZGV2aWNlPgogIDwvcmVjZWl2ZXI+CiAgPHNlbmRlciB0eXBlQ29kZT0iU05EIj4KICAgIDxkZXZpY2UgY2xhc3NDb2RlPSJERVYiIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgIDxpZCByb290PSIyLjE2Ljg0MC4xLjExMzg4My40LjIiLz4KICAgICAgPGFzQWdlbnQgY2xhc3NDb2RlPSJBR05UIj4KICAgICAgICA8cmVwcmVzZW50ZWRPcmdhbml6YXRpb24gY2xhc3NDb2RlPSJPUkciIGRldGVybWluZXJDb2RlPSJJTlNUQU5DRSI+CiAgICAgICAgICA8aWQgcm9vdD0iMi4xNi44NDAuMS4xMTM4ODMuNC4yIi8+CiAgICAgICAgPC9yZXByZXNlbnRlZE9yZ2FuaXphdGlvbj4KICAgICAgPC9hc0FnZW50PgogICAgPC9kZXZpY2U+CiAgPC9zZW5kZXI+CiAgPGNvbnRyb2xBY3RQcm9jZXNzIGNsYXNzQ29kZT0iQ0FDVCIgbW9vZENvZGU9IkVWTiI+CiAgICA8Y29kZSBjb2RlPSJQUlBBX1RFMjAxMzA5VVYwMiIgY29kZVN5c3RlbT0iMi4xNi44NDAuMS4xMTM4ODMuMS42Ii8+CiAgICA8cXVlcnlCeVBhcmFtZXRlcj4KICAgICAgPHF1ZXJ5SWQgZXh0ZW5zaW9uPSIxODQwOTk3MDg0IiByb290PSIxLjIuODQwLjExNDM1MC4xLjEzLjI4LjEuMTguNS45OTkiLz4KICAgICAgPHN0YXR1c0NvZGUgY29kZT0ibmV3Ii8+CiAgICAgIDxyZXNwb25zZVByaW9yaXR5Q29kZSBjb2RlPSJJIi8+CiAgICAgIDxwYXJhbWV0ZXJMaXN0PgogICAgICAgIDxwYXRpZW50SWRlbnRpZmllcj4KICAgICAgICAgIDx2YWx1ZSBleHRlbnNpb249IlN1cnlhQnJhbmQiIHJvb3Q9IjIuMTYuODQwLjEuMTEzODgzLjQuMiIvPgogICAgICAgICAgPHNlbWFudGljc1RleHQ+UGF0aWVudC5JZDwvc2VtYW50aWNzVGV4dD4KICAgICAgICA8L3BhdGllbnRJZGVudGlmaWVyPgogICAgICA8L3BhcmFtZXRlckxpc3Q+CiAgICA8L3F1ZXJ5QnlQYXJhbWV0ZXI+CiAgPC9jb250cm9sQWN0UHJvY2Vzcz4KPC9QUlBBX0lOMjAxMzA5VVYwMj4K"/>
 		<detail>
 			<!-- MSH-10 -->
-			<type value="MSH-10"/>
+			<type>
+			<coding>
+			<code value="MSH-10"/>
+			</coding>
+			</type> 
 			<valueBase64Binary value="MS4yLjg0MC4xMTQzNTAuMS4xMy4wLjEuNy4xLjE="/>
 		</detail>
 	</entity>

--- a/source/auditevent/audit-event-example-search.xml
+++ b/source/auditevent/audit-event-example-search.xml
@@ -2,14 +2,18 @@
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-search"/>
 	<type>
+		<coding>
 		<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
 		<code value="rest"/>
 		<display value="Restful Operation"/>
+		</coding>
 	</type>
 	<subtype>
+		<coding>
 		<system value="http://hl7.org/fhir/restful-interaction"/>
 		<code value="search"/>
 		<display value="search"/>
+		</coding>
 	</subtype>
 	<action value="E"/>
 	<recorded value="2015-08-22T23:42:24Z"/>
@@ -21,6 +25,7 @@
 		</coding>
 	</outcome> 
 	<agent>
+
 		<type>
 			<coding>
 				<system value="http://terminology.hl7.org/CodeSystem/extra-security-role-type"/>
@@ -33,13 +38,20 @@
 			<identifier>
 				<value value="95"/>
 			</identifier>
+		<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<agent>
 		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+			  <type>
+				<text value="process ID"/>
+			  </type>
+			  <value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
@@ -53,7 +65,6 @@
 				<value value="2.16.840.1.113883.4.2"/> 
 			</identifier>
 		</who>
-		<altId value="6580"/> 
 		<requestor value="false"/> 
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
@@ -61,29 +72,28 @@
 		</network> 
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
 			<display value="hl7connect.healthintersections.com.au"/>
 		</observer>
 		<type>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="3"/>
 			<display value="Web Server"/>
+			</coding>
 		</type>
 	</source>
 	<entity>
 		<!-- HTTP GET encoded in base64Binary -->
 		<!-- orignal example encoded here is -->
 		<!-- "http://fhir-dev.healthintersections.com.au/open/Encounter?participant=13" -->
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
+
 		<role>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="24"/>
 			<display value="Query"/>
+			</coding>
 		</role>
 		<query value="aHR0cDovL2ZoaXItZGV2LmhlYWx0aGludGVyc2VjdGlvbnMuY29tLmF1L29wZW4vRW5jb3VudGVyP3BhcnRpY2lwYW50PTEz"/>
 	</entity>

--- a/source/auditevent/audit-event-example-vread.xml
+++ b/source/auditevent/audit-event-example-vread.xml
@@ -2,14 +2,18 @@
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
 	<id value="example-rest"/>
 	<type>
-		<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
-		<code value="rest"/>
-		<display value="Restful Operation"/>
+		<coding>
+			<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
+			<code value="rest"/>
+			<display value="Restful Operation"/>
+		</coding>
 	</type>
 	<subtype>
-		<system value="http://hl7.org/fhir/restful-interaction"/>
-		<code value="vread"/>
-		<display value="vread"/>
+		<coding>
+			<system value="http://hl7.org/fhir/restful-interaction"/>
+			<code value="vread"/>
+			<display value="vread"/>
+		</coding>
 	</subtype>
 	<action value="R"/>
 	<recorded value="2013-06-20T23:42:24Z"/>
@@ -19,8 +23,7 @@
 			<code value="0"/>
 			<display value="Success"/>
 		</coding>
-	</outcome> 
-
+	</outcome>
 	<agent>
 		<type>
 			<coding>
@@ -28,70 +31,68 @@
 				<code value="humanuser"/>
 				<display value="human user"/>
 			</coding>
-		</type> 
-
+		</type>
 		<who>
 			<identifier>
 				<value value="95"/>
 			</identifier>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<agent>
-		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<!-- Source active participant, the software making the . AlternativeUserId - Process ID -->
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+				<type>
+					<text value="process ID"/>
+				</type>
+				<value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 				<code value="110153"/>
 				<display value="Source Role ID"/>
 			</coding>
-		</type> 
+		</type>
 		<who>
 			<identifier>
-				<system value="urn:oid:2.16.840.1.113883.4.2"/> 
-				<value value="2.16.840.1.113883.4.2"/> 
+				<system value="urn:oid:2.16.840.1.113883.4.2"/>
+				<value value="2.16.840.1.113883.4.2"/>
 			</identifier>
 		</who>
-		<altId value="6580"/> 
-		<requestor value="false"/> 
+		<requestor value="false"/>
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
 			<type value="1"/>
-		</network> 
+		</network>
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
-		<identifier>
-			<value value="hl7connect.healthintersections.com.au"/>
+			<identifier>
+				<value value="hl7connect.healthintersections.com.au"/>
 			</identifier>
 		</observer>
 		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
-			<code value="3"/>
-			<display value="Web Server"/>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
+				<code value="3"/>
+				<display value="Web Server"/>
+			</coding>
 		</type>
 	</source>
 	<entity>
 		<what>
 			<reference value="Patient/example/_history/1"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
+
 		<role>
-			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
-			<code value="1"/>
-			<display value="Patient"/>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+				<code value="1"/>
+				<display value="Patient"/>
+			</coding>
 		</role>
-		<lifecycle>
-			<system value="http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle"/>
-			<code value="6"/>
-			<display value="Access / Use"/>
-		</lifecycle>
 	</entity>
 </AuditEvent>

--- a/source/auditevent/auditevent-example-breakglass-start.xml
+++ b/source/auditevent/auditevent-example-breakglass-start.xml
@@ -5,14 +5,18 @@
 		<div xmlns="http://www.w3.org/1999/xhtml">Authorized Break-Glass period has been declared to enable immediate emergent treatment condition. This AuditEvent indicates the start of the Break-Glass event. Another would indicate the stop of that Break-Glass period, providd there is a session or state that can detect the end of the break-glass event.</div>
 	</text>
 	<type>
+	   <coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110113"/>
 		<display value="Security Alert"/>
+	   </coding>
 	</type>
 	<subtype>
+	   <coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110127"/>
 		<display value="Emergency Override Started"/>
+	   </coding>
 	</subtype>
 	<action value="E"/>
 	<!-- when was the break-glass started -->
@@ -25,14 +29,14 @@
 		</coding>
 		<text value="Successful  Start of Break-Glass"/>
 	</outcome> 
-	<purposeOfEvent>
+	<authorization>
 		<!-- why was the break-glass declared -->
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-ActReason"/>
 			<code value="ETREAT"/>
 			<display value="Emergency Treatment"/>
 		</coding>
-	</purposeOfEvent>
+	</authorization>
 	<agent>
 		<!-- who declared the break-glass -->
 		<who>
@@ -50,14 +54,15 @@
 	</agent>
 	<source>
 		<!-- what system detected this break-glass -->
-		<site value="Watcher"/>
 		<observer>
 			<display value="Watchers Accounting of Disclosures Application"/>
 		</observer>
 		<type>
+	   <coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="4"/>
 			<display value="Application Server"/>
+	   </coding>
 		</type>
 	</source>
 	<entity>
@@ -65,15 +70,13 @@
 		<what>
 			<reference value="Patient/example"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
+
 		<role>
+	   <coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="1"/>
 			<display value="Patient"/>
+	   </coding>
 		</role>
 	</entity>
 </AuditEvent>

--- a/source/auditevent/auditevent-example-disclosure.xml
+++ b/source/auditevent/auditevent-example-disclosure.xml
@@ -33,13 +33,17 @@
 		</div>
 	</text>
 	<type>
+	   <coding>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110106"/>
 		<display value="Export"/>
+	   </coding>
 	</type>
 	<subtype>
+	   <coding>
 		<code value="Disclosure"/>
 		<display value="HIPAA disclosure"/>
+	   </coding>
 	</subtype>
 	<action value="R"/>
 	<severity value="notice"/>
@@ -53,13 +57,13 @@
 		<text value="Successful Disclosure"/>
 	</outcome> 
 
-	<purposeOfEvent>
+	<authorization>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-ActReason"/>
 			<code value="HMARKT"/>
 			<display value="healthcare marketing"/>
 		</coding>
-	</purposeOfEvent>
+	</authorization>
 	<agent>
 		<!-- who disclosed the data -->
 		<type>
@@ -73,9 +77,8 @@
 			<identifier>
 				<value value="SomeIdiot@nowhere"/>
 			</identifier>
+		<display value="That guy everyone wishes would be caught"/>
 		</who>
-		<altId value="notMe"/>
-		<name value="That guy everyone wishes would be caught"/>
 		<requestor value="true"/>
 		<location>
 			<reference value="Location/1"/>
@@ -104,24 +107,26 @@
 			<address value="marketing.land"/>
 			<type value="1"/>
 		</network>
-		<purposeOfUse>
+		<authorization>
 			<coding>
 				<system value="http://terminology.hl7.org/CodeSystem/v3-ActReason"/>
 				<code value="HMARKT"/>
 				<display value="healthcare marketing"/>
 			</coding>
-		</purposeOfUse>
+		</authorization>
 	</agent>
 	<source>
 		<!-- what system detected this disclosure -->
-		<site value="Watcher"/>
+
 		<observer>
 			<display value="Watchers Accounting of Disclosures Application"/>
 		</observer>
 		<type>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
 			<code value="4"/>
 			<display value="Application Server"/>
+			</coding>
 		</type>
 	</source>
 	<entity>
@@ -129,15 +134,13 @@
 		<what>
 			<reference value="Patient/example"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="1"/>
-			<display value="Person"/>
-		</type>
+
 		<role>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="1"/>
 			<display value="Patient"/>
+			</coding>
 		</role>
 	</entity>
 	<entity>
@@ -147,37 +150,36 @@
 			<identifier>
 				<value value="What.id"/>
 			</identifier>
+		<display value="data about Everthing important"/>
 		</what>
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
+
 		<role>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
 			<code value="4"/>
 			<display value="Domain Resource"/>
+			</coding>
 		</role>
-		<lifecycle>
-			<system value="http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle"/>
-			<code value="11"/>
-			<display value="Disclosure"/>
-		</lifecycle>
 		<securityLabel>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-Confidentiality"/>
 			<code value="V"/>
 			<display value="very restricted"/>
+			</coding>
 		</securityLabel>
 		<securityLabel>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-ActCode"/>
 			<code value="STD"/>
 			<display value="sexually transmitted disease information sensitivity"/>
+			</coding>
 		</securityLabel>
 		<securityLabel>
+			<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-ActCode"/>
 			<code value="DELAU"/>
 			<display value="delete after use"/>
+			</coding>
 		</securityLabel>
-		<name value="data about Everthing important"/>
 	</entity>
 </AuditEvent>

--- a/source/auditevent/auditevent-example-error.xml
+++ b/source/auditevent/auditevent-example-error.xml
@@ -4,12 +4,11 @@
 	<text>
 		<status value="generated"/>
 		<div xmlns="http://www.w3.org/1999/xhtml">Recording that an error has happened due to a client requesting that an Observation resource be Created on the Patient endpoint. Note that the OperationOutcome from failed transaction is recorded as an AuditEvent.entity.</div>
-	</text>  
+	</text>
 	<contained>
 		<!-- contained OperationOutcome from failed transaction -->
 		<OperationOutcome xmlns="http://hl7.org/fhir">
 			<id value="o1"/>
-
 			<issue>
 				<severity value="error"/>
 				<code value="invalid"/>
@@ -20,14 +19,18 @@
 		</OperationOutcome>
 	</contained>
 	<type>
-		<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
-		<code value="rest"/>
-		<display value="Restful Operation"/>
+		<coding>
+			<system value="http://terminology.hl7.org/CodeSystem/audit-event-type"/>
+			<code value="rest"/>
+			<display value="Restful Operation"/>
+		</coding>
 	</type>
 	<subtype>
-		<system value="http://hl7.org/fhir/restful-interaction"/>
-		<code value="create"/>
-		<display value="create"/>
+		<coding>
+			<system value="http://hl7.org/fhir/restful-interaction"/>
+			<code value="create"/>
+			<display value="create"/>
+		</coding>
 	</subtype>
 	<action value="C"/>
 	<recorded value="2017-09-07T23:42:24Z"/>
@@ -38,8 +41,7 @@
 			<display value="Serious Failure"/>
 		</coding>
 		<text value="Invalid request to create an Operation resource on the Patient endpoint."/>
-	</outcome> 
-
+	</outcome>
 	<agent>
 		<type>
 			<coding>
@@ -47,75 +49,66 @@
 				<code value="humanuser"/>
 				<display value="human user"/>
 			</coding>
-		</type> 
-
+		</type>
 		<who>
 			<identifier>
 				<value value="95"/>
 			</identifier>
+			<display value="Grahame Grieve"/>
 		</who>
-		<altId value="601847123"/>
-		<name value="Grahame Grieve"/>
 		<requestor value="true"/>
 	</agent>
 	<agent>
-		<!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
+		<!-- Source active participant, the software making the . AlternativeUserId - Process ID -->
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+				<type>
+					<text value="process ID"/>
+				</type>
+				<value value="6580"/>
+			</valueIdentifier>
+		</extension>
 		<type>
 			<coding>
 				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 				<code value="110153"/>
 				<display value="Source Role ID"/>
 			</coding>
-		</type> 
+		</type>
 		<who>
-	<identifier>
-		<system value="urn:oid:2.16.840.1.113883.4.2"/> 
-		<value value="2.16.840.1.113883.4.2"/> 
-	</identifier>
-</who>
-		<altId value="6580"/> 
-		<requestor value="false"/> 
+			<identifier>
+				<system value="urn:oid:2.16.840.1.113883.4.2"/>
+				<value value="2.16.840.1.113883.4.2"/>
+			</identifier>
+		</who>
+		<requestor value="false"/>
 		<network>
 			<address value="Workstation1.ehr.familyclinic.com"/>
 			<type value="1"/>
-		</network> 
+		</network>
 	</agent>
 	<source>
-		<site value="Cloud"/>
 		<observer>
 			<identifier>
 				<value value="hl7connect.healthintersections.com.au"/>
 			</identifier>
+			<display value="Cloud"/>
 		</observer>
 		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
-			<code value="3"/>
-			<display value="Web Server"/>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
+				<code value="3"/>
+				<display value="Web Server"/>
+			</coding>
 		</type>
 	</source>
-	<entity>
-		<!-- record the original transaction parameters -->
-		<type>
-			<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-			<code value="2"/>
-			<display value="System Object"/>
-		</type>
-		<detail>
-			<type value="requested transaction"/>
-			<valueString value="http POST ..... "/>
-			<!-- or better to have a pointer to the propritary log files from the API gateway or web server -->
-		</detail>
-	</entity>
+
 	<entity>
 		<!-- record the OperationOutcome returned to the client -->
 		<what>
 			<reference value="#o1"/>
+			<display value="transaction failed"/>
 		</what>
-		<type>
-			<system value="http://hl7.org/fhir/resource-types"/>
-			<code value="OperationOutcome"/>
-			<display value="OperationOutcome"/>
-		</type>
-		<name value="transaction failed"/>
+
 	</entity>
 </AuditEvent>

--- a/source/auditevent/auditevent-example.xml
+++ b/source/auditevent/auditevent-example.xml
@@ -1,98 +1,102 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <AuditEvent xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/auditevent.xsd">
- <id value="example"/>
-  <text>
-    <status value="generated"/>
-    <div xmlns="http://www.w3.org/1999/xhtml">Application Start for under service login "Grahame" (id: Grahame's Test HL7Connect)</div>
-  </text>
-
-    <type>
-        <system value="http://dicom.nema.org/resources/ontology/DCM"/>
-        <code value="110100"/>
-        <display value="Application Activity"/>
-    </type>
-    <subtype>
-        <system value="http://dicom.nema.org/resources/ontology/DCM"/>
-        <code value="110120"/>
-        <display value="Application Start"/>
-    </subtype>
-    <action value="E"/>
-    <recorded value="2012-10-25T22:04:27+11:00"/>
+	<id value="example"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">Application Start for under service login "Grahame" (id: Grahame's Test HL7Connect)</div>
+	</text>
+	<type>
+		<coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="110100"/>
+			<display value="Application Activity"/>
+		</coding>
+	</type>
+	<subtype>
+		<coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="110120"/>
+			<display value="Application Start"/>
+		</coding>
+	</subtype>
+	<action value="E"/>
+	<recorded value="2012-10-25T22:04:27+11:00"/>
 	<outcome>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/audit-event-outcome"/>
 			<code value="0"/>
 			<display value="Success"/>
 		</coding>
-	</outcome> 
-  <agent>
-      <type> <coding> <system value="http://terminology.hl7.org/CodeSystem/extra-security-role-type"/> <code value="humanuser"/> <display value="human user"/> </coding> </type> 
-
-    <role>
-      <text value="Service User (Logon)"/>
-    </role>
-			<who>
-			<identifier>
-		<value value="Grahame"/>
-			</identifier>
-		</who>
-
-    <requestor value="false"/>
-    <network>
-      <address value="127.0.0.1"/>
-      <type value="2"/>
-    </network>
-  </agent>
-  <agent> <!-- Source active participant, the software making the . AlternativeUserId - Process ID --> 
-    <type> <coding> <system value="http://dicom.nema.org/resources/ontology/DCM"/> <code value="110153"/> <display value="Source Role ID"/> </coding> </type> 
+	</outcome>
+	<agent>
+		<role>
+			<text value="Service User (Logon)"/>
+		</role>
 		<who>
 			<identifier>
-				<system value="urn:oid:2.16.840.1.113883.4.2"/> 
-				<value value="2.16.840.1.113883.4.2"/> 
+				<value value="Grahame"/>
 			</identifier>
 		</who>
-    <altId value="6580"/> 
-    <requestor value="false"/> 
-    <network> <address value="Workstation1.ehr.familyclinic.com"/> <type value="1"/> </network> 
-  </agent>
-  <source>
-    <site value="Development"/>
-	<observer>
-		<display value="Grahame's Laptop"/>
-	</observer>
-    <type>
-      <system value="http://dicom.nema.org/resources/ontology/DCM"/>
-      <code value="110122"/>
-      <display value="Login"/>
-    </type>
-  </source>
-  <entity>
-    <what><identifier>
-      <type>
-        <coding>
-          <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-          <code value="SNO"/>
-        </coding>
-        <text value="Dell Serial Number"/>
-      </type>
-      <value value="ABCDEF"/>
-    </identifier>
-	</what>
-	<type>
-		<system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-		<code value="4"/>
-		<display value="Other"/>
-	</type>
-	<role>
-		<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
-		<code value="4"/>
-		<display value="Domain Resource"/>
-	</role>
-    <lifecycle>
-		<system value="http://terminology.hl7.org/CodeSystem/dicom-audit-lifecycle"/>
-		<code value="6"/>
-		<display value="Access / Use"/>
-	</lifecycle>
-    <name value="Grahame's Laptop"/>
-  </entity>
+		<requestor value="false"/>
+		<network>
+			<address value="127.0.0.1"/>
+			<type value="2"/>
+		</network>
+	</agent>
+	<agent>
+		<!-- Source active participant, the software making the . AlternativeUserId - Process ID -->
+		<extension url="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID">
+			<valueIdentifier>
+				<type>
+					<text value="process ID"/>
+				</type>
+				<value value="6580"/>
+			</valueIdentifier>
+		</extension>
+		<who>
+			<identifier>
+				<system value="urn:oid:2.16.840.1.113883.4.2"/>
+				<value value="2.16.840.1.113883.4.2"/>
+			</identifier>
+		</who>
+		<requestor value="false"/>
+		<network>
+			<address value="Workstation1.ehr.familyclinic.com"/>
+			<type value="1"/>
+		</network>
+	</agent>
+	<source>
+		<observer>
+			<display value="Grahame's Laptop"/>
+		</observer>
+		<type>
+			<coding>
+				<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+				<code value="110122"/>
+				<display value="Login"/>
+			</coding>
+		</type>
+	</source>
+	<entity>
+		<what>
+			<identifier>
+				<type>
+					<coding>
+						<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
+						<code value="SNO"/>
+					</coding>
+					<text value="Dell Serial Number"/>
+				</type>
+				<value value="ABCDEF"/>
+			</identifier>
+		</what>
+
+		<role>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+				<code value="4"/>
+				<display value="Domain Resource"/>
+			</coding>
+		</role>
+	</entity>
 </AuditEvent>

--- a/source/auditevent/auditevent-notes.xml
+++ b/source/auditevent/auditevent-notes.xml
@@ -122,7 +122,19 @@ Audit Event Actions for RESTful operations:
 			<td>E</td>
 		</tr>
 	</table>
-
+	<a name="recordingsearch"/>
+	<h4>Recording Search Events</h4>
+	<p>
+A search event is recorded as an Execute action as the server must execute the search parameters to get the results. The type is a <code>rest</code> operation. The subtype should be <code>search</code>. The Server is identified in an <code>.agent</code> as the role <code>Destination Role ID</code>, and the client is identified in an <code>.agent</code> as the role <code>Source Role ID</code>. Additional <code>.agent</code> elements may be used to identify user, application, organization, etc.
+</p><p>
+A Search Event records one <code>.entity</code> element that holds the search request, and should not record the contents of the search response so as to limit duplication of sensitive health information that is already present in the system, and discoverable by replaying the search request.
+</p><p>
+The <code>AuditEvent.entity.query</code> shall hold the whole WHOLE http header and body encoded as base64binary. This should preserve as much of the raw http header and body as possible to best capture any attempts by clients or intermediaries to misbehave. There should be no sanitization or normalization of this value. 
+</p><p>
+The FHIR specification defines a harmonized search parameter string, which is returned in the searchset bundle as the <code>.link.url</code> on the <code>.link</code> for self. This string could be recorded in the <code>AuditEvent.entry.description</code> as it is well behaved and represents what was actually processed as search parameters. See: <a href="http://hl7.org/fhir/search.html#conformance">conformance</a>
+</p><p>
+Where there are identifiable Patient subject(s) associated with the returned Resource(s), the <a href="auditevent.html#patient">Patient as subject reference in AuditEvent.entity</a> below should be also used to record the Patient as the subject. When multiple patient results are returned one AuditEvent is created for every Patient identified in the resulting search set. Note this is true when the search set bundle includes any number of resources that collectively reference multiple Patients. This includes one Resource with multiple subject values, or many Resources with single subject values that are different.
+</p>
 	<a name="operationoutcome"/>
 	<h3>Encoding a FHIR operation outcome</h3>
 	<p>FHIR interactions can result in a rich description of the outcome using 

--- a/source/auditevent/bundle-AuditEvent-search-params.xml
+++ b/source/auditevent/bundle-AuditEvent-search-params.xml
@@ -65,26 +65,6 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="AuditEvent-agent-name"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.agent.name"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-agent-name"/>
-        <description value="Human friendly name for the agent"/>
-        <code value="agent-name"/>
-        <type value="string"/>
-        <expression value="AuditEvent.agent.name"/>
-        <xpath value="f:AuditEvent/f:agent/f:name"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
         <id value="AuditEvent-agent-role"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>
@@ -98,26 +78,6 @@
         <type value="token"/>
         <expression value="AuditEvent.agent.role"/>
         <xpath value="f:AuditEvent/f:agent/f:role"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
-        <id value="AuditEvent-altid"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.agent.altId"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-altid"/>
-        <description value="Alternative User identity"/>
-        <code value="altid"/>
-        <type value="token"/>
-        <expression value="AuditEvent.agent.altId"/>
-        <xpath value="f:AuditEvent/f:agent/f:altId"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -205,26 +165,6 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="AuditEvent-entity-name"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.entity.name"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-entity-name"/>
-        <description value="Descriptor for entity"/>
-        <code value="entity-name"/>
-        <type value="string"/>
-        <expression value="AuditEvent.entity.name"/>
-        <xpath value="f:AuditEvent/f:entity/f:name"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
         <id value="AuditEvent-entity-role"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>
@@ -238,26 +178,6 @@
         <type value="token"/>
         <expression value="AuditEvent.entity.role"/>
         <xpath value="f:AuditEvent/f:entity/f:role"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
-        <id value="AuditEvent-entity-type"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="trial-use"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.entity.type"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-entity-type"/>
-        <description value="Type of entity involved"/>
-        <code value="entity-type"/>
-        <type value="token"/>
-        <expression value="AuditEvent.entity.type"/>
-        <xpath value="f:AuditEvent/f:entity/f:type"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -325,39 +245,19 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="AuditEvent-purpose"/>
+        <id value="AuditEvent-authorization"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.purposeOfEvent,AuditEvent.agent.purposeOfUse"/>
+          <valueString value="AuditEvent.authorization,AuditEvent.agent.authorization"/>
         </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-purpose"/>
-        <description value="The purposeOfUse of the event"/>
+        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-authorization"/>
+        <description value="The authorization (purposeOfUse) of the event"/>
         <code value="purpose"/>
         <type value="token"/>
-        <expression value="AuditEvent.purposeOfEvent | AuditEvent.agent.purposeOfUse"/>
-        <xpath value="f:AuditEvent/f:purposeOfEvent | f:AuditEvent/f:agent/f:purposeOfUse"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
-        <id value="AuditEvent-site"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="AuditEvent.source.site"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/AuditEvent-site"/>
-        <description value="Logical source location within the enterprise"/>
-        <code value="site"/>
-        <type value="token"/>
-        <expression value="AuditEvent.source.site"/>
-        <xpath value="f:AuditEvent/f:source/f:site"/>
+        <expression value="AuditEvent.authorization | AuditEvent.agent.authorization"/>
+        <xpath value="f:AuditEvent/f:authorization | f:AuditEvent/f:agent/f:authorization"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/auditevent/codesystem-sample-entity-detail-type.xml
+++ b/source/auditevent/codesystem-sample-entity-detail-type.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="sample-entity-detail-type"/>
+  <url value="http://hl7.org/fhir/sample-entity-detail-type"/>
+  <name value="SampleEntityDetailType"/>
+  <title value="Sample Codes for AuditEvent.entity.detail.type"/>
+  <status value="draft"/>
+  <experimental value="true"/>
+  <description value="This codeSystem contains examples of codes. These are not known to be used."/>
+  <copyright value="This is an example set."/>
+  <caseSensitive value="true"/>
+  <content value="complete"/>
+  <concept>
+    <code value="orientation"/>
+    <display value="Orientation"/>
+    <definition value="The orientation of the entity with respect to the event"/>
+  </concept>
+  <concept>
+	<code value="spin"/>
+	<display value="Spin"/>
+	<definition value="The spin of the entity with respect to the event"/>
+  </concept>
+
+</CodeSystem>

--- a/source/auditevent/implementationguide-AuditEvent-core.xml
+++ b/source/auditevent/implementationguide-AuditEvent-core.xml
@@ -55,5 +55,10 @@
         <reference value="StructureDefinition/auditevent-Lifecycle"/>
       </reference>
     </resource>
+    <resource>
+      <reference>
+        <reference value="StructureDefinition/auditevent-AlternativeUserID"/>
+      </reference>
+    </resource>
   </definition>
 </ImplementationGuide>

--- a/source/auditevent/implementationguide-AuditEvent-core.xml
+++ b/source/auditevent/implementationguide-AuditEvent-core.xml
@@ -50,5 +50,10 @@
         <reference value="StructureDefinition/auditevent-ParticipantObjectContainsStudy"/>
       </reference>
     </resource>
+    <resource>
+      <reference>
+        <reference value="StructureDefinition/auditevent-Lifecycle"/>
+      </reference>
+    </resource>
   </definition>
 </ImplementationGuide>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -937,7 +937,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Location"/>
       </type>
       <mapping>
         <identity value="w5"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -594,7 +594,7 @@
       <path value="AuditEvent.agent.who"/>
       <short value="Identifier of who"/>
       <definition value="Reference to who this agent is that was involved in the event."/>
-      <comment value="Where a User ID is available it will go into who.identifier."/>
+      <comment value="Where a User ID is available it will go into who.identifier. Where a name of the user (human readable) it will go into who.display."/>
       <requirements value="This field ties an audit event to a specific resource or identifier."/>
       <alias value="userId"/>
       <min value="0"/>
@@ -624,7 +624,7 @@
       </mapping>
       <mapping>
         <identity value="dicom"/>
-        <map value="UserId"/>
+        <map value="UserName and UserId"/>
       </mapping>
       <mapping>
         <identity value="w3c.prov"/>
@@ -656,33 +656,6 @@
       <mapping>
         <identity value="dicom"/>
         <map value="AlternativeUserId"/>
-      </mapping>
-      <mapping>
-        <identity value="w3c.prov"/>
-        <map value="Agent.Identity"/>
-      </mapping>
-    </element>
-    <element id="AuditEvent.agent.name">
-      <path value="AuditEvent.agent.name"/>
-      <short value="Human friendly name for the agent"/>
-      <definition value="Human-meaningful name for the agent."/>
-      <requirements value="The User ID and Authorization User ID may be internal or otherwise obscure values. This field assists the auditor in identifying the actual user."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.who"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".name"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="UserName"/>
       </mapping>
       <mapping>
         <identity value="w3c.prov"/>
@@ -1084,6 +1057,7 @@
       <path value="AuditEvent.entity.what"/>
       <short value="Specific instance of resource"/>
       <definition value="Identifies a specific instance of the entity. The reference should be version specific."/>
+	  <comment value="Use .what.display when all you have is a string (e.g. ParticipantObjectName)."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -1101,7 +1075,7 @@
       </mapping>
       <mapping>
         <identity value="dicom"/>
-        <map value="ParticipantObjectID and ParticipantObjectIDTypeCode"/>
+        <map value="ParticipantObjectName, ParticipantObjectID and ParticipantObjectIDTypeCode"/>
       </mapping>
       <mapping>
         <identity value="fhirprovenance"/>
@@ -1271,35 +1245,6 @@
       <mapping>
         <identity value="dicom"/>
         <map value="ParticipantObjectSensitivity"/>
-      </mapping>
-    </element>
-    <element id="AuditEvent.entity.name">
-      <path value="AuditEvent.entity.name"/>
-      <short value="Descriptor for entity"/>
-      <definition value="A name of the entity in the audit event."/>
-      <comment value="This field may be used in a query/report to identify audit events for a specific person.  For example, where multiple synonymous entity identifiers (patient number, medical record number, encounter number, etc.) have been used."/>
-      <requirements value="Use only where entity can&#39;t be identified with an identifier."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.context"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".title"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="ParticipantObjectName"/>
-      </mapping>
-      <mapping>
-        <identity value="w3c.prov"/>
-        <map value="Entity.Label"/>
       </mapping>
     </element>
     <element id="AuditEvent.entity.query">

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -114,7 +114,7 @@
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
       <binding>
@@ -157,7 +157,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
       <binding>
@@ -754,7 +754,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -993,7 +993,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -1092,7 +1092,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -1134,7 +1134,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="Coding"/>
+        <code value="CodeableConcept"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1370,7 +1370,7 @@
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="CodeableConcept"/>
       </type>
       <mapping>
         <identity value="w5"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1059,14 +1059,6 @@
       <type>
         <code value="BackboneElement"/>
       </type>
-      <constraint>
-        <key value="sev-1"/>
-        <severity value="error"/>
-        <human value="Either a name or a query (NOT both)"/>
-        <expression value="name.empty() or query.empty()"/>
-        <xpath value="not(exists(f:name)) or not(exists(f:query))"/>
-        <source value="http://hl7.org/fhir/StructureDefinition/AuditEvent"/>
-      </constraint>
       <mapping>
         <identity value="w5"/>
         <map value="FiveWs.what[x]"/>
@@ -1292,7 +1284,6 @@
       <type>
         <code value="string"/>
       </type>
-      <condition value="sev-1"/>
       <isSummary value="true"/>
       <mapping>
         <identity value="w5"/>
@@ -1315,14 +1306,13 @@
       <path value="AuditEvent.entity.query"/>
       <short value="Query parameters"/>
       <definition value="The query parameters for a query-type entities."/>
-      <comment value="The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, AuditEvent.entity.type, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example, if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob."/>
+      <comment value="The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, AuditEvent.entity.type, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example, if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob.&#xA;&#xA;The DICOM AuditMessage schema does not support both .name and .query being populated."/>
       <requirements value="For query events, it may be necessary to capture the actual query input to the query process in order to identify the specific event. Because of differences among query implementations and data encoding for them, this is a base 64 encoded data blob. It may be subsequently decoded or interpreted by downstream audit analysis processing."/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="base64Binary"/>
       </type>
-      <condition value="sev-1"/>
       <isSummary value="true"/>
       <mapping>
         <identity value="w5"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -253,15 +253,18 @@
         <map value="PRI"/>
       </mapping>
     </element>
-    <element id="AuditEvent.period">
-      <path value="AuditEvent.period"/>
+    <element id="AuditEvent.occurred[x]">
+      <path value="AuditEvent.occurred[x]"/>
       <short value="When the activity occurred"/>
-      <definition value="The period during which the activity occurred."/>
-      <comment value="The period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time."/>
+      <definition value="The time or period during which the activity occurred."/>
+      <comment value="The time or period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time."/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Period"/>
+      </type>
+      <type>
+        <code value="dateTime"/>
       </type>
       <mapping>
         <identity value="workflow"/>
@@ -282,8 +285,7 @@
       <mapping>
         <identity value="fhirprovenance"/>
         <map value="Provenance.occurred[x]"/>
-      </mapping>
-    </element>
+      </mapping>    </element>
     <element id="AuditEvent.recorded">
       <path value="AuditEvent.recorded"/>
       <short value="Time when the event was recorded"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1075,57 +1075,11 @@
       </mapping>
       <mapping>
         <identity value="dicom"/>
-        <map value="ParticipantObjectName, ParticipantObjectID and ParticipantObjectIDTypeCode"/>
+        <map value="ParticipantObjectTypeCode, ParticipantObjectName, ParticipantObjectID and ParticipantObjectIDTypeCode"/>
       </mapping>
       <mapping>
         <identity value="fhirprovenance"/>
         <map value="Provenance.target, Provenance.entity.what"/>
-      </mapping>
-    </element>
-    <element id="AuditEvent.entity.type">
-      <path value="AuditEvent.entity.type"/>
-      <short value="Type of entity involved"/>
-      <definition value="The type of the object that was involved in this audit event."/>
-      <comment value="This value is distinct from the user&#39;s role or any user relationship to the entity."/>
-      <requirements value="To describe the object being acted upon. In addition to queries on the subject of the action in an auditable event, it is also important to be able to query on the object type for the action."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Coding"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="AuditEventEntityType"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
-          <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/definition">
-          <valueString value="Code for the entity type involved in the audit event."/>
-        </extension>
-        <strength value="extensible"/>
-        <description value="DICOM Audit Event Entity Type"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/audit-entity-type"/>
-      </binding>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.what[x]"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value="[self::Act].code or role.player.code"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="ParticipantObjectTypeCode"/>
-      </mapping>
-      <mapping>
-        <identity value="w3c.prov"/>
-        <map value="Entity.type"/>
-      </mapping>
-      <mapping>
-        <identity value="fhirprovenance"/>
-        <map value="Provenance.entity.type"/>
       </mapping>
     </element>
     <element id="AuditEvent.entity.role">

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1196,6 +1196,14 @@
       <type>
         <code value="CodeableConcept"/>
       </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="AuditEventDetailType"/>
+        </extension>
+        <strength value="example"/>
+        <description value="Additional detail about an entity used in an event."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
+      </binding>
       <mapping>
         <identity value="w5"/>
         <map value="FiveWs.context"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -635,33 +635,6 @@
         <map value="Provenance.agent.who"/>
       </mapping>
     </element>
-    <element id="AuditEvent.agent.altId">
-      <path value="AuditEvent.agent.altId"/>
-      <short value="Alternative User identity"/>
-      <definition value="Alternative agent Identifier. For a human, this should be a user identifier text string from authentication system. This identifier would be one known to a common authentication system (e.g. single sign-on), if available."/>
-      <requirements value="In some situations, a human user may authenticate with one identity but, to access a specific application system, may use a synonymous identify. For example, some &quot;single sign on&quot; implementations will do this. The alternative identifier would then be the original identify  used for authentication, and the User ID is the one known to and used by the application."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="string"/>
-      </type>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.who"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".id (distinguish id type by root)"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="AlternativeUserId"/>
-      </mapping>
-      <mapping>
-        <identity value="w3c.prov"/>
-        <map value="Agent.Identity"/>
-      </mapping>
-    </element>
     <element id="AuditEvent.agent.requestor">
       <path value="AuditEvent.agent.requestor"/>
       <short value="Whether user is initiator"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1169,49 +1169,6 @@
         <map value="Entity.role"/>
       </mapping>
     </element>
-    <element id="AuditEvent.entity.lifecycle">
-      <path value="AuditEvent.entity.lifecycle"/>
-      <short value="Life-cycle stage for the entity"/>
-      <definition value="Identifier for the data life-cycle stage for the entity."/>
-      <comment value="This can be used to provide an audit trail for data, over time, as it passes through the system."/>
-      <requirements value="Institutional policies for privacy and security may optionally fall under different accountability rules based on data life cycle. This provides a differentiating value for those cases."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Coding"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="AuditEventEntityLifecycle"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
-          <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
-        </extension>
-        <strength value="extensible"/>
-        <description value="Identifier for the data life-cycle stage for the entity."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/object-lifecycle-events"/>
-      </binding>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.context"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value="target of ObservationEvent[code=&quot;lifecycle&quot;].value"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="ParticipantObjectDataLifeCycle"/>
-      </mapping>
-      <mapping>
-        <identity value="w3c.prov"/>
-        <map value="Entity.role"/>
-      </mapping>
-      <mapping>
-        <identity value="fhirprovenance"/>
-        <map value="Provenance.entity.role"/>
-      </mapping>
-    </element>
     <element id="AuditEvent.entity.securityLabel">
       <path value="AuditEvent.entity.securityLabel"/>
       <short value="Security labels on the entity"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -908,8 +908,8 @@
       </extension>
       <path value="AuditEvent.source"/>
       <short value="Audit Event Reporter"/>
-      <definition value="The system that is reporting the event."/>
-      <comment value="Since multi-tier, distributed, or composite applications make source identification ambiguous, this collection of fields may repeat for each application or process actively involved in the event. For example, multiple value-sets can identify participating web servers, application processes, and database server threads in an n-tier distributed application. Passive event participants (e.g. low-level network transports) need not be identified."/>
+      <definition value="The actor that is reporting the event."/>
+      <comment value="Events are reported by the actor that detected them. This may be one of the participating actors, but may also be different. The actor may be a human such as a medical-records clerk disclosing data manually, that clerk would be the source for the record of disclosure."/>
       <requirements value="The event is reported by one source."/>
       <min value="1"/>
       <max value="1"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -358,11 +358,11 @@
         <map value="EventOutcomeIndicator EventOutcomeIndicator"/>
       </mapping>
     </element>
-    <element id="AuditEvent.authorizations">
-      <path value="AuditEvent.authorizations"/>
-      <short value="Authorizations related to the event"/>
-      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
-      <comment value="Use AuditEvent.agent.authorizations when you know that it is specific to the agent, otherwise use AuditEvent.authorizations. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
+    <element id="AuditEvent.authorization">
+      <path value="AuditEvent.authorization"/>
+      <short value="Authorization related to the event"/>
+      <definition value="The authorization (e.g., PurposeOfUse) that was used during the event being recorded."/>
+      <comment value="Use AuditEvent.agent.authorization when you know that it is specific to the agent, otherwise use AuditEvent.authorization. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
       <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
 	  <alias value="PurposeOfEvent"/>
       <min value="0"/>
@@ -401,7 +401,7 @@
       </mapping>
       <mapping>
         <identity value="fhirprovenance"/>
-        <map value="Provenance.reason, Provenance.activity"/>
+        <map value="Provenance.authorization"/>
       </mapping>
     </element>
     <element id="AuditEvent.basedOn">
@@ -845,11 +845,11 @@
         <map value="NetworkAccessPointTypeCode"/>
       </mapping>
     </element>
-    <element id="AuditEvent.agent.authorizations">
-      <path value="AuditEvent.agent.authorizations"/>
-      <short value="Allowable authorizations for this agent"/>
-      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
-      <comment value="Use AuditEvent.agent.authorizations when you know that is specific to the agent, otherwise use AuditEvent.authorizations. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
+    <element id="AuditEvent.agent.authorization">
+      <path value="AuditEvent.agent.authorization"/>
+      <short value="Allowable authorization for this agent"/>
+      <definition value="The authorization (e.g., PurposeOfUse) that was used during the event being recorded."/>
+      <comment value="Use AuditEvent.agent.authorization when you know that is specific to the agent, otherwise use AuditEvent.authorization. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
       <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
 	  <alias value="PurposeOfUse"/>
       <min value="0"/>
@@ -1140,7 +1140,7 @@
       <path value="AuditEvent.entity.query"/>
       <short value="Query parameters"/>
       <definition value="The query parameters for a query-type entities."/>
-      <comment value="The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, AuditEvent.entity.type, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example, if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob.&#xA;&#xA;The DICOM AuditMessage schema does not support both .name and .query being populated."/>
+      <comment value="The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example, if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob.&#xA;&#xA;The DICOM AuditMessage schema does not support both .name and .query being populated."/>
       <requirements value="For query events, it may be necessary to capture the actual query input to the query process in order to identify the specific event. Because of differences among query implementations and data encoding for them, this is a base 64 encoded data blob. It may be subsequently decoded or interpreted by downstream audit analysis processing."/>
       <min value="0"/>
       <max value="1"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -1001,8 +1001,8 @@
         <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
           <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
         </extension>
-        <strength value="extensible"/>
-        <description value="Code specifying the type of system that detected and recorded the event."/>
+        <strength value="preferred"/>
+        <description value="Code specifying the type of system that detected and recorded the event. Use of these codes is not required but is encouraged to maintain translation with DICOM AuditMessage schema."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/security-source-type"/>
       </binding>
       <mapping>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -963,11 +963,12 @@
       <max value="1"/>
       <type>
         <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
       </type>
       <isSummary value="true"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -356,12 +356,13 @@
         <map value="EventOutcomeIndicator EventOutcomeIndicator"/>
       </mapping>
     </element>
-    <element id="AuditEvent.purposeOfEvent">
-      <path value="AuditEvent.purposeOfEvent"/>
-      <short value="The purposeOfUse of the event"/>
-      <definition value="The purposeOfUse (reason) that was used during the event being recorded."/>
-      <comment value="Use AuditEvent.agent.purposeOfUse when you know that it is specific to the agent, otherwise use AuditEvent.purposeOfEvent. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
-      <requirements value="record of any relevant security context not restricted to purposeOfUse valueSet, may include security compartments or other security tags."/>
+    <element id="AuditEvent.authorizations">
+      <path value="AuditEvent.authorizations"/>
+      <short value="Authorizations related to the event"/>
+      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
+      <comment value="Use AuditEvent.agent.authorizations when you know that it is specific to the agent, otherwise use AuditEvent.authorizations. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
+      <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
+	  <alias value="PurposeOfEvent"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -372,8 +373,8 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="AuditPurposeOfUse"/>
         </extension>
-        <strength value="extensible"/>
-        <description value="The reason the activity took place."/>
+        <strength value="example"/>
+        <description value="The authorized purposeOfUse for the activity."/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"/>
       </binding>
       <mapping>
@@ -895,12 +896,13 @@
         <map value="NetworkAccessPointTypeCode"/>
       </mapping>
     </element>
-    <element id="AuditEvent.agent.purposeOfUse">
-      <path value="AuditEvent.agent.purposeOfUse"/>
-      <short value="Reason given for this user"/>
-      <definition value="The reason (purpose of use), specific to this agent, that was used during the event being recorded."/>
-      <comment value="Use AuditEvent.agent.purposeOfUse when you know that is specific to the agent, otherwise use AuditEvent.purposeOfEvent. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
-      <requirements value="record of any relevant security context not restricted to purposeOfUse valueSet, may include security compartments or other security tags."/>
+    <element id="AuditEvent.agent.authorizations">
+      <path value="AuditEvent.agent.authorizations"/>
+      <short value="Allowable authorizations for this agent"/>
+      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
+      <comment value="Use AuditEvent.agent.authorizations when you know that is specific to the agent, otherwise use AuditEvent.authorizations. For example, during a machine-to-machine transfer it might not be obvious to the audit system who caused the event, but it does know why."/>
+      <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
+	  <alias value="PurposeOfUse"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -910,7 +912,7 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="AuditPurposeOfUse"/>
         </extension>
-        <strength value="extensible"/>
+        <strength value="example"/>
         <description value="The reason the activity took place."/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"/>
       </binding>
@@ -1387,16 +1389,42 @@
       <path value="AuditEvent.entity.detail.value[x]"/>
       <short value="Property value"/>
       <definition value="The  value of the extra detail."/>
-      <comment value="The value can be string when known to be a string, else base64 encoding should be used to protect binary or undefined content.  The meaning and secondary-encoding of the content of base64 encoded blob is specific to the AuditEvent.type, AuditEvent.subtype, AuditEvent.entity.type, and AuditEvent.entity.role.  The base64 is a general-use and safe container for event specific data blobs regardless of the encoding used by the transaction being recorded.  An AuditEvent consuming application must understand the event it is consuming and the formats used by the event. For example if auditing an Oracle network database access, the Oracle formats must be understood as they will be simply encoded in the base64binary blob."/>
       <requirements value="Should not duplicate the entity value unless absolutely necessary."/>
       <min value="1"/>
       <max value="1"/>
       <type>
+        <code value="Quantity"/>
+      </type>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <type>
         <code value="string"/>
       </type>
       <type>
-        <code value="base64Binary"/>
+        <code value="boolean"/>
       </type>
+      <type>
+        <code value="integer"/>
+      </type>
+      <type>
+        <code value="Range"/>
+      </type>
+      <type>
+        <code value="Ratio"/>
+      </type>
+      <type>
+        <code value="time"/>
+      </type>
+      <type>
+        <code value="dateTime"/>
+      </type>
+      <type>
+        <code value="Period"/>
+      </type>
+      <type>
+        <code value="base64Binary"/>
+      </type>	  
       <mapping>
         <identity value="w5"/>
         <map value="FiveWs.context"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -597,7 +597,7 @@
       <comment value="Where a User ID is available it will go into who.identifier. Where a name of the user (human readable) it will go into who.display."/>
       <requirements value="This field ties an audit event to a specific resource or identifier."/>
       <alias value="userId"/>
-      <min value="0"/>
+      <min value="1"/>
       <max value="1"/>
       <type>
         <code value="Reference"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -810,7 +810,7 @@
       <definition value="An identifier for the network access point of the user device for the audit event."/>
       <comment value="This could be a device id, IP address or some other identifier associated with a device."/>
       <requirements value="This datum identifies the user&#39;s network access point, which may be distinct from the server that performed the action. It is an optional value that may be used to group events recorded on separate servers for analysis of a specific network access point&#39;s data access across all servers."/>
-      <min value="0"/>
+      <min value="1"/>
       <max value="1"/>
       <type>
         <code value="string"/>
@@ -837,7 +837,7 @@
       <short value="The type of network access point"/>
       <definition value="An identifier for the type of network access point that originated the audit event."/>
       <requirements value="This datum identifies the type of network access point identifier of the user device for the audit event. It is an optional value that may be used to group events recorded on separate servers for analysis of access according to a network access point&#39;s type."/>
-      <min value="0"/>
+      <min value="1"/>
       <max value="1"/>
       <type>
         <code value="code"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -641,11 +641,12 @@
       <definition value="Indicator that the user is or is not the requestor, or initiator, for the event being audited."/>
       <comment value="There can only be one initiator. If the initiator is not clear, then do not choose any one agent as the initiator."/>
       <requirements value="This value is used to distinguish between requestor-users and recipient-users. For example, one person may initiate a report-output to be sent to another user."/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="boolean"/>
       </type>
+	  <meaningWhenMissing value="false"/>
       <isSummary value="true"/>
       <mapping>
         <identity value="w5"/>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -167,7 +167,7 @@
         <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
           <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
         </extension>
-        <strength value="extensible"/>
+        <strength value="example"/>
         <description value="Sub-type of event."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-sub-type"/>
       </binding>

--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -124,7 +124,7 @@
         <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
           <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
         </extension>
-        <strength value="extensible"/>
+        <strength value="example"/>
         <description value="Type of event."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
       </binding>

--- a/source/auditevent/structuredefinition-extension-auditevent-AlternativeUserID.xml
+++ b/source/auditevent/structuredefinition-extension-auditevent-AlternativeUserID.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="auditevent-AlternativeUserID"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="sec"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID"/>
+  <version value="4.6.0"/>
+  <name value="AlternativeUserID"/>
+  <status value="draft"/>
+  <date value="2020-12-28T16:55:11+11:00"/>
+  <publisher value="Health Level Seven, Inc. - Security WG"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/security/index.cfm"/>
+    </telecom>
+  </contact>
+  <description value="An AlternativeUserID Number associated with this participant object."/>
+  <fhirVersion value="4.6.0"/>
+  <mapping>
+    <identity value="dicom"/>
+    <uri value="http://nema.org/dicom"/>
+    <name value="DICOM Tag Mapping"/>
+  </mapping>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="AuditEvent.agent"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="AlternativeUserID"/>
+      <definition value="An AlternativeUserID associated with this active participant object."/>
+      <min value="0"/>
+      <max value="*"/>
+      <mapping>
+        <identity value="dicom"/>
+        <map value="AlternativeUserID"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="Identifier"/>
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/source/auditevent/structuredefinition-extension-auditevent-Lifecycle.xml
+++ b/source/auditevent/structuredefinition-extension-auditevent-Lifecycle.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="auditevent-Lifecycle"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="sec"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/auditevent-Lifecycle"/>
+  <version value="4.6.0"/>
+  <name value="Lifecycle"/>
+  <status value="draft"/>
+  <date value="2021-10-02T16:55:11+11:00"/>
+  <publisher value="Health Level Seven, Inc. - Security WG"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/security/index.cfm"/>
+    </telecom>
+  </contact>
+  <description value="An Lifecycle event associated with this participant object."/>
+  <fhirVersion value="4.6.0"/>
+  <mapping>
+    <identity value="dicom"/>
+    <uri value="http://nema.org/dicom"/>
+    <name value="DICOM Tag Mapping"/>
+  </mapping>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="AuditEvent.entity"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Lifecycle"/>
+      <definition value="An Lifecycle event associated with this participant object."/>
+      <min value="0"/>
+      <max value="*"/>
+      <mapping>
+        <identity value="dicom"/>
+        <map value="ParticipantObjectDataLifeCycle"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url"/>
+      <fixedUri value="http://hl7.org/fhir/StructureDefinition/auditevent-Lifecycle"/>
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="AuditEventEntityLifecycle"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/copyright">
+          <valueString value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association."/>
+        </extension>
+        <strength value="preferred"/>
+        <description value="Identifier for the data life-cycle stage for the entity."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/object-lifecycle-events"/>
+      </binding>
+     </element>
+  </differential>
+</StructureDefinition>

--- a/source/auditevent/valueset-audit-event-sub-type.xml
+++ b/source/auditevent/valueset-audit-event-sub-type.xml
@@ -33,6 +33,7 @@
     <include>
       <system value="http://hl7.org/fhir/restful-interaction"/>
     </include>
+	<!-- JFM: want these here, but build does not like a system value like this
 	<include>
 		<system value="urn:ihe:event-type-code" />
 		<concept>
@@ -53,5 +54,6 @@
 		</concept>
 
 	</include>
+	-->
   </compose>
 </ValueSet>

--- a/source/auditevent/valueset-audit-event-sub-type.xml
+++ b/source/auditevent/valueset-audit-event-sub-type.xml
@@ -33,11 +33,25 @@
     <include>
       <system value="http://hl7.org/fhir/restful-interaction"/>
     </include>
-    <include>
-      <system value="http://hl7.org/fhir/bundle-type"/>
-    </include>
-    <include>
-      <system value="http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle"/>
-    </include>
+	<include>
+		<system value="urn:ihe:event-type-code" />
+		<concept>
+			<code value="ITI-65" />
+			<display value="Provide Document Bundle" />
+		</concept>
+		<concept>
+			<code value="ITI-66" />
+			<display value="Find Document Lists" />
+		</concept>
+		<concept>
+			<code value="ITI-67" />
+			<display value="Find Document References" />
+		</concept>
+		<concept>
+			<code value="ITI-68" />
+			<display value="Retrieve Document" />
+		</concept>
+
+	</include>
   </compose>
 </ValueSet>

--- a/source/auditevent/valueset-entity-detail-type.xml
+++ b/source/auditevent/valueset-entity-detail-type.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="entity-detail-type"/>
+  <meta>
+    <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <ul>
+        <li>Include all codes defined in 
+          <a href="codesystem-entity-detail-type.html">
+            <code>http://hl7.org/fhir/entity-detail-type</code>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="sec"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="3"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/network-type"/>
+  <version value="4.6.0"/>
+  <name value="AuditEventEntityDetailType"/>
+  <title value="AuditEventEntityDetailType"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2021-10-02T16:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Additional detail about an entity used in an event."/>
+  <immutable value="true"/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/sample-entity-detail-type"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/auditevent/valueset-security-source-type.xml
+++ b/source/auditevent/valueset-security-source-type.xml
@@ -24,6 +24,30 @@
   <compose>
     <include>
       <system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>
+	  <concept>
+	    <code value="1"/>
+	  </concept>
+	  <concept>
+	    <code value="2"/>
+	  </concept>
+	  <concept>
+	    <code value="3"/>
+	  </concept>
+	  <concept>
+	    <code value="4"/>
+	  </concept>
+	  <concept>
+	    <code value="5"/>
+	  </concept>
+	  <concept>
+	    <code value="6"/>
+	  </concept>
+	  <concept>
+	    <code value="7"/>
+	  </concept>
+	  <concept>
+	    <code value="8"/>
+	  </concept>
     </include>
   </compose>
 </ValueSet>

--- a/source/auditevent/valueset-security-source-type.xml
+++ b/source/auditevent/valueset-security-source-type.xml
@@ -19,7 +19,8 @@
   <status value="active"/>
   <date value="2010-08-26"/>
   <publisher value="HL7 (FHIR Project)"/>
-  <description value="The type of process where the audit event originated from."/>
+  <description value="The type of process where the audit event originated from. Use of these codes is not required but is encouraged to maintain translation with DICOM AuditMessage schema."/>
+  <copyright value="These codes are excerpted from Digital Imaging and Communications in Medicine (DICOM) Standard, Part 16: Content Mapping Resource, Copyright &#xA9; 2011 by the National Electrical Manufacturers Association. Additional codes added by HL7 FHIR use-case analysis"/>
   <compose>
     <include>
       <system value="http://terminology.hl7.org/CodeSystem/security-source-type"/>

--- a/source/provenance/provenance-consent-signature.xml
+++ b/source/provenance/provenance-consent-signature.xml
@@ -5,7 +5,7 @@
 <Provenance xmlns="http://hl7.org/fhir"> 
   <id value="consent-signature"/>
   <target>
-    <reference value="Consent/consent-example-signature"/>
+    <reference value="Consent/consent-example-basic"/>
   </target>
  
   <!-- the provenance is recorded at the same time as 

--- a/source/provenance/provenance-example-biocompute-object.xml
+++ b/source/provenance/provenance-example-biocompute-object.xml
@@ -61,9 +61,9 @@
 		<start value="2017-06-06"/>
 	</occurredPeriod>
 	<recorded value="2016-06-09T08:12:14+10:00"/>
-	<reason>
+	<activity>
 		<text value="antiviral resistance detection"/>
-	</reason>
+	</activity>
 
 	<agent>
 		<type>

--- a/source/provenance/provenance-example-cwl.xml
+++ b/source/provenance/provenance-example-cwl.xml
@@ -63,9 +63,9 @@
 	</occurredPeriod>
 	<recorded value="2016-12-01T08:12:14+10:00"/>
 
-	<reason>
+	<activity>
 		<text value="profiling Short Tandem Repeats (STRs) from high throughput sequencing data."/>
-	</reason>
+	</activity>
 	<agent> 
 		<type>
 			<coding>

--- a/source/provenance/provenance-example-sig.xml
+++ b/source/provenance/provenance-example-sig.xml
@@ -14,13 +14,13 @@
 		<reference value="DocumentReference/example"/>    
 	</target>
 	<recorded value="2015-08-27T08:39:24+10:00"/>
-	<reason>
+	<authorization>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-ActReason"/>
 			<code value="TREAT"/>
 			<display value="treatment"/>
 		</coding>
-	</reason>
+	</authorization>
 	<activity>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-DocumentCompletion"/>

--- a/source/provenance/provenance-example.xml
+++ b/source/provenance/provenance-example.xml
@@ -23,13 +23,13 @@
 	<location>
 		<reference value="Location/1"/>
 	</location>
-	<reason>
+	<activity>
 		<coding>
 			<system value="http://snomed.info/sct"/>
 			<code value="3457005"/>
 			<display value="Referral"/>
 		</coding>
-	</reason>
+	</activity>
 
 	<!-- author = Harold Hippocrates -->
 	<agent>

--- a/source/provenance/provenance-example.xml
+++ b/source/provenance/provenance-example.xml
@@ -55,7 +55,7 @@
 			</coding>
 		</type>
 		<who>
-			<reference value="Device/software"/>
+			<display  value="Device/software"/>
 		</who>
 	</agent>
 	<!-- information extract from a CCDA referral document -->

--- a/source/provenance/structuredefinition-Provenance.xml
+++ b/source/provenance/structuredefinition-Provenance.xml
@@ -244,10 +244,12 @@
         <map value="Activity.location"/>
       </mapping>
     </element>
-    <element id="Provenance.reason">
-      <path value="Provenance.reason"/>
-      <short value="Reason the activity is occurring"/>
-      <definition value="The reason that the activity was taking place."/>
+    <element id="Provenance.authorizations">
+      <path value="Provenance.authorizations"/>
+      <short value="Authorizations (purposeOfUse) related to the event"/>
+      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
+      <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
+	  <alias value="PurposeOfEvent"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -257,8 +259,8 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="ProvenanceReason"/>
         </extension>
-        <strength value="extensible"/>
-        <description value="The reason the activity took place."/>
+        <strength value="example"/>
+        <description value="The authorized purposeOfUse for the activity."/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"/>
       </binding>
       <mapping>

--- a/source/provenance/structuredefinition-Provenance.xml
+++ b/source/provenance/structuredefinition-Provenance.xml
@@ -244,10 +244,10 @@
         <map value="Activity.location"/>
       </mapping>
     </element>
-    <element id="Provenance.authorizations">
-      <path value="Provenance.authorizations"/>
-      <short value="Authorizations (purposeOfUse) related to the event"/>
-      <definition value="The authorizations (e.g., PurposeOfUse) that was used during the event being recorded."/>
+    <element id="Provenance.authorization">
+      <path value="Provenance.authorization"/>
+      <short value="Authorization (purposeOfUse) related to the event"/>
+      <definition value="The authorization (e.g., PurposeOfUse) that was used during the event being recorded."/>
       <requirements value="Record of any relevant security context, not restricted to purposeOfUse valueSet. May include security compartments, refrain, obligation, or other security tags."/>
 	  <alias value="PurposeOfEvent"/>
       <min value="0"/>
@@ -589,7 +589,7 @@
       </mapping>
       <mapping>
         <identity value="fhirauditevent"/>
-        <map value="AuditEvent.entity.lifecycle"/>
+        <map value="AuditEvent.entity.role"/>
       </mapping>
       <mapping>
         <identity value="w3c.prov"/>

--- a/source/provenance/structuredefinition-profile-provenance-relevant-history.xml
+++ b/source/provenance/structuredefinition-profile-provenance-relevant-history.xml
@@ -84,9 +84,9 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="Provenance.reason">
-      <path value="Provenance.reason"/>
-      <comment value="Plain text reasons can be sent in the &quot;text&quot; component with no codings.  Domains may wish to define a constrained terminology.  The reason for the resource&#39;s existence of the resource itself will be maintained on the resource, not here."/>
+    <element id="Provenance.authorization">
+      <path value="Provenance.authorization"/>
+      <comment value="Plain text reasons can be sent in the &quot;text&quot; component with no codings.  Domains may wish to define a constrained terminology.  The authorization for the resource&#39;s existence of the resource itself will be maintained on the resource, not here."/>
       <mustSupport value="true"/>
     </element>
     <element id="Provenance.activity">

--- a/source/spelling/add.txt
+++ b/source/spelling/add.txt
@@ -1,13 +1,10 @@
-﻿_query
-_security
-recruitment_actual
-_lastupdated
-_list
-subject_state
+﻿_list
+_query
 _profile
 _tag
+_security
 _source
 _id
 _content
 _text
-recruitment_target
+_lastupdated

--- a/suppressed-messages.txt
+++ b/suppressed-messages.txt
@@ -7,7 +7,7 @@ INFORMATION: ImmunizationRecommendation.recommendation: Name of child (recommend
 INFORMATION: Reference.reference: Name of child (reference) overlaps with name of parent (Reference)
 INFORMATION: SampledData.data: Name of child (data) overlaps with name of parent (SampledData)
 WARNING: Attachment.contentType: Unable to resolve value set on 'code' Binding
-WARNING: AuditEvent: Resource elements are out of order. The correct order is '[type(=what), subtype(=what), action(=what), outcome(=what), entity(=what), period(=when.done), recorded(=when.recorded), source(=who.witness), agent(=who), purposeOfEvent(=why), basedOn(=why), encounter(=why)]' but the actual order is '[type(=what), subtype(=what), action(=what), period(=when.done), recorded(=when.recorded), outcome(=what), purposeOfEvent(=why), basedOn(=why), encounter(=why), agent(=who), source(=who.witness), entity(=what)]'
+WARNING: AuditEvent: Resource elements are out of order. The correct order is '[type(=what), subtype(=what), action(=what), outcome(=what), entity(=what), occurred[x](=when.done), recorded(=when.recorded), source(=who.witness), agent(=who), authorization(=why), basedOn(=why), encounter(=why)]' but the actual order is '[type(=what), subtype(=what), action(=what), occurred[x](=when.done), recorded(=when.recorded), outcome(=what), authorization(=why), basedOn(=why), encounter(=why), agent(=who), source(=who.witness), entity(=what)]'
 WARNING: CapabilityStatement.format: Unable to resolve value set on 'code' Binding
 WARNING: CapabilityStatement.patchFormat: Unable to resolve value set on 'code' Binding
 WARNING: CapabilityStatement.rest.security.certificate.type: Unable to resolve value set on 'code' Binding
@@ -31,7 +31,7 @@ WARNING: Observation.comment: MnM must have confirmed this should not be an Anno
 WARNING: OperationDefinition.comment: MnM must have confirmed this should not be an Annotation
 WARNING: OperationDefinition.overload.comment: MnM must have confirmed this should not be an Annotation
 WARNING: Parameters: All resources should have an identifier
-WARNING: Provenance: Resource elements are out of order. The correct order is '[target(=what), occurred[x](=when.done), recorded(=when.recorded), agent(=who), location(=where), reason(=why), activity(=why), basedOn(=why), encounter(=why)]' but the actual order is '[target(=what), occurred[x](=when.done), recorded(=when.recorded), location(=where), reason(=why), activity(=why), basedOn(=why), encounter(=why), agent(=who)]'
+WARNING: Provenance: Resource elements are out of order. The correct order is '[target(=what), occurred[x](=when.done), recorded(=when.recorded), agent(=who), location(=where), authorization(=why), activity(=why), basedOn(=why), encounter(=why)]' but the actual order is '[target(=what), occurred[x](=when.done), recorded(=when.recorded), location(=where), authorization(=why), activity(=why), basedOn(=why), encounter(=why), agent(=who)]'
 WARNING: Signature.contentType: Unable to resolve value set on 'code' Binding
 WARNING: StructureDefinition.mapping.comment: MnM must have confirmed this should not be an Annotation
 WARNING: pa:ValueSetComparison: Duplicate Valueset Names: v2/0002/index.html (v2 Marital Status) & valueset-marital-status.html (Marital Status Codes) (name: [statuses, maritals] / [statuses, maritals]))

--- a/vscache/all-systems.cache
+++ b/vscache/all-systems.cache
@@ -3936,7 +3936,7 @@ e: {
   "status" : "draft",
   "experimental" : false,
   "date" : "2021-04-13T05:44:31+10:00",
-  "description" : "Value Set Contents (Expansion) for DataElement SDC Object Class at Tue, Apr 13, 2021 07:21+1000",
+  "description" : "Value Set Contents (Expansion) for DataElement SDC Object Class at Sat, Oct 2, 2021 12:57-0500",
   "expansion" : {
     "extension" : [{
       "url" : "http://hl7.org/fhir/StructureDefinition/valueset-toocostly",
@@ -3995,7 +3995,7 @@ e: {
   "title" : "Audit Event ID",
   "status" : "active",
   "date" : "2020-08-04",
-  "description" : "Value Set Contents (Expansion) for Audit Event ID at Tue, Apr 13, 2021 07:20+1000",
+  "description" : "Value Set Contents (Expansion) for Audit Event ID at Sat, Oct 2, 2021 12:57-0500",
   "expansion" : {
     "identifier" : "urn:uuid:4ac5d8b7-1869-45d6-8e41-5a0ac800be46",
     "timestamp" : "2021-04-12T20:28:44.773Z",
@@ -17567,6 +17567,269 @@ v: {
 v: {
   "display" : "Groups Only",
   "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : true, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_401.html"]
+    },
+    {
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_403.html"]
+    },
+    {
+      "system" : "http://hl7.org/fhir/restful-interaction"
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "id" : "audit-event-sub-type",
+  "meta" : {
+    "lastUpdated" : "2021-10-02T12:54:23.265-05:00",
+    "profile" : ["http://hl7.org/fhir/StructureDefinition/shareablevalueset"]
+  },
+  "language" : "en",
+  "url" : "http://hl7.org/fhir/ValueSet/audit-event-sub-type",
+  "identifier" : [{
+    "system" : "urn:ietf:rfc:3986",
+    "value" : "urn:oid:2.16.840.1.113883.4.642.3.464"
+  }],
+  "version" : "4.6.0",
+  "name" : "AuditEventSub-Type",
+  "title" : "Audit Event Sub-Type",
+  "status" : "active",
+  "date" : "2020-08-04",
+  "expansion" : {
+    "identifier" : "urn:uuid:8506b06b-9f28-404e-a609-6dd12ed66fe4",
+    "timestamp" : "2021-10-02T17:58:18.458Z",
+    "parameter" : [{
+      "name" : "expansion-source",
+      "valueString" : "ValueSet/audit-event-sub-type"
+    },
+    {
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "includeDesignations",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueString" : "http://hl7.org/fhir/restful-interaction|4.6.0"
+    }],
+    "contains" : [{
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Read the current state of the resource."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "read",
+      "display" : "read",
+      "designation" : [{
+        "value" : "read"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Read the state of a specific version of the resource."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "vread",
+      "display" : "vread",
+      "designation" : [{
+        "value" : "vread"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Update an existing resource by its id (or create it if it is new)."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "update",
+      "display" : "update",
+      "designation" : [{
+        "value" : "update"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Update an existing resource by posting a set of changes to it."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "patch",
+      "display" : "patch",
+      "designation" : [{
+        "value" : "patch"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Delete a resource."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "delete",
+      "display" : "delete",
+      "designation" : [{
+        "value" : "delete"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Retrieve the change history for a particular resource, type of resource, or the entire system."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "history",
+      "display" : "history",
+      "designation" : [{
+        "value" : "history"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Retrieve the change history for a particular resource."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "history-instance",
+      "display" : "history-instance",
+      "designation" : [{
+        "value" : "history-instance"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Retrieve the change history for all resources of a particular type."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "history-type",
+      "display" : "history-type",
+      "designation" : [{
+        "value" : "history-type"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Retrieve the change history for all resources on a system."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "history-system",
+      "display" : "history-system",
+      "designation" : [{
+        "value" : "history-system"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Create a new resource with a server assigned id."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "create",
+      "display" : "create",
+      "designation" : [{
+        "value" : "create"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Search a resource type or all resources based on some filter criteria."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "search",
+      "display" : "search",
+      "designation" : [{
+        "value" : "search"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Search all resources of the specified type based on some filter criteria."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "search-type",
+      "display" : "search-type",
+      "designation" : [{
+        "value" : "search-type"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Search all resources based on some filter criteria."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "search-system",
+      "display" : "search-system",
+      "designation" : [{
+        "value" : "search-system"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Get a Capability Statement for the system."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "capabilities",
+      "display" : "capabilities",
+      "designation" : [{
+        "value" : "capabilities"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Update, create or delete a set of resources as a single transaction."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "transaction",
+      "display" : "transaction",
+      "designation" : [{
+        "value" : "transaction"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "perform a set of a separate interactions in a single http operation"
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "batch",
+      "display" : "batch",
+      "designation" : [{
+        "value" : "batch"
+      }]
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Perform an operation as defined by an OperationDefinition."
+      }],
+      "system" : "http://hl7.org/fhir/restful-interaction",
+      "code" : "operation",
+      "display" : "operation",
+      "designation" : [{
+        "value" : "operation"
+      }]
+    }]
+  }
+},
   "error" : ""
 }
 -------------------------------------------------------------------------------------

--- a/vscache/dicom.cache
+++ b/vscache/dicom.cache
@@ -162,7 +162,7 @@ e: {
   },
   "text" : {
     "status" : "generated",
-    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set contains 10 concepts</p><p style=\"border: black 1px dotted; background-color: #EEEEEE; padding: 8px; margin-bottom: 8px\">Expansion based on <a href=\"codesystem-dicom-dcim.html\">DICOM Controlled Terminology Definitions v01 (CodeSystem)</a></p><p>All codes from system <a href=\"codesystem-dicom-dcim.html\"><code>http://dicom.nema.org/resources/ontology/DCM</code></a></p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110010\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110010\">110010</a></td><td>Film</td><td>Film type of output</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110030\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110030\">110030</a></td><td>USB Disk Emulation</td><td>A device that connects using the USB hard drive interface. These may be USB-Sticks, portable hard drives, and other technologies</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110031\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110031\">110031</a></td><td>Email</td><td>Email and email attachments used as a media for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110032\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110032\">110032</a></td><td>CD</td><td>CD-R, CD-ROM, and CD-RW media used for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110033\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110033\">110033</a></td><td>DVD</td><td>DVD, DVD-RAM, and other DVD formatted media used for data transport</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110034\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110034\">110034</a></td><td>Compact Flash</td><td>Media that comply with the Compact Flash standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110035\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110035\">110035</a></td><td>Multi-media Card</td><td>Media that comply with the Multi-media Card standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110036\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110036\">110036</a></td><td>Secure Digital Card</td><td>Media that comply with the Secure Digital Card standard</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110037\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110037\">110037</a></td><td>URI</td><td>URI Identifier for network or other resource, see RFC 3968</td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110038\"> </a><a href=\"codesystem-dicom-dcim.html#dicom-dcim-110038\">110038</a></td><td>Paper Document</td><td>Any paper or similar document</td></tr></table></div>"
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set contains 10 concepts</p><p style=\"border: black 1px dotted; background-color: #EEEEEE; padding: 8px; margin-bottom: 8px\">Expansion based on <a href=\"codesystem-dicom-dcim.html\">DICOM Controlled Terminology Definitions v01 (CodeSystem)</a></p><p>All codes from system <a href=\"http://terminology.hl7.org/2.1.0/CodeSystem-v3-DCM.html\"><code>http://dicom.nema.org/resources/ontology/DCM</code></a></p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110010\"> </a>110010</td><td>Film</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110030\"> </a>110030</td><td>USB Disk Emulation</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110031\"> </a>110031</td><td>Email</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110032\"> </a>110032</td><td>CD</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110033\"> </a>110033</td><td>DVD</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110034\"> </a>110034</td><td>Compact Flash</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110035\"> </a>110035</td><td>Multi-media Card</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110036\"> </a>110036</td><td>Secure Digital Card</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110037\"> </a>110037</td><td>URI</td><td/></tr><tr><td style=\"white-space:nowrap\"><a name=\"http---dicom.nema.org-resources-ontology-DCM-110038\"> </a>110038</td><td>Paper Document</td><td/></tr></table></div>"
   },
   "url" : "http://hl7.org/fhir/ValueSet/audit-media-type",
   "identifier" : [{
@@ -174,8 +174,7 @@ e: {
   "title" : "Audit Agent Media Type",
   "status" : "active",
   "date" : "2020-08-04",
-
-  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Mon, Jul 5, 2021 15:25-0400",
+  "description" : "Value Set Contents (Expansion) for Audit Agent Media Type at Sat, Oct 2, 2021 16:17-0500",
   "expansion" : {
     "identifier" : "urn:uuid:1d5595cf-8302-4d69-bb86-970f83289c04",
     "timestamp" : "2021-04-12T20:28:39.976Z",
@@ -2308,6 +2307,89 @@ v: {
 }, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
 v: {
   "display" : "Emergency Override Started",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110153",
+  "display" : "Source Role ID"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Source Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110152",
+  "display" : "Destination Role ID"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Role ID",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110154",
+  "display" : "Destination Media"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "Destination Media",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "coding" : [{
+    "system" : "http://dicom.nema.org/resources/ontology/DCM",
+    "code" : "110033",
+    "display" : "DVD"
+  }]
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_405.html"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"CHECK_MEMERSHIP_ONLY"}####
+v: {
+  "display" : "DVD",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110033",
+  "display" : "DVD"
+}, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "include" : [{
+      "system" : "http://dicom.nema.org/resources/ontology/DCM",
+      "valueSet" : ["http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_405.html"]
+    }]
+  }
+}, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"NO_MEMBERSHIP_CHECK"}####
+v: {
+  "display" : "DVD",
+  "severity" : null,
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"code" : {
+  "system" : "http://dicom.nema.org/resources/ontology/DCM",
+  "code" : "110033"
+}, "valueSet" :null, "lang":"null", "useServer":"true", "useClient":"true", "guessSystem":"false", "valueSetMode":"ALL_CHECKS"}####
+v: {
+  "display" : "DVD",
   "severity" : null,
   "error" : ""
 }


### PR DESCRIPTION
## HL7 FHIR Pull Request

For AuditEvent and Provenance

* FHIR-32475 - more datatypes on AuditEvent.entity.detail.valueset-imagingreference-status.xml[x]
* FHIR-32515 - changes to purposeOfUse to authorizations
* FHIR-32474 - change AuditEvent.entity.type to CodeableConcept
* FHIR-32473 - remove invariant between name and query
* FHIR-32472 - eliminate .name elements as they are supported in what/who .display element
* FHIR-32470 - remove lifecycle element, and make an extension for it.
* FHIR-32467, FHIR-32466 - remove .entity.type as redundant with .entity.what
* FHIR-32465 - explain .source as a human, one of the .agent, or other
* FHIR-32464 - change source.site to Reference(Location)
* FHIR-32463 - cleanups on .source.type valueset use and descriptions
* FHIR-32462 - update valueset-security-source-type to not include other(9) (i.e. include 1-8)
* FHIR-32461 - change source.observer to all participant resource types
* FHIR-32460 - change Coding to CodeableConcept
* FHIR-32458 - when network is used it must have address and type
* FHIR-32455 - remove altId, and create an extension for AlternativeUserID
* FHIR-32451 - agent.type should not be extensible
* FHIR-32449 - make .agent.who 1..1
* FHIR-32448 - .requester optional and meaning when missing is false
* FHIR-32444 - change period to occurred[x] (taken from provenance)
* FHIR-32441 - change sub-type binding to example, and make the valueSet more of an example, remove lifecycle events
* FHIR-32440 - sub-type simplification
* FHIR-32439 - type binding to example
* FHIR-26938 - explain how a FHIR search using POST is recorded in AuditEvent
