### PR TITLE
Add config to publish task to reduce chatter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,12 @@ repositories {
 
 dependencies {
     implementation("org.hl7.fhir:kindling:${property("kindlingVersion")}")
-
 }
 
 task("publish", JavaExec::class) {
     dependsOn(":printVersion")
+    jvmArgs = listOf("-Dlogback.configurationFile=${properties["logback.configurationFile"]}")
+    //jvmArgs = listOf("-Dlogback.configurationFile=publish-logback.xml")
     main = "org.hl7.fhir.tools.publisher.Publisher"
     classpath = sourceSets["main"].compileClasspath
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,11 @@ task("printVersion") {
             "\nGenerating code using kindling version ${properties["kindlingVersion"]}" +
             "\nFor more information on kindling, and to check latest version, check here:" +
             "\nhttps://github.com/HL7/kindling" +
+            "\n"+
+            "\nVerbose or customized output can be further configured using the logback.configurationFile gradle property:"+
+            "\n"+
+            "\n  ./gradlew publish -Plogback.configurationFile=~/my-logback-config.xml"+
+            "\n"+
             "\n==============================")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 # Versions
 kindlingVersion=1.0.3-SNAPSHOT
+logback.configurationFile=publish-logback.xml
+

--- a/publish-logback.xml
+++ b/publish-logback.xml
@@ -1,0 +1,15 @@
+<configuration debug="false">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/publish-logback.xml
+++ b/publish-logback.xml
@@ -1,5 +1,7 @@
 <configuration debug="false">
+    <!-- NopStatusListener prevents logback from logging its own status messages, as it does by default-->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

This PR adds a default logback configuration to the `publish` task. This config reduces the log chatter produced by dependencies logging using slf4j.

For detailed logging, the config file location can be overridden using the gradle `-P` property argument:

```zsh
./gradlew publish -Plogback.configurationFile=~/my-logback-config.xml
``` 
