### PR TITLE
J# 33119, J# 32322, J# 33421

### DIFF
--- a/source/citation/citation-example-research-doi.xml
+++ b/source/citation/citation-example-research-doi.xml
@@ -134,7 +134,7 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="webpage"/>
 					<display value="Webpage"/>
@@ -145,7 +145,7 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="doi-based"/>
 					<display value="DOI Based"/>
@@ -156,7 +156,7 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="doi-based"/>
 					<display value="DOI Based"/>
@@ -168,7 +168,7 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="compressed-file"/>
 					<display value="Compressed file"/>

--- a/source/citation/citation-example-research-doi.xml
+++ b/source/citation/citation-example-research-doi.xml
@@ -132,29 +132,29 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 			<copyright value="https://physionet.org/content/ninfea/view-license/1.0.0/ and https://physionet.org/content/ninfea/1.0.0/LICENSE.txt"/>
 		</publicationForm>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="webpage"/>
 					<display value="Webpage"/>
 				</coding>
-			</type>
+			</classifier>
 			<url value="https://physionet.org/content/ninfea/1.0.0/"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="doi-based"/>
 					<display value="DOI Based"/>
 				</coding>
-			</type>
+			</classifier>
 			<url value="https://doi.org/10.13026/c4n5-3b04"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
@@ -162,34 +162,34 @@ The Non-Invasive Multimodal Foetal ECG-Doppler Dataset for Antenatal Cardiology 
 					<display value="DOI Based"/>
 				</coding>
 				<text value="original publication"/>
-			</type>
+			</classifier>
 			<url value="https://doi.org/10.1038/s41597-021-00811-3"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="compressed-file"/>
 					<display value="Compressed file"/>
 				</coding>
-			</type>
+			</classifier>
 			<url value="https://physionet.org/static/published-projects/ninfea/ninfea-non-invasive-multimodal-foetal-ecg-doppler-dataset-for-antenatal-cardiology-research-1.0.0.zip"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<text value="DOI-for-metadata"/>
-			</type>
+			</classifier>
 			<url value="https://doi.org/10.6084/m9.figshare.13283492"/>
 		</webLocation>
 		<classification>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/cited-artifact-classification-type"/>
 					<code value="knowledge-artifact-type"/>
 					<display value="Knowledge Artifact Type"/>
 				</coding>
-			</type>
+			</classifier>
 			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/citation-artifact-classifier"/>

--- a/source/citation/citation-example-systematic-meta-review.xml
+++ b/source/citation/citation-example-systematic-meta-review.xml
@@ -809,7 +809,7 @@
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<code value="doi-based"/>
 					<display value="DOI Based"/>
 				</coding>
@@ -819,7 +819,7 @@
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="abstract"/>
 					<display value="Abstract"/>
@@ -832,7 +832,7 @@
 		<webLocation>
 			<type>
 				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
 					<code value="full-text"/>
 					<display value="Full-Text"/>

--- a/source/citation/citation-example-systematic-meta-review.xml
+++ b/source/citation/citation-example-systematic-meta-review.xml
@@ -73,7 +73,7 @@
 			<start value="2021-06-07"/>
 		</period>
 	</statusDate>
-	<relatesTo>
+	<relatedArtifact>
 		<type value="derived-from"/>
 		<classifier>
 			<coding>
@@ -94,7 +94,7 @@
 			</identifier>
 			<display value="32876694 Medline Base"/>
 		</resourceReference>
-	</relatesTo>
+	</relatedArtifact>
 	<citedArtifact>
 		<identifier>
 			<system value="https://pubmed.ncbi.nlm.nih.gov"/>
@@ -807,17 +807,17 @@
 			<pageString value="1330-1341"/>
 		</publicationForm>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<code value="doi-based"/>
 					<display value="DOI Based"/>
 				</coding>
-			</type>
+			</classifier>
 			<url value="http://doi.org/10.1001/jama.2020.17023"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
