### PR TITLE
J# 31694

### DIFF
--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -1377,7 +1377,7 @@
       <path value="Citation.citedArtifact.contributorship.entry.name"/>
       <short value="A name associated with the person"/>
       <definition value="A name associated with the individual."/>
-      <comment value="humanName.family can match MEDLINE-based lastName (used for surname or single name), humanName.given can match MEDLINE-based forename (used for remainder of name except for suffix), humanName.suffix can match MEDLINE-based suffix (eg 2nd, 3rd, Jr, Sr)."/>
+      <comment value="humanName.family can match MEDLINE-based lastName (used for surname or single name), humanName.given can match MEDLINE-based forename (used for remainder of name except for suffix), humanName.suffix can match MEDLINE-based suffix (e.g., 2nd, 3rd, Jr, Sr)."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -1406,7 +1406,7 @@
     </element>
     <element id="Citation.citedArtifact.contributorship.entry.identifier">
       <path value="Citation.citedArtifact.contributorship.entry.identifier"/>
-      <short value="Author identifier, eg ORCID"/>
+      <short value="Author identifier, e.g., ORCID"/>
       <definition value="Unique person identifier."/>
       <comment value="Avoids needing to disambiguate common last names or changes of name. ORCID is commonly used as author identifier."/>
       <min value="0"/>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -44,7 +44,7 @@
       <value value="http://www.hl7.org/Special/committees/dss/index.cfm"/>
     </telecom>
   </contact>
-  <description value="The Evidence Resource provides a machine-interpretable expression of an evidence concept including the evidence variables (eg population, exposures/interventions, comparators, outcomes, measured variables, confounding variables), the statistics, and the certainty of this evidence."/>
+  <description value="The Evidence Resource provides a machine-interpretable expression of an evidence concept including the evidence variables (e.g., population, exposures/interventions, comparators, outcomes, measured variables, confounding variables), the statistics, and the certainty of this evidence."/>
   <fhirVersion value="4.6.0"/>
   <mapping>
     <identity value="w5"/>
@@ -78,7 +78,7 @@
       </extension>
       <path value="Evidence"/>
       <short value="Single evidence bit"/>
-      <definition value="The Evidence Resource provides a machine-interpretable expression of an evidence concept including the evidence variables (eg population, exposures/interventions, comparators, outcomes, measured variables, confounding variables), the statistics, and the certainty of this evidence."/>
+      <definition value="The Evidence Resource provides a machine-interpretable expression of an evidence concept including the evidence variables (e.g., population, exposures/interventions, comparators, outcomes, measured variables, confounding variables), the statistics, and the certainty of this evidence."/>
       <min value="0"/>
       <max value="*"/>
       <constraint>
@@ -593,7 +593,7 @@
     </element>
     <element id="Evidence.statistic.statisticType">
       <path value="Evidence.statistic.statisticType"/>
-      <short value="Type of statistic, eg relative risk"/>
+      <short value="Type of statistic, e.g., relative risk"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -743,7 +743,7 @@
     </element>
     <element id="Evidence.statistic.attributeEstimate.type">
       <path value="Evidence.statistic.attributeEstimate.type"/>
-      <short value="The type of attribute estimate, eg confidence interval or p value"/>
+      <short value="The type of attribute estimate, e.g., confidence interval or p value"/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -769,7 +769,7 @@
     </element>
     <element id="Evidence.statistic.attributeEstimate.level">
       <path value="Evidence.statistic.attributeEstimate.level"/>
-      <short value="Level of confidence interval, eg 0.95 for 95% confidence interval"/>
+      <short value="Level of confidence interval, e.g., 0.95 for 95% confidence interval"/>
       <definition value="Use 95 for a 95% confidence interval."/>
       <min value="0"/>
       <max value="1"/>


### PR DESCRIPTION
Changed "eg" to "e.g.," in the Evidence Content Description. (And also did it for Citation Resource)