### PR TITLE
J# 32795 and J# 31967

### DIFF
--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -659,21 +659,57 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/citation-artifact-classifier"/>
       </binding>
     </element>
-    <element id="Citation.relatesTo.target[x]">
-      <path value="Citation.relatesTo.target[x]"/>
+    <element id="Citation.relatesTo.target">
+      <path value="Citation.relatesTo.target"/>
       <short value="The article or artifact that the Citation Resource is related to"/>
       <min value="1"/>
       <max value="1"/>
       <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="Citation.relatesTo.target.url">
+      <path value="Citation.relatesTo.target.url"/>
+      <short value="The article or artifact that the Citation Resource is related to URL"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
         <code value="uri"/>
       </type>
+    </element>
+    <element id="Citation.relatesTo.target.identifier">
+      <path value="Citation.relatesTo.target.identifier"/>
+      <short value="The article or artifact that the Citation Resource is related to Identifier"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Identifier"/>
       </type>
+    </element>
+    <element id="Citation.relatesTo.target.display">
+      <path value="Citation.relatesTo.target.display"/>
+      <short value="The article or artifact that the Citation Resource is related to Display"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
+    <element id="Citation.relatesTo.target.resource">
+      <path value="Citation.relatesTo.target.resource"/>
+      <short value="The article or artifact that the Citation Resource is related to Resource reference"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
       </type>
+    </element>
+    <element id="Citation.relatesTo.target.attachment">
+      <path value="Citation.relatesTo.target.attachment"/>
+      <short value="The article or artifact that the Citation Resource is related to Attachment"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Attachment"/>
       </type>
@@ -1013,21 +1049,57 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/citation-artifact-classifier"/>
       </binding>
     </element>
-    <element id="Citation.citedArtifact.relatesTo.target[x]">
-      <path value="Citation.citedArtifact.relatesTo.target[x]"/>
+    <element id="Citation.citedArtifact.relatesTo.target">
+      <path value="Citation.citedArtifact.relatesTo.target"/>
       <short value="The article or artifact that the cited artifact is related to"/>
       <min value="1"/>
       <max value="1"/>
       <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.target.url">
+      <path value="Citation.citedArtifact.relatesTo.target.url"/>
+      <short value="The article or artifact that the cited artifact is related to URL"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
         <code value="uri"/>
       </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.target.identifier">
+      <path value="Citation.citedArtifact.relatesTo.target.identifier"/>
+      <short value="The article or artifact that the cited artifact is related to Identifier"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Identifier"/>
       </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.target.display">
+      <path value="Citation.citedArtifact.relatesTo.target.display"/>
+      <short value="The article or artifact that the cited artifact is related to Display"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.target.resource">
+      <path value="Citation.citedArtifact.relatesTo.target.resource"/>
+      <short value="The article or artifact that the cited artifact is related to Resource reference"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
       </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.target.attachment">
+      <path value="Citation.citedArtifact.relatesTo.target.attachment"/>
+      <short value="The article or artifact that the cited artifact is related to Attachment"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Attachment"/>
       </type>
@@ -1651,9 +1723,10 @@
         <code value="boolean"/>
       </type>
     </element>
-    <element id="Citation.citedArtifact.contributorship.entry.listOrder">
-      <path value="Citation.citedArtifact.contributorship.entry.listOrder"/>
-      <short value="Used to code order of authors"/>
+    <element id="Citation.citedArtifact.contributorship.entry.rankingOrder">
+      <path value="Citation.citedArtifact.contributorship.entry.rankingOrder"/>
+      <short value="Ranked order of contribution"/>
+      <definition value="Provides a numerical ranking to represent the degree of contributorship relative to other contributors, such as 1 for first author and 2 for second author."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/evidencereport/structuredefinition-EvidenceReport.xml
+++ b/source/evidencereport/structuredefinition-EvidenceReport.xml
@@ -265,7 +265,7 @@
       <path value="EvidenceReport.subject"/>
       <short value="Focus of the report"/>
       <definition value="Specifies the subject or focus of the report. Answers &quot;What is this report about?&quot;."/>
-	  <comment value="May be used as an expression for search queries and search results"/>
+      <comment value="May be used as an expression for search queries and search results"/>
       <min value="1"/>
       <max value="1"/>
       <type>
@@ -469,18 +469,60 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/report-relation-type"/>
       </binding>
     </element>
-    <element id="EvidenceReport.relatesTo.target[x]">
-      <path value="EvidenceReport.relatesTo.target[x]"/>
+    <element id="EvidenceReport.relatesTo.target">
+      <path value="EvidenceReport.relatesTo.target"/>
       <short value="Target of the relationship"/>
       <definition value="The target composition/document of this relationship."/>
       <min value="1"/>
       <max value="1"/>
       <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="EvidenceReport.relatesTo.target.url">
+      <path value="EvidenceReport.relatesTo.target.url"/>
+      <short value="Target of the relationship URL"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="uri"/>
+      </type>
+    </element>
+    <element id="EvidenceReport.relatesTo.target.identifier">
+      <path value="EvidenceReport.relatesTo.target.identifier"/>
+      <short value="Target of the relationship Identifier"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
         <code value="Identifier"/>
       </type>
+    </element>
+    <element id="EvidenceReport.relatesTo.target.display">
+      <path value="EvidenceReport.relatesTo.target.display"/>
+      <short value="Target of the relationship Display"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
+    <element id="EvidenceReport.relatesTo.target.resource">
+      <path value="EvidenceReport.relatesTo.target.resource"/>
+      <short value="Target of the relationship Resource reference"/>
+      <min value="0"/>
+      <max value="1"/>
       <type>
         <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/EvidenceReport"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
+      </type>
+    </element>
+    <element id="EvidenceReport.relatesTo.target.attachment">
+      <path value="Citation.citedArtifact.relatesTo.target.attachment"/>
+      <short value="Target of the relationship Attachment"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Attachment"/>
       </type>
     </element>
     <element id="EvidenceReport.section">

--- a/source/terminologies/valueset-languages.xml
+++ b/source/terminologies/valueset-languages.xml
@@ -6,14 +6,14 @@
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="fhir"/> 
-  </extension> 
+    <valueCode value="fhir"/>
+  </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/> 
-  </extension> 
+    <valueCode value="trial-use"/>
+  </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="3"/> 
-  </extension> 
+    <valueInteger value="3"/>
+  </extension>
   <url value="http://hl7.org/fhir/ValueSet/languages"/>
     <version value="3.1.0"/>
     <name value="CommonLanguages"/>
@@ -746,14 +746,14 @@
             </concept>
             <concept>
                 <code value="en-NZ"/>
-                <display value="English (New Zeland)"/>
+                <display value="English (New Zealand)"/>
                 <designation>
                     <language value="en"/>
                     <use>
                       <system value="http://terminology.hl7.org/CodeSystem/designation-usage"/>
                       <code value="display"/>
                     </use>
-                    <value value="English (New Zeland)"/>
+                    <value value="English (New Zealand)"/>
                 </designation>
                 <designation>
                     <language value="nl"/>


### PR DESCRIPTION
Revised relatesTo.target[x] to BackboneElement
 - with sub-elements: url, identifier, display, resource, attachment
 - this change is in the Citation resource (twice) and EvidenceReport

New Zealand misspelt in Language list, now fixed