@@ -826,11 +826,11 @@
 					<userSelected value="true"/>
 				</coding>
 				<text value="on PubMed"/>
-			</type>
+			</classifier>
 			<url value="https://pubmed.ncbi.nlm.nih.gov/32876694/"/>
 		</webLocation>
 		<webLocation>
-			<type>
+			<classifier>
 				<coding>
 					<system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
 					<version value="4.6.0"/>
@@ -839,7 +839,7 @@
 					<userSelected value="true"/>
 				</coding>
 				<text value="on JAMA"/>
-			</type>
+			</classifier>
 			<url value="https://jamanetwork.com/journals/jama/fullarticle/2770279"/>
 		</webLocation>
 		<classification>

--- a/source/citation/codesystem-artifact-url-classifier.xml
+++ b/source/citation/codesystem-artifact-url-classifier.xml
@@ -35,7 +35,7 @@
           </td>
         
         </tr>
-        
+		
         <tr>
           
           <td style="white-space:nowrap">abstract
@@ -46,38 +46,12 @@
           
           <td>Abstract</td>
           
-          <td>URL to reach the abstract for the article.</td>
+          <td>The URL will reach a brief summary for the article.</td>
         
         </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">abstract-version
-            
-            <a name="artifact-url-classifier-abstract-version"> </a>
-          
-          </td>
-          
-          <td>Abstract Version</td>
-          
-          <td>URL to reach a specific version of the abstract for the article.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">doi-based
-            
-            <a name="artifact-url-classifier-doi-based"> </a>
-          
-          </td>
-          
-          <td>DOI Based</td>
-          
-          <td>URL derived from DOI.</td>
-        
-        </tr>
-        
+
+
+
         <tr>
           
           <td style="white-space:nowrap">full-text
@@ -88,135 +62,12 @@
           
           <td>Full-Text</td>
           
-          <td>URL to reach the full-text of the article.</td>
+          <td>The URL will reach the full-text of the article.</td>
         
         </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">full-text-version
-            
-            <a name="artifact-url-classifier-full-text-version"> </a>
-          
-          </td>
-          
-          <td>Full-Text Version</td>
-          
-          <td>URL to reach a specific version of the full-text of the article.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">pdf
-            
-            <a name="artifact-url-classifier-pdf"> </a>
-          
-          </td>
-          
-          <td>PDF</td>
-          
-          <td>URL to reach the full-text of the article in PDF form.</td>
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">pdf-version
-            
-            <a name="artifact-url-classifier-pdf-version"> </a>
-          
-          </td>
-          
-          <td>PDF Version</td>
-          
-          <td>URL to reach a specific version of the full-text of the article in PDF form.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">webpage
-            
-            <a name="artifact-url-classifier-webpage"> </a>
-          
-          </td>
-          
-          <td>Webpage</td>
-          
-          <td>Used when URL type is a webpage, but other codes do not apply.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">not-specified
-            
-            <a name="artifact-url-classifier-not-specified"> </a>
-          
-          </td>
-          
-          <td>Not Specified</td>
-          
-          <td>Used when URL type is not specified, commonly when only a single URL is provided.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">json
-            
-            <a name="artifact-url-classifier-json"> </a>
-          
-          </td>
-          
-          <td>JSON</td>
-          
-          <td>URL to reach the computable content in JSON format.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">json-version
-            
-            <a name="artifact-url-classifier-json-version"> </a>
-          
-          </td>
-          
-          <td>JSON Version</td>
-          
-          <td>URL to reach a specific version of computable content in JSON format.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">xml
-            
-            <a name="artifact-url-classifier-xml"> </a>
-          
-          </td>
-          
-          <td>XML</td>
-          
-          <td>URL to reach the computable content in XML format.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">xml-version
-            
-            <a name="artifact-url-classifierxml-version"> </a>
-          
-          </td>
-          
-          <td>JSON Version</td>
-          
-          <td>URL to reach a specific version of computable content in XML format.</td>
-        
-        </tr>
-		
+
+
+
         <tr>
           
           <td style="white-space:nowrap">supplement
