### PR TITLE
FHIR-32682, 32683 - cardinality updates to TestScript.url and TestScr…

### DIFF
--- a/source/testscript/implementationguide-TestScript-core.xml
+++ b/source/testscript/implementationguide-TestScript-core.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ImplementationGuide xmlns="http://hl7.org/fhir">
+  <id value="TestScript-core"/>
+  <version value="0.01"/>
+  <name value="Shareable TestScript"/>
+  <title value="Shareable TestScript"/>
+  <status value="draft"/>
+  <date value="1970-01-01T10:00:00+10:00"/>
+  <publisher value="HL7"/>
+  <description value="Enforces the minimum information set for the test script metadata required by HL7 and other organizations that share and publish test scripts"/>
+  <definition>
+    <resource>
+      <reference>
+        <reference value="StructureDefinition/shareabletestscript"/>
+      </reference>
+    </resource>
+  </definition>
+</ImplementationGuide>

--- a/source/testscript/list-TestScript-packs.xml
+++ b/source/testscript/list-TestScript-packs.xml
@@ -4,4 +4,9 @@
   <id value="TestScript-packs"/>
   <status value="current"/>
   <mode value="working"/>
+  <entry>
+    <item>
+      <reference value="ImplementationGuide/TestScript-core"/>
+    </item>
+  </entry>
 </List>

--- a/source/testscript/structuredefinition-TestScript.xml
+++ b/source/testscript/structuredefinition-TestScript.xml
@@ -108,7 +108,7 @@
       <alias value="authoritative-url"/>
       <alias value="destination"/>
       <alias value="identity"/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="uri"/>
@@ -130,7 +130,7 @@
       <comment value="Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this test script outside of FHIR, where it is not possible to use the logical URI."/>
       <requirements value="Allows externally provided and/or usable business identifiers to be easily associated with the module."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
         <code value="Identifier"/>
       </type>

--- a/source/testscript/structuredefinition-profile-shareabletestscript.xml
+++ b/source/testscript/structuredefinition-profile-shareabletestscript.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="shareabletestscript"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">to do</div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="2"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="fhir"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/shareabletestscript"/>
+  <version value="4.6.0"/>
+  <name value="Shareable TestScript"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2021-11-08T17:15:11-04:00"/>
+  <publisher value="HL7"/>
+  <description value="Enforces the minimum information set for the test script metadata required by HL7 and other organizations that share and publish test scripts"/>
+  <fhirVersion value="4.6.0"/>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <mapping>
+    <identity value="workflow"/>
+    <uri value="http://hl7.org/fhir/workflow"/>
+    <name value="Workflow Pattern"/>
+  </mapping>
+  <mapping>
+    <identity value="w5"/>
+    <uri value="http://hl7.org/fhir/fivews"/>
+    <name value="FiveWs Pattern Mapping"/>
+  </mapping>
+  <mapping>
+    <identity value="objimpl"/>
+    <uri value="http://hl7.org/fhir/object-implementation"/>
+    <name value="Object Implementation Information"/>
+  </mapping>
+  <kind value="resource"/>
+  <abstract value="false"/>
+  <type value="TestScript"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/TestScript"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="TestScript">
+      <path value="TestScript"/>
+      <min value="1"/>
+      <max value="1"/>
+    </element>
+    <element id="TestScript.url">
+      <path value="TestScript.url"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="uri"/>
+      </type>
+    </element>
+    <element id="TestScript.version">
+      <path value="TestScript.version"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="TestScript.experimental">
+      <path value="TestScript.experimental"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
+    <element id="TestScript.publisher">
+      <path value="TestScript.publisher"/>
+      <alias value="steward"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="TestScript.description">
+      <path value="TestScript.description"/>
+      <alias value="scope"/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+      <mapping>
+        <identity value="rim"/>
+        <map value="N/A"/>
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

Apply changes to the TestScript resource type per the following HL7 JIRA issues:
* FHIR-32682 - TestScript.identifier cardinality updated from 0..1 to 0..*
* FHIR-32683 - TestScript.url cardinality updated from 1..1 to 0..1; also added new Testscript shareabletestscript profile to enforce the minimum information set for TestScript metadata