@@ -227,24 +78,76 @@
           
           <td>Supplement</td>
           
-          <td>Supplement</td>
+          <td>The URL will reach a supplement, appendix, or additional supporting information for the article.</td>
         
-        </tr>   
-        
+        </tr>
+
+
+
         <tr>
           
-          <td style="white-space:nowrap">supplementary-file-directory
+          <td style="white-space:nowrap">webpage
             
-            <a name="artifact-url-classifier-supplementary-file-directory"> </a>
+            <a name="artifact-url-classifier-webpage"> </a>
           
           </td>
           
-          <td>Supplementary File Directory</td>
+          <td>Webpage</td>
           
-          <td>Supplementary File Directory</td>
+          <td>The URL will reach a webpage related to the article, where the content is not easily classified as abstract, full-text or supplement.</td>
         
         </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">file-directory
+            
+            <a name="artifact-url-classifier-file-directory"> </a>
+          
+          </td>
+          
+          <td>File directory</td>
+          
+          <td>The URL will reach a file directory.</td>
         
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">code-repository
+            
+            <a name="artifact-url-classifier-code-repository"> </a>
+          
+          </td>
+          
+          <td>Code repository</td>
+          
+          <td>File archive and web hosting facility for source code of software, documentation, web pages, and other works.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">restricted
+            
+            <a name="artifact-url-classifier-restricted"> </a>
+          
+          </td>
+          
+          <td>Restricted</td>
+          
+          <td>The URL content has restricted access (e.g. subcription required).</td>
+        
+        </tr>
+
+
+
         <tr>
           
           <td style="white-space:nowrap">compressed-file
@@ -256,6 +159,118 @@
           <td>Compressed file</td>
           
           <td>Compressed archive file (e.g. a zip file) that contains multiple files</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">doi-based
+            
+            <a name="artifact-url-classifier-doi-based"> </a>
+          
+          </td>
+          
+          <td>DOI Based</td>
+          
+          <td>The URL is derived from the Digital Object Identifier (DOI).</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">pdf
+            
+            <a name="artifact-url-classifier-pdf"> </a>
+          
+          </td>
+          
+          <td>PDF</td>
+          
+          <td>The URL will reach content in PDF form.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">json
+            
+            <a name="artifact-url-classifier-json"> </a>
+          
+          </td>
+          
+          <td>JSON</td>
+          
+          <td>The URL will reach content in JSON format.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">xml
+            
+            <a name="artifact-url-classifier-xml"> </a>
+          
+          </td>
+          
+          <td>XML</td>
+          
+          <td>The URL will reach content in XML format.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">version-specific
+            
+            <a name="artifact-url-classifier-version-specific"> </a>
+          
+          </td>
+          
+          <td>Version Specific</td>
+          
+          <td>The URL will reach content that is a specific version of the article.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">computable-resource
+            
+            <a name="artifact-url-classifier-computable-resource"> </a>
+          
+          </td>
+          
+          <td>Computable resource</td>
+          
+          <td>The URL will reach content that is machine-interpretable.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">not-specified
+            
+            <a name="artifact-url-classifier-not-specified"> </a>
+          
+          </td>
+          
+          <td>Not Specified</td>
+          
+          <td>Used when URL classifier is not specified but expected in a system.</td>
         
         </tr>
       
@@ -301,81 +316,76 @@
   <concept>
     <code value="abstract"/>
     <display value="Abstract"/>
-    <definition value="URL to reach the abstract for the article."/>
-  </concept>
-  <concept>
-    <code value="abstract-version"/>
-    <display value="Abstract Version"/>
-    <definition value="URL to reach a specific version of the abstract for the article."/>
-  </concept>
-  <concept>
-    <code value="doi-based"/>
-    <display value="DOI Based"/>
-    <definition value="URL derived from DOI."/>
+    <definition value="The URL will reach a brief summary for the article."/>
   </concept>
   <concept>
     <code value="full-text"/>
     <display value="Full-Text"/>
-    <definition value="URL to reach the full-text of the article."/>
-  </concept>
-  <concept>
-    <code value="full-text-version"/>
-    <display value="Full-Text Version"/>
-    <definition value="URL to reach a specific version of the full-text of the article."/>
-  </concept>
-  <concept>
-    <code value="pdf"/>
-    <display value="PDF"/>
-    <definition value="URL to reach the full-text of the article in PDF form."/>
-  </concept>
-  <concept>
-    <code value="pdf-version"/>
-    <display value="PDF Version"/>
-    <definition value="URL to reach a specific version of the full-text of the article in PDF form."/>
-  </concept>
-  <concept>
-    <code value="webpage"/>
-    <display value="Webpage"/>
-    <definition value="Used when URL type is a webpage, but other codes do not apply."/>
-  </concept>
-  <concept>
-    <code value="not-specified"/>
-    <display value="Not Specified"/>
-    <definition value="Used when URL type is not specified, commonly when only a single URL is provided."/>
-  </concept>
-  <concept>
-    <code value="json"/>
-    <display value="JSON"/>
-    <definition value="URL to reach computable content in JSON format."/>
-  </concept>
-  <concept>
-    <code value="json-version"/>
-    <display value="JSON Version"/>
-    <definition value="URL to reach a specific version of computable content in JSON format."/>
-  </concept>
-  <concept>
-    <code value="xml"/>
-    <display value="XML"/>
-    <definition value="URL to reach computable content in XML format."/>
-  </concept>
-  <concept>
-    <code value="xml-version"/>
-    <display value="XML"/>
-    <definition value="URL to reach a specific version of computable content in XML format."/>
+    <definition value="The URL will reach the full-text of the article."/>
   </concept>
   <concept>
     <code value="supplement"/>
     <display value="Supplement"/>
-    <definition value="Supplement"/>
+    <definition value="The URL will reach a supplement, appendix, or additional supporting information for the article."/>
   </concept>
   <concept>
-    <code value="supplementary-file-directory"/>
-    <display value="Supplementary file directory"/>
-    <definition value="Supplementary file directory"/>
+    <code value="webpage"/>
+    <display value="Webpage"/>
+    <definition value="The URL will reach a webpage related to the article, where the content is not easily classified as abstract, full-text or supplement."/>
+  </concept>
+  <concept>
+    <code value="file-directory"/>
+    <display value="File directory"/>
+    <definition value="The URL will reach a file directory."/>
+  </concept>
+  <concept>
+    <code value="code-repository"/>
+    <display value="Code repository"/>
+    <definition value="File archive and web hosting facility for source code of software, documentation, web pages, and other works."/>
+  </concept>
+  <concept>
+    <code value="restricted"/>
+    <display value="Restricted"/>
+    <definition value="The URL content has restricted access (e.g. subcription required)."/>
   </concept>
   <concept>
     <code value="compressed-file"/>
     <display value="Compressed file"/>
     <definition value="Compressed archive file (e.g. a zip file) that contains multiple files"/>
+  </concept>
+  <concept>
+    <code value="doi-based"/>
+    <display value="DOI Based"/>
+    <definition value="The URL is derived from the Digital Object Identifier (DOI)."/>
+  </concept>
+  <concept>
+    <code value="pdf"/>
+    <display value="PDF"/>
+    <definition value="The URL will reach content in PDF form."/>
+  </concept>
+  <concept>
+    <code value="json"/>
+    <display value="JSON"/>
+    <definition value="The URL will reach content in JSON format."/>
+  </concept>
+  <concept>
+    <code value="xml"/>
+    <display value="XML"/>
+    <definition value="The URL will reach content in XML format."/>
+  </concept>
+  <concept>
+    <code value="version-specific"/>
+    <display value="Version Specific"/>
+    <definition value="The URL will reach content that is a specific version of the article."/>
+  </concept>
+  <concept>
+    <code value="computable-resource"/>
+    <display value="Computable resource"/>
+    <definition value="The URL will reach content that is machine-interpretable."/>
+  </concept>
+  <concept>
+    <code value="not-specified"/>
+    <display value="Not Specified"/>
+    <definition value="Used when URL classifier is not specified but expected in a system."/>
   </concept>
 </CodeSystem>

--- a/source/citation/codesystem-artifact-url-classifier.xml
+++ b/source/citation/codesystem-artifact-url-classifier.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <id value="article-url-type"/>
+  <id value="artifact-url-classifier"/>
   <meta>
     <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
@@ -10,7 +10,7 @@
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       
-      <p>This code system http://terminology.hl7.org/CodeSystem/article-url-type defines the following codes:</p>
+      <p>This code system http://terminology.hl7.org/CodeSystem/artifact-url-classifier defines the following codes:</p>
       
       <table class="codes">
         
@@ -40,7 +40,7 @@
           
           <td style="white-space:nowrap">abstract
             
-            <a name="article-url-type-abstract"> </a>
+            <a name="artifact-url-classifier-abstract"> </a>
           
           </td>
           
@@ -54,7 +54,7 @@
           
           <td style="white-space:nowrap">abstract-version
             
-            <a name="article-url-type-abstract-version"> </a>
+            <a name="artifact-url-classifier-abstract-version"> </a>
           
           </td>
           
@@ -68,7 +68,7 @@
           
           <td style="white-space:nowrap">doi-based
             
-            <a name="article-url-type-doi-based"> </a>
+            <a name="artifact-url-classifier-doi-based"> </a>
           
           </td>
           
@@ -82,7 +82,7 @@
           
           <td style="white-space:nowrap">full-text
             
-            <a name="article-url-type-full-text"> </a>
+            <a name="artifact-url-classifier-full-text"> </a>
           
           </td>
           
@@ -96,7 +96,7 @@
           
           <td style="white-space:nowrap">full-text-version
             
-            <a name="article-url-type-full-text-version"> </a>
+            <a name="artifact-url-classifier-full-text-version"> </a>
           
           </td>
           
@@ -110,7 +110,7 @@
           
           <td style="white-space:nowrap">pdf
             
-            <a name="article-url-type-pdf"> </a>
+            <a name="artifact-url-classifier-pdf"> </a>
           
           </td>
           
@@ -123,7 +123,7 @@
           
           <td style="white-space:nowrap">pdf-version
             
-            <a name="article-url-type-pdf-version"> </a>
+            <a name="artifact-url-classifier-pdf-version"> </a>
           
           </td>
           
@@ -137,7 +137,7 @@
           
           <td style="white-space:nowrap">webpage
             
-            <a name="article-url-type-webpage"> </a>
+            <a name="artifact-url-classifier-webpage"> </a>
           
           </td>
           
@@ -151,7 +151,7 @@
           
           <td style="white-space:nowrap">not-specified
             
-            <a name="article-url-type-not-specified"> </a>
+            <a name="artifact-url-classifier-not-specified"> </a>
           
           </td>
           
@@ -165,7 +165,7 @@
           
           <td style="white-space:nowrap">json
             
-            <a name="article-url-type-json"> </a>
+            <a name="artifact-url-classifier-json"> </a>
           
           </td>
           
@@ -179,7 +179,7 @@
           
           <td style="white-space:nowrap">json-version
             
-            <a name="article-url-type-json-version"> </a>
+            <a name="artifact-url-classifier-json-version"> </a>
           
           </td>
           
@@ -193,7 +193,7 @@
           
           <td style="white-space:nowrap">xml
             
-            <a name="article-url-type-xml"> </a>
+            <a name="artifact-url-classifier-xml"> </a>
           
           </td>
           
@@ -207,7 +207,7 @@
           
           <td style="white-space:nowrap">xml-version
             
-            <a name="article-url-typexml-version"> </a>
+            <a name="artifact-url-classifierxml-version"> </a>
           
           </td>
           
@@ -221,7 +221,7 @@
           
           <td style="white-space:nowrap">supplement
             
-            <a name="article-url-type-supplement"> </a>
+            <a name="artifact-url-classifier-supplement"> </a>
           
           </td>
           
@@ -235,7 +235,7 @@
           
           <td style="white-space:nowrap">supplementary-file-directory
             
-            <a name="article-url-type-supplementary-file-directory"> </a>
+            <a name="artifact-url-classifier-supplementary-file-directory"> </a>
           
           </td>
           
@@ -249,7 +249,7 @@
           
           <td style="white-space:nowrap">compressed-file
             
-            <a name="article-url-type-compressed-file"> </a>
+            <a name="artifact-url-classifier-compressed-file"> </a>
           
           </td>
           
@@ -272,14 +272,14 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="0"/>
   </extension>
-  <url value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+  <url value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
     <value value="urn:oid:2.16.840.1.113883.4.642.1.1491"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ArticleUrlType"/>
-  <title value="ArticleUrlType"/>
+  <name value="ArtifactUrlClassifier"/>
+  <title value="ArtifactUrlClassifier"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -296,7 +296,7 @@
   </contact>
   <description value="Code the reason for different URLs, eg abstract and full-text."/>
   <caseSensitive value="true"/>
-  <valueSet value="http://hl7.org/fhir/ValueSet/article-url-type"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/artifact-url-classifier"/>
   <content value="complete"/>
   <concept>
     <code value="abstract"/>

--- a/source/citation/codesystem-citation-artifact-classifier.xml
+++ b/source/citation/codesystem-citation-artifact-classifier.xml
@@ -446,6 +446,100 @@
         
         
         </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">cds-artifact
+            
+            <a name="citation-artifact-classifier-cds-artifact"> </a>
+          
+          </td>
+          
+          <td>Clinical Decision Support Artifact</td>
+          
+          <td>The artifact is used for decision support for healthcare decisions.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">prediction-model
+            
+            <a name="citation-artifact-classifier-prediction-model"> </a>
+          
+          </td>
+          
+          <td>Prediction Model</td>
+          
+          <td>A formula or expression used to calculate an outcome representing a predicted result.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">interactive-form
+            
+            <a name="citation-artifact-classifier-interactive-form"> </a>
+          
+          </td>
+          
+          <td>Interactive Form</td>
+          
+          <td>A user interface that supports data entry and data display.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">terminology
+            
+            <a name="citation-artifact-classifier-terminology"> </a>
+          
+          </td>
+          
+          <td>Terminology</td>
+          
+          <td>A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">pseudocode
+            
+            <a name="citation-artifact-classifier-pseudocode"> </a>
+          
+          </td>
+          
+          <td>PseudoCode</td>
+          
+          <td>A non-executable, human-readable representation of software code.</td>
+        
+        </tr>
+
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">standard-specification
+            
+            <a name="citation-artifact-classifier-standard-specification"> </a>
+          
+          </td>
+          
+          <td>Standard Specification</td>
+          
+          <td>An explicit set of requirements for an item, material, component, system or service, often used to define a technical standard which is an established norm or requirement for a repeatable technical task.</td>
+        
+        </tr>		
         
       </table>
     
@@ -606,5 +700,35 @@
     <code value="project-specific"/>
     <display value="Project Specific"/>
     <definition value="Citation Resource containing value added data specific to a project"/>
+  </concept>
+  <concept>
+    <code value="cds-artifact"/>
+    <display value="Clinical Decision Support Artifact"/>
+    <definition value="The artifact is used for decision support for healthcare decisions."/>
+  </concept>
+  <concept>
+    <code value="prediction-model"/>
+    <display value="Prediction Model"/>
+    <definition value="A formula or expression used to calculate an outcome representing a predicted result."/>
+  </concept>
+  <concept>
+    <code value="interactive-form"/>
+    <display value="Interactive Form"/>
+    <definition value="A user interface that supports data entry and data display."/>
+  </concept>
+  <concept>
+    <code value="terminology"/>
+    <display value="Terminology"/>
+    <definition value="A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology."/>
+  </concept>
+  <concept>
+    <code value="pseudocode"/>
+    <display value="PseudoCode"/>
+    <definition value="A non-executable, human-readable representation of software code."/>
+  </concept>
+  <concept>
+    <code value="standard-specification"/>
+    <display value="Standard Specification"/>
+    <definition value="An explicit set of requirements for an item, material, component, system or service, often used to define a technical standard which is an established norm or requirement for a repeatable technical task."/>
   </concept>
 </CodeSystem>

--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -618,8 +618,8 @@
         <code value="Period"/>
       </type>
     </element>
-    <element id="Citation.relatesTo">
-      <path value="Citation.relatesTo"/>
+    <element id="Citation.relatedArtifact">
+      <path value="Citation.relatedArtifact"/>
       <short value="Artifact related to the Citation Resource"/>
       <min value="0"/>
       <max value="*"/>

--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -1216,11 +1216,11 @@
         <code value="BackboneElement"/>
       </type>
     </element>
-    <element id="Citation.citedArtifact.webLocation.type">
-      <path value="Citation.citedArtifact.webLocation.type"/>
+    <element id="Citation.citedArtifact.webLocation.classifier">
+      <path value="Citation.citedArtifact.webLocation.classifier"/>
       <short value="Code the reason for different URLs, e.g. abstract and full-text"/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
         <code value="CodeableConcept"/>
       </type>

--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -1226,10 +1226,10 @@
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ArticleUrlType"/>
+          <valueString value="ArtifactUrlClassifier"/>
         </extension>
         <strength value="extensible"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/article-url-type"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/artifact-url-classifier"/>
       </binding>
     </element>
     <element id="Citation.citedArtifact.webLocation.url">

--- a/source/citation/valueset-artifact-url-classifier.xml
+++ b/source/citation/valueset-artifact-url-classifier.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="article-url-type"/>
+  <id value="artifact-url-classifier"/>
   <meta>
     <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
@@ -11,8 +11,8 @@
     <div xmlns="http://www.w3.org/1999/xhtml">
       <ul>
         <li>Include all codes defined in 
-          <a href="codesystem-article-url-type.html">
-            <code>http://terminology.hl7.org/CodeSystem/article-url-type</code>
+          <a href="codesystem-artifact-url-classifier.html">
+            <code>http://terminology.hl7.org/CodeSystem/artifact-url-classifier</code>
           </a>
         </li>
       </ul>
@@ -27,14 +27,14 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="0"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/article-url-type"/>
+  <url value="http://hl7.org/fhir/ValueSet/artifact-url-classifier"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
     <value value="urn:oid:2.16.840.1.113883.4.642.3.1490"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ArticleUrlType"/>
-  <title value="ArticleUrlType"/>
+  <name value="ArtifactUrlClassifier"/>
+  <title value="ArtifactUrlClassifier"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -53,7 +53,7 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://terminology.hl7.org/CodeSystem/article-url-type"/>
+      <system value="http://terminology.hl7.org/CodeSystem/artifact-url-classifier"/>
     </include>
   </compose>
 </ValueSet>


### PR DESCRIPTION
- Changed Citation.relatesTo to Citation.relatedArtifact (to reduce confusion with Citation.citedArtifact.relatesTo)
- Added 6 terms to to the CitationArtifactClassifier codesystem
- Changed the name of the codesystem/valueset ArticleUrlType to ArtifactUrlClassifier
- Made changes to the ArtifactUrlClassifier codesystem terms
- Removed the Citation.citedArtifact.webLocation.type
- Added a Citation.citedArtifact.webLocation.classifier element with 0..* CodeableConcept with Extensible binding to the ArtifactUrlClassifier value set.
- Updated  the Citation examples to reflect the changes to the Citation resource and ArtifactUrlClassifier codesystem