### PR TITLE
Update async page - FHIR-35936

### DIFF
--- a/publish.ini
+++ b/publish.ini
@@ -194,6 +194,8 @@ administration-module.html =
 ; order here is significant! ballot intro must come second last
 ;administration.html=
 async.html =
+async-bulk.html =
+async-bundle.html =
 backboneelement-definitions.html =
 backboneelement.html =
 cda-intro.html =

--- a/source/async-bulk.html
+++ b/source/async-bulk.html
@@ -1,0 +1,434 @@
+<!DOCTYPE HTML>
+
+[%settitle Asynchronous bulk data pattern%]
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  [%file newheader%]
+</head>
+
+<body>
+  [%file newnavbar%]
+
+
+  <h2 id="asynchronous-bulk-data-request-pattern">Asynchronous Bulk Data Request Pattern</h2>
+  <table class="colsd">
+    <tr>
+      <td id="wg"><a _target="blank" href="[%wg fhir%]">[%wgt fhir%]</a> Work Group</td>
+      <td id="fmm"><a href="versions.html#maturity">Maturity Level</a>: 4</td>
+      <td id="ballot"><a href="versions.html#std-process">Standards Status</a>:
+        <!--!ns!--><a href="versions.html#std-process">Draft</a>
+      </td>
+    </tr>
+  </table>
+
+  <h3 id="use-case">Use Case</h3>
+  <p>All of the interactions defined in the <a href="http.html">RESTful API</a> are described as synchronous operations
+    - that is, the client makes a query and waits for the server to respond with the outcome in the HTTP response. This
+    pattern is not always suitable when substantial amounts of data must be returned.</p>
+  <p>A good example of this is the <a href="https://hl7.org/fhir/uv/bulkdata/export.html">$export operation</a>, where
+    simple searches may result in large amounts of data. </p>
+  <p>The asynchronous request pattern, based on <a href="https://tools.ietf.org/html/rfc7240#section-4.1">rfc 7240</a>,
+    caters to this use case and is applicable for for use in <a href="operations.html">Operations</a> and
+    <a href="http.html">Defined Interactions</a> interactions. Servers may choose which interactions the pattern should be
+    supported
+    on (if at all).</p>
+
+  <h4 id="compare-with">Related Pattern: Asynchronous Interaction Request</h4>
+  <p>For use cases that return small amounts of data but may take a lot of time to process, see <a href="async-bundle.html">Asynchronous Interaction Request</a>.</p>
+
+  <h3 id="kick-off-request">Kick-off Request</h3>
+  <p>The request will support the HTTP methods, URLs, headers and other parameters that normally apply, but servers
+    SHALL also support the <code>Prefer</code> header described below, and SHOULD support the <code>Accept</code> header
+    and <code>_outputFormat</code> parameter described below.</p>
+
+  <h5 id="headers">Headers</h5>
+  <ul>
+    <li>
+      <p><code>Accept</code> (string)</p>
+      <p>Specifies the format of the optional <a href="OperationOutcome.html">OperationOutcome Resource</a> response to
+        the kick-off request. A client SHOULD provide this header. A server may support any subset of the <a
+          href="formats.html#wire">Serialization Format Representations</a>. If omitted, the server MAY return an error
+        or MAY process the request and return a format selected by the server.</p>
+    </li>
+    <li>
+      <p><code>Prefer</code> (string, required)</p>
+      <p>Specifies whether the response is immediate or asynchronous. Setting this to <code>respond-async</code>
+        triggers this async pattern.</p>
+    </li>
+  </ul>
+
+  <h5 id="kick-off-parameters">Parameters</h5>
+  <ul>
+    <li>
+      <p><code>_outputFormat</code> (string, optional, defaults to <code>application/fhir+ndjson</code>)</p>
+      <p>The format for the generated bulk data files. Currently, <a href="http://ndjson.org/">ndjson</a> must be
+        supported, though servers may choose to also support other output formats. Servers SHALL support the full
+        content type of <code>application/fhir+ndjson</code> as well as abbreviated representations including
+        <code>application/ndjson</code> and <code>ndjson</code>.
+      </p>
+      <p>For requests types where the server supports either the Asynchronous Bulk Data Request pattern or the <a
+          href="async-bundle.html">Asynchronous Interaction Request</a> pattern,
+        requests that include the <code>_outputFormat</code> parameter SHALL trigger the Asynchronous Bulk Data Request pattern.</p>
+    </li>
+  </ul>
+
+  <h5 id="kick-off-response---success">Response - Success</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code> </li>
+    <li><code>Content-Location</code> header with the absolute URL of an endpoint for subsequent status requests
+      (polling location)</li>
+    <li>Optionally, a <a href="OperationOutcome.html">OperationOutcome Resource</a> in the body</li>
+  </ul>
+  <h5 id="kick-off-response---error">Response - Error (e.g. unsupported search parameter)</h5>
+  <ul>
+    <li>HTTP Status Code of <code>4XX</code> or <code>5XX</code></li>
+    <li>The body SHALL be a <a href="OperationOutcome.html">OperationOutcome Resource</a></li>
+  </ul>
+  <hr />
+
+  <h3 id="delete-request">Delete Request</h3>
+
+  <p>After a Bulk Data request has been started, a client MAY send a http DELETE request to the URL provided in the
+  <code>Content-Location</code> header to cancel the request. If the request has been completed, a server MAY use the
+  request as a signal that a client is done retrieving files and that it is safe for the sever to remove those from
+  storage. Following the delete request, when subsequent requests are made to the polling location, the server SHALL
+  return a <code>404 Not Found</code> error and an associated <a href="OperationOutcome.html">OperationOutcome
+    Resource</a>.</p>
+
+  <h5 id="delete-response---success">Response - Success</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code></li>
+    <li>Optionally a FHIR OperationOutcome in the body</li>
+  </ul>
+  <h5 id="delete-response---error">Response - Error</h5>
+  <ul>
+    <li>HTTP status code of <code>4XX</code> or <code>5XX</code></li>
+    <li>Optionally a <a href="OperationOutcome.html">OperationOutcome Resource</a> in the body</li>
+  </ul>
+
+  <h3 id="status-request">Status Request</h3>
+
+  <p>After a Bulk Data request has been started, the client MAY poll the status URL provided in the
+    <code>Content-Location</code> header by issuing HTTP GET requests to the location.
+  </p>
+
+  <p>A client SHOULD follow an <a href="https://en.wikipedia.org/wiki/Exponential_backoff">exponential backoff</a>
+    approach when polling for status. A server SHOULD supply a <a
+      href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After"><code>Retry-After</code></a> header
+    with a with a delay time in seconds (e.g., <code>120</code> to represent two minutes) or a http-date (e.g.,
+    <code>Fri, 31 Dec 1999 23:59:59 GMT</code>). When provided, a client SHOULD use this information to inform the
+    timing of future polling requests. The server SHOULD keep an accounting of status queries received from a given
+    client, and if a client is polling too frequently, the server SHOULD respond with a
+    <code>429 Too Many Requests</code> status code in addition to a <code>Retry-After</code> header, and optionally a <a
+      href="OperationOutcome.html">OperationOutcome Resource</a> with further explanation. If excessively frequent
+    status queries persist, the server MAY return a <code>429 Too Many Requests</code> status code and terminate the
+    session. Other standard HTTP <code>4XX</code> as well as <code>5XX</code> status codes may be used to identify
+    errors as mentioned.
+  </p>
+
+  <p>When requesting status, the client SHOULD use an <code>Accept</code> header indicating a content type of
+    <code>application/json</code>. In the case that errors prevent the asynchronous operation from completing, the server SHOULD respond
+    with a <a href="OperationOutcome.html">OperationOutcome Resource</a> in JSON format.
+  </p>
+
+  <h5 id="status-response---in-progress">Response - In-Progress</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code></li>
+    <li>Optionally an <code>X-Progress</code> header with a text description of the status of the request that is less
+      than 100 characters. The format of this description is at the server's discretion and MAY be a percentage complete
+      value, or MAY be a more general status such as "in progress". The client MAY parse the description, display it to
+      the user, or log it.</li>
+  </ul>
+  <h5 id="status-response---error">Response - Error</h5>
+  <ul>
+    <li>HTTP status code of <code>4XX</code> or <code>5XX</code></li>
+    <li><code>Content-Type</code> header of <code>application/fhir+json</code> when body is a <a
+        href="OperationOutcome.html">OperationOutcome Resource</a></li>
+    <li>The body of the response SHOULD be a <a href="OperationOutcome.html">OperationOutcome Resource</a> in
+      JSON format. If this is not possible (for example, the infrastructure layer returning the error is not FHIR
+      aware), the server MAY return an error message in another format and include a corresponding value for the
+      <code>Content-Type</code> header.
+    </li>
+  </ul>
+
+  <p>In the case of a polling failure that does not indicate failure of the original request, a server SHOULD use a <a
+      href="codesystem-issue-type.html#issue-type-transient">transient code</a> from the <a
+      href="codesystem-issue-type.html">IssueType valueset</a> when populating the <a
+      href="OperationOutcome.html">OperationOutcome Resource</a> <code>issue.code</code> element to indicate to the
+    client that it should retry the request at a later time.</p>
+
+  <p><em>Note</em>: Even if some of the requested resources cannot successfully be returned, the overall request MAY
+    still succeed. In this case, the <code>Response.error</code> array of the completion response body SHALL be
+    populated with one or more files in ndjson format containing <a href="OperationOutcome.html">OperationOutcome
+      Resources</a> to indicate what went wrong (see below). In the case of a partial success, the server SHALL use a
+    <code>200</code> status code instead of <code>4XX</code> or <code>5XX</code>. The choice of when to determine that
+    an job has failed in its entirety (error status) vs. returning a partial success (complete status) is left up to the
+    server implementer.
+  </p>
+
+  <h5 id="status-response---complete">Response - Complete</h5>
+  <ul>
+    <li>HTTP status of <code>200 OK</code></li>
+    <li><code>Content-Type</code> header of <code>application/json</code></li>
+    <li>The server SHOULD return an <code>Expires</code> header indicating when the files listed will no longer be
+      available for access.</li>
+    <li>A body containing a JSON object providing metadata, and links to the generated Bulk Data files. The files SHALL
+      be accessible to the client at the URLs advertised. These URLs MAY be served by file servers other than a
+      FHIR-specific server.</li>
+  </ul>
+
+  <p>Fields:</p>
+  <table class="table">
+    <thead>
+      <th>Field</th>
+      <th>Optionality</th>
+      <th>Type</th>
+      <th>Description</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>transactionTime</code></td>
+        <td><span class="label label-success">required</span></td>
+        <td>FHIR instant</td>
+        <td>Indicates the server's time when the query is run. The response SHOULD NOT include any resources modified
+          after this instant, and SHALL include any matching resources modified up to and including this instant.
+          <br />
+          <br />
+          Note: To properly meet these constraints, a FHIR server might need to wait for any pending transactions to
+          resolve in its database before starting the asynchronous operation process.
+        </td>
+      </tr>
+      <tr>
+        <td><code>request</code></td>
+        <td><span class="label label-success">required</span></td>
+        <td>String</td>
+        <td>The full URL of the original kick-off request. In the case of a HTTP POST request, this URL will not include
+          the request parameters. Note: this field may be removed in a future version.</td>
+      </tr>
+      <tr>
+        <td><code>requiresAccessToken</code></td>
+        <td><span class="label label-success">required</span></td>
+        <td>Boolean</td>
+        <td>Indicates whether downloading the generated files requires the same authorization mechanism as kick-off and
+          status requests.
+          <br />
+          <br />
+          Value SHALL be <code>true</code> if both the file server and the FHIR API server control access using OAuth
+          2.0 bearer tokens. Value MAY be <code>false</code> for file servers that use access-control schemes other than
+          OAuth 2.0 or provide output file URLs that are "capability URLs" (e.g., short-lived high-entropy URLs that can
+          be dereferenced without additional authentication).
+        </td>
+      </tr>
+      <tr>
+        <td><code>output</code></td>
+        <td><span class="label label-success">required</span></td>
+        <td>JSON array</td>
+        <td>An array of file items with one entry for each generated file. If no resources are returned from the
+          kick-off request, the server SHOULD return an empty array.
+          <br />
+          <br />
+          Each file item SHALL contain the following fields:
+          <br />
+          <br />
+          - <code>type</code> - the FHIR resource type that is contained in the file.
+          <br />
+          <br />
+          Each file SHALL contain resources of only one type, but a server MAY create more than one file for each
+          resource type returned. The number of resources contained in a file MAY vary between servers. If no data are
+          found for a resource, the server SHOULD NOT return an output item for that resource in the response. These
+          rules apply only to top-level resources within the response; as always in FHIR, any resource MAY have a
+          "contained" array that includes referenced resources of other types.
+          <br />
+          <br />
+          - <code>url</code> - the absolute path to the file. The format of the file SHOULD reflect that requested in
+          the <code>_outputFormat</code> parameter of the initial kick-off request.
+          <br />
+          <br />
+          Each file item MAY optionally contain the following field:
+          <br />
+          <br />
+          - <code>count</code> - the number of resources in the file, represented as a JSON number.
+        </td>
+      </tr>
+      <tr>
+        <td><code>deleted</code></td>
+        <td><span class="label label-success">optional</span></td>
+        <td>JSON array</td>
+        <td>An array of deleted file items following the same structure as the <code>output</code> array.
+          <br />
+          <br />
+          The ability to convey deleted resources is important in cases when a server may have previously returned data
+          and wishes to indicate that these data should be removed from downstream systems. When a
+          timestamp parameter such as <code>_since</code> is supported by the request type and supplied in the kick-off
+          request, this array SHOULD be populated with output files containing
+          FHIR Transaction Bundles that indicate which FHIR resources match the kick-off request criteria, but have been
+          deleted subsequent to the timestamp. If no resources have been deleted, or the
+          timestamp parameter was not supplied, or the server has other reasons to avoid exposing these data,
+          the server MAY omit this key or MAY return an empty array. Resources that appear in the 'deleted' section of
+          a manifest SHALL NOT appear in the 'output' section of the manifest.
+          <br />
+          <br />
+          Each line in the output file SHALL contain a FHIR Bundle with a type of <code>transaction</code> which SHALL
+          contain one or more entry items that reflect a deleted resource. In each entry, the <code>request.url</code>
+          and <code>request.method</code> elements SHALL be populated. The <code>request.method</code> element SHALL be
+          set to <code>DELETE</code>.
+          <br />
+          <br />
+          Example deleted resource bundle (represents one line in output file):
+          <pre><code>{
+&nbsp;"resourceType": "Bundle",
+&nbsp;"id": "bundle-transaction",
+&nbsp;"meta": {"lastUpdated: "2020-04-27T02:56:00Z},
+&nbsp;"type": "transaction",
+&nbsp;"entry":[{
+&nbsp;&nbsp;"request": {"method": "DELETE", "url": "Patient/123"}
+&nbsp;&nbsp;...
+&nbsp;}]
+}</code></pre>
+        </td>
+      </tr>
+      <tr>
+        <td><code>error</code></td>
+        <td><span class="label label-success">required</span></td>
+        <td>Array</td>
+        <td>Array of message file items following the same structure as the <code>output</code> array.
+          <br />
+          <br />
+          Error, warning, and information messages related to the asynchronous operation SHOULD be included here (not in output). If
+          there are no relevant messages, the server SHOULD return an empty array. Only the FHIR
+          <code>OperationOutcome</code> resource type is currently supported, so the server SHALL generate files in the
+          same format as Bulk Data output files that contain FHIR <code>OperationOutcome</code> resources.<br /><br />
+          If the request contained invalid or unsupported parameters along with a <code>Prefer: handling=lenient</code>
+          header and the server processed the request, the server SHOULD include a FHIR <code>OperationOutcome</code>
+          resource for each of these parameters.
+          <br /><br />Note: this field may be renamed in a future version of this specification to reflect the inclusion of FHIR
+          <code>OperationOutcome</code> resources with severity levels other than error.
+        </td>
+      </tr>
+      <tr>
+        <td><code>extension</code></td>
+        <td><span class="label label-info">optional</span></td>
+        <td>JSON object</td>
+        <td>Server implementations may use the extension field to provide custom behavior and information. For example,
+          a server may choose to provide a custom extension that contains a decryption key for encrypted ndjson files.
+          The value of an extension element SHALL be a pre-coordinated JSON object.
+          <br />
+          <br />
+          Note: In addition to extensions being supported on the root object level, extensions may also be included
+          within the fields above (e.g., in the 'output' object).
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Example response body:</p>
+
+  <pre><code class="json language-json">{
+  "transactionTime": "2021-01-01T00:00:00Z",
+  "request" : "https://example.com/fhir/Patient/$export?_type=Patient,Observation",
+  "requiresAccessToken" : true,
+  "output" : [{
+    "type" : "Patient",
+    "url" : "https://example.com/output/patient_file_1.ndjson"
+  },{
+    "type" : "Patient",
+    "url" : "https://example.com/output/patient_file_2.ndjson"
+  },{
+    "type" : "Observation",
+    "url" : "https://example.com/output/observation_file_1.ndjson"
+  }],
+  "deleted": [{
+    "type" : "Bundle",
+    "url" : "https://example.com/output/del_file_1.ndjson"      
+  }],
+  "error" : [{
+    "type" : "OperationOutcome",
+    "url" : "https://example.com/output/err_file_1.ndjson"
+  }],
+  "extension":{"https://example.com/extra-property": true}
+}</code></pre>
+
+  <h3 id="output-file-request">Output File Request</h3>
+
+  <p>Using the URLs supplied by the FHIR server in the Complete Status response body, a client MAY download the
+    generated Bulk Data files (one or more per resource type) within the time period specified in the
+    <code>Expires</code> header (if present). If the <code>requiresAccessToken</code> field in the Complete Status body
+    is set to <code>true</code>, the request SHALL include a valid access token.
+  </p>
+
+  <p>As long as servers are following relevant security guidance, they MAY choose to generate output manifests where
+    <code>requiresAccessToken</code> is true or false; this applies even for servers available on the public internet.
+    When <code>requiresAccessToken</code> is set to <code>false</code> and no additional authorization-related
+    extensions are present on the completion manifest's output entry, then the output URLs SHALL be dereferenceable
+    directly, and SHALL be short lived following the expiration timing requirement that have been documented for bearer
+    tokens in the <a href="https://hl7.org/fhir/uv/bulkdata/authorization/index.html">SMART Backend Services
+      Authorization Guide</a>. In this case, a client MAY re-fetch the output manifest if output links have expired and
+    MAY use the Expires header on the output response, when present, as a hint to know when capability URLs will expire.
+  </p>
+
+  <p>The output data SHALL include only the most recent version of any FHIR resources unless the client explicitly
+    requests different behavior in a fashion supported by the server (e.g., via a new query parameter yet to be
+    defined). Inclusion of the <code>Resource.meta</code> information in the resources is at the discretion of the
+    server (as it is for all FHIR interactions).</p>
+
+  <p>References in the resources returned MAY be relative URLs with the format
+    <code>resourceType</code>/<code>id</code>, or MAY be absolute
+    URLs with the same structure rooted in the base URL for the server from which the asynchronous operation was performed.
+  </p>
+
+  <p>Example NDJSON output file:</p>
+  <pre><code class="json language-json">{"resourceType":"Patient","id":"5c41cecf-cf81-434f-9da7-e24e5a99dbc2","name":[{"given":["Brenda"],"family":["Jackson"]}],"gender":"female","birthDate":"1956-10-14T00:00:00.000Z"}
+{"resourceType":"Patient","id":"3fabcb98-0995-447d-a03f-314d202b32f4","name":[{"given":["Bram"],"family":["Sandeep"]}],"gender":"male","birthDate":"1994-11-01T00:00:00.000Z"}
+{"resourceType":"Patient","id":"945e5c7f-504b-43bd-9562-a2ef82c244b2","name":[{"given":["Sandy"],"family":["Hamlin"]}],"gender":"female","birthDate":"1988-01-24T00:00:00.000Z"}
+</code></pre>
+
+  <h5 id="output-file-headers">Headers</h5>
+  <ul>
+    <li><code>Accept</code> (optional, defaults to <code>application/fhir+ndjson</code>)</li>
+  </ul>
+
+  <p>Specifies the format of the file being requested.</p>
+
+  <h5 id="output-file-response---success">Response - Success</h5>
+
+  <ul>
+    <li>HTTP status of <code>200 OK</code></li>
+    <li><code>Content-Type</code> header that matches the file format being delivered. For files in ndjson format, SHALL
+      be <code>application/fhir+ndjson</code></li>
+    <li>Body of FHIR resources in newline delimited json - <a href="http://ndjson.org/">ndjson</a> or other requested
+      format</li>
+  </ul>
+
+  <h5 id="output-file-response---error">Response - Error</h5>
+
+  <ul>
+    <li>HTTP Status Code of <code>4XX</code> or <code>5XX</code></li>
+  </ul>
+
+  <h5 id="attachments">Attachments</h5>
+
+  <p>If resources in an output file contain elements of the type <code>Attachment</code>, the server SHOULD populate the
+    <code>Attachment.contentType</code> code as well as either the <code>data</code> element or the <code>url</code>
+    element. When populated, the <code>url</code> element SHALL be an absolute url that can be de-referenced to the
+    attachment’s content.
+  </p>
+
+  <p>When the <code>url</code> element is populated with an absolute URL and the <code>requiresAccessToken</code> field
+    in the Complete Status body is set to <code>true</code>, the url location must be accessible by a client with a
+    valid access token, and SHALL NOT require the use of additional authentication credentials. When the
+    <code>url</code> element is populated and the <code>requiresAccessToken</code> field in the Complete Status body is
+    set to <code>false</code> and no additional authorization-related extensions are present on a the Complete Status
+    body's output entry, the url location SHALL be dereferenceable directly, and SHALL be short lived following the 
+    expiration timing requirement that have been documented for bearer
+    tokens in the <a href="https://hl7.org/fhir/uv/bulkdata/authorization/index.html">SMART Backend Services Authorization Guide</a>.
+  </p>
+
+  <p>Note that if a server copies files to the Bulk Data output endpoint or proxies requests to facilitate access from
+    this endpoint, it may need to modify the <code>Attachment.url</code> element when generating the Bulk Data output
+    files.</p>
+
+  [%file newfooter%]
+</body>
+
+</html>

--- a/source/async-bundle.html
+++ b/source/async-bundle.html
@@ -1,0 +1,204 @@
+<!DOCTYPE HTML>
+
+[%settitle Asynchronous interaction pattern%]
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  [%file newheader%]
+</head>
+
+<body>
+  [%file newnavbar%]
+
+
+  <h2 id="asynchronous-request-pattern">Asynchronous Interaction Request Pattern</h2>
+  <table class="colsd">
+    <tr>
+      <td id="wg"><a _target="blank" href="[%wg fhir%]">[%wgt fhir%]</a> Work Group</td>
+      <td id="fmm"><a href="versions.html#maturity">Maturity Level</a>: 1</td>
+      <td id="ballot"><a href="versions.html#std-process">Standards Status</a>:
+        <!--!ns!--><a href="versions.html#std-process">Draft</a>
+      </td>
+    </tr>
+  </table>
+
+  [%impl-note%]
+  The FHIR Asynchronous Interaction Request Pattern API is under active development. Participate in design discussions
+  at <a href="https://chat.fhir.org/">chat.fhir.org</a></p>
+  [%end-note-np%]
+
+  <h3 id="use-case">Use Case</h3>
+  <p>All of the interactions defined in the <a href="http.html">RESTful API</a> are described as synchronous operations
+    - that is, the client makes a query and waits for the server to respond with the outcome in the HTTP response. This
+    pattern is not always suitable when significant server side processing is necessary.</p>
+  <p>The asynchronous request pattern, based on <a href="https://tools.ietf.org/html/rfc7240#section-4.1">rfc 7240</a>,
+    caters to this use case and is applicable in <a href="operations.html">Operations</a> and <a
+      href="http.html">Defined Interactions</a> that are not processed synchronously or may take a lot of time to
+    process. For example, servers that accept a high volume sensor data and queue it for saving, or an operation that
+    re-indexes the data in a server to add a new search parameter. Servers may choose which interactions the pattern
+    should be supported on (if at all).</p>
+
+  <h4 id="compare-with">Related Pattern: Asynchronous Bulk Data Request</h4>
+  <p>For use cases that may return a large amount of data, see <a href="async-bulk.html">Asynchronous Bulk Data
+      Request</a>.</p>
+
+  <h3 id="kick-off-request">Kick-off Request</h3>
+  <p>The request will support the HTTP methods, URLs, headers and other parameters that normally apply, but servers
+    SHALL also support the <code>Prefer</code> header described below. The <code>Accept</code> header in the request
+    will dictate the format of the Bundle Resource returned when the request completes successfully or an
+    OperationOutcome Resource when it fails, as well any the format for any OperationOutcome Resources returned to
+    indicate a transient polling error while the request is being processed.</p>
+  <p>If an <code>_outputFormat</code> parameter is supplied as part of the request, the server SHALL respond using the
+    <a href="async-bulk.html">Asynchronous Bulk Data Request</a> pattern, or if this pattern is not supported by the
+    server
+    for the current request type, SHALL return an error and <a href="OperationOutcome.html">OperationOutcome
+      Resource</a>.
+  </p>
+
+  <h5 id="headers">Headers</h5>
+  <ul>
+    <li>
+      <p><code>Accept</code> (string)</p>
+      <p>Specifies the format of the optional <a href="OperationOutcome.html">OperationOutcome Resource</a> response to
+        the kick-off request. A client SHOULD provide this header. A server may support any subset of the <a
+          href="formats.html#wire">Serialization Format Representations</a>. If omitted, the server MAY return an error
+        or MAY process the request and return a format selected by the server format.</p>
+    </li>
+    <li>
+      <p><code>Prefer</code> (string, required)</p>
+      <p>Specifies whether the response is immediate or asynchronous. Setting this to <code>respond-async</code>
+        triggers this async pattern.</p>
+    </li>
+  </ul>
+
+  <h5 id="kick-off-response---success">Response - Success</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code> </li>
+    <li><code>Content-Location</code> header with the absolute URL of an endpoint for subsequent status requests
+      (polling location)</li>
+    <li>Optionally, a <a href="OperationOutcome.html">OperationOutcome Resource</a> in the body</li>
+  </ul>
+
+  <h5 id="kick-off-response---error">Response - Error (e.g. unsupported search parameter)</h5>
+  <ul>
+    <li>HTTP Status Code of <code>4XX</code> or <code>5XX</code></li>
+    <li>The body SHALL be a <a href="OperationOutcome.html">OperationOutcome Resource</a></li>
+  </ul>
+  <hr />
+
+  <h3 id="delete-request">Delete Request</h3>
+
+  <p>After an asynchronous request has been started, a client MAY send a http DELETE request to the URL provided in the
+    <code>Content-Location</code> header to cancel the request. Following the delete request, when subsequent requests
+    are made to the polling location, the server SHALL
+    return a <code>404 Not Found</code> error and an associated <a href="OperationOutcome.html">OperationOutcome
+      Resource</a>.
+  </p>
+
+  <h5 id="delete-response---success">Response - Success</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code></li>
+    <li>Optionally a FHIR OperationOutcome in the body</li>
+  </ul>
+
+  <h5 id="delete-response---error">Response - Error</h5>
+  <ul>
+    <li>HTTP status code of <code>4XX</code> or <code>5XX</code></li>
+    <li>Optionally a <a href="OperationOutcome.html">OperationOutcome Resource</a> in the body</li>
+  </ul>
+
+  <h3 id="status-request">Status Request</h3>
+
+  <p>After an asynchronous request has been started, the client MAY poll the status URL provided in the
+    <code>Content-Location</code> header by issuing HTTP GET requests to the location.
+  </p>
+
+  <p>A client SHOULD follow an <a href="https://en.wikipedia.org/wiki/Exponential_backoff">exponential backoff</a>
+    approach when polling for status. A server SHOULD supply a <a
+      href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After"><code>Retry-After</code></a> header
+    with a with a delay time in seconds (e.g., <code>120</code> to represent two minutes) or a http-date (e.g.,
+    <code>Fri, 31 Dec 1999 23:59:59 GMT</code>). When provided, a client SHOULD use this information to inform the
+    timing of future polling requests. The server SHOULD keep an accounting of status queries received from a given
+    client, and if a client is polling too frequently, the server SHOULD respond with a
+    <code>429 Too Many Requests</code> status code in addition to a <code>Retry-After</code> header, and optionally a <a
+      href="OperationOutcome.html">OperationOutcome Resource</a> with further explanation. If excessively frequent
+    status queries persist, the server MAY return a <code>429 Too Many Requests</code> status code and terminate the
+    session. Other standard HTTP <code>4XX</code> as well as <code>5XX</code> status codes may be used to identify
+    errors as mentioned.
+  </p>
+
+  <h5 id="status-response---in-progress">Response - In-Progress</h5>
+  <ul>
+    <li>HTTP Status Code of <code>202 Accepted</code></li>
+    <li>Optionally an <code>X-Progress</code> header with a text description of the status of the request that is less
+      than 100 characters. The format of this description is at the server's discretion and MAY be a percentage complete
+      value, or MAY be a more general status such as "in progress". The client MAY parse the description, display it to
+      the user, or log it.</li>
+  </ul>
+
+  <h5 id="status-response---error">Response - Error</h5>
+  <ul>
+    <li>HTTP status code of <code>4XX</code> or <code>5XX</code></li>
+    <li>The body of the response SHOULD be a <a href="OperationOutcome.html">OperationOutcome Resource</a>.
+      If this is not possible (for example, the infrastructure layer returning the error is not FHIR
+      aware), the server MAY return an error message in another format and include a corresponding value for the
+      <code>Content-Type</code> header.
+    </li>
+  </ul>
+
+  <p>Servers SHOULD NOT use status request failures to indicate a problem processing the original request. Rather,
+    status request failures SHOULD use a <a href="codesystem-issue-type.html#issue-type-transient">transient code</a>
+    from the <a href="codesystem-issue-type.html">IssueType valueset</a> when populating the <a
+      href="OperationOutcome.html">OperationOutcome Resource</a> <code>issue.code</code> element to indicate to the
+    client that it should retry the request at a later time.</p>
+
+  <h5 id="status-response---complete">Response - Complete</h5>
+  <ul>
+    <li>HTTP status of <code>200 OK</code></li>
+    <li>
+      A body containing a <a href="bundle.html">Bundle Resource</a> with a type of <code>batch-response</code>.
+    </li>
+  </ul>
+  <p>
+    The outcome of the kick-off request SHALL be present as the first entry in the bundle. A successful completion
+    of the status request SHOULD be used whenever processing has completed, regardless of whether the underlying
+    interaction has succeeded or failed. A server SHOULD use the <code>status</code> and <code>outcome</code>
+    elements of <code>Bundle.entry[0].response</code> to communicate any processing errors.
+  </p><p>
+    For example, if a client asynchronously invokes a hypothetical <code>$example</code> operation but omits a
+    required parameter, the server would respond with a
+    <code>200 OK</code> on the status request once processing is complete, and would include a
+    <code>Bundle.entry[0].response.code</code> element with a value of <code>400 Bad Request</code>
+    and a <code>Bundle.entry[0].response.outcome</code> with a <a href="OperationOutcome.html">OperationOutcome Resource</a>
+    containing details about the error.
+  </p>
+
+  <p>Example output bundle:</p>
+  <pre><code class="json language-json">{
+  "resourceType": "Bundle",
+  "type": "batch-response",
+  "entry": [{
+    "response": {
+        "status": "200 OK", 
+        "location": "Observation/123"
+        // additional fields if needed
+        //  * etag
+        //  * lastModified
+        //  * outcome
+    },
+    "resource": {
+      // populated whenever a non-asynchronous
+      // interaction would have included a resource in the
+      // response body -- e.g. if client initially specified
+      // `Prefer: return=representation`
+      "resourceType": "Observation",
+      "id": "123", 
+      // ... snipped for brevity
+    }
+  }]
+}</code></pre>
+
+  [%file newfooter%]
+</body>
+
+</html>

--- a/source/async.html
+++ b/source/async.html
@@ -1,150 +1,53 @@
 <!DOCTYPE HTML>
 
-[%settitle Asynchronous pattern%]
+[%settitle Asynchronous patterns%]
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
 <head>
-[%file newheader%]
+  [%file newheader%]
 </head>
+
 <body>
-[%file newnavbar%]
+  [%file newnavbar%]
 
 
-<h2 id="asynchronous-request-pattern">Asynchronous Request Pattern</h2>
-<table class="colsd"><tr><td id="wg"><a _target="blank" href="[%wg fhir%]">[%wgt fhir%]</a> Work Group</td><td id="fmm"><a href="versions.html#maturity">Maturity Level</a>: 2</td><td id="ballot"><a href="versions.html#std-process">Standards Status</a>:<!--!ns!--><a href="versions.html#std-process">Draft</a></td></tr></table>
+  <h2 id="asynchronous-request-patterns">Asynchronous Request Patterns</h2>
+  <table class="colsd">
+    <tr>
+      <td id="wg"><a _target="blank" href="[%wg fhir%]">[%wgt fhir%]</a> Work Group</td>
+      <td id="fmm"><a href="versions.html#maturity">Maturity Level</a>: N/A</td>
+      <td id="ballot"><a href="versions.html#std-process">Standards Status</a>:
+        <!--!ns!--><a href="versions.html#std-process">Informative</a>
+      </td>
+    </tr>
+  </table>
 
-[%impl-note%]
-the FHIR Asynchronous API and the $export Operation are under active development:</p>
-<ul>
-<li>Visit the <a href="https://github.com/smart-on-fhir/fhir-bulk-data-docs">Draft FHIR Bulk Data Repository</a> for the most recent draft documentation and open issues</li>
-<li>Participate in design discussions at <a href="https://chat.fhir.org/#narrow/stream/bulk.20data">chat.fhir.org</a></li>
-</ul>
-[%end-note-np%]
+  <h3 id="use-case">Use Case</h3>
+  <p>All of the interactions defined in the <a href="http.html">RESTful API</a> are described as synchronous operations
+    - that is, the client makes a query and waits for the server to respond with the outcome in the HTTP response. This
+    pattern is not always suitable when significant server side processing is necessary or when substantial amounts of
+    data must be returned.</p>
+  <p>A good example of this is the <a href="https://hl7.org/fhir/uv/bulkdata/export.html">$export operation</a>, where
+    simple searches may result in large amounts of data.</p>
+  <p>The asynchronous request patterns, based on <a href="https://tools.ietf.org/html/rfc7240#section-4.1">rfc 7240</a>,
+    cater to this use case and can be used for FHIR <a href="http.html">Defined Interactions</a> and <a
+      href="operations.html">Operations</a>.
+  </p>
 
-<h3 id="use-case">Use Case</h3>
-<p>All of the interactions defined in the <a href="http.html">RESTful API</a> are described as synchronous operations - that is, the client makes a query and waits for the server to respond with the outcome in the HTTP response. This pattern is not suitable once significant server side processing becomes necessary or when substantial amounts of data must be returned.</p>
-<p>A good example of this is the <a href="https://github.com/smart-on-fhir/fhir-bulk-data-docs/blob/master/export.md">$export operation</a>, where simple searches may result in large amounts of data. </p>
-<p>The asynchronous request pattern, based on <a href="https://tools.ietf.org/html/rfc7240#section-4.1">rfc 7240</a>, caters to this use case and is applicable for all the <a href="http.html">Defined Interactions</a> and for <a href="operations.html">Operations</a>, although for many of these uses it brings no benefit. Servers may choose which interactions the pattern should be supported on (if at all), and servers may choose to only support some of the operations using the asynchronous pattern.</p>
-<hr/>
-<h3 id="kick-off-request">Kick Off Request</h3>
-<p>The request will have whatever URL and other parameters would normally apply, but must include the headers described below.</p>
-<p><code>GET [FHIR API Request]</code></p>
-<h5 id="headers">Headers</h5>
-<ul>
-<li><p><code>Prefer</code> (required)</p>
-<p>Specifies whether the response is immediate or asynchronous. Setting this to <code>respond-async</code> triggers the async pattern.</p></li>
-<li><p><code>Accept</code> (required)</p>
-<p>Specifies the format of the optional OperationOutcome response to the kick-off request. Any of the <a href="formats.html#wire">Serialization Format Representations</a> are  supported.</p></li>
-</ul>
-<h5 id="query-string-parameters">Query String Parameters</h5>
-<ul>
-<li><p><code>_outputFormat</code> (string, optional, defaults to <code>application/fhir+ndjson</code>)</p>
-<p>The format for the generated bulk data files. Currently, <a href="http://ndjson.org/">ndjson</a> must be supported, though servers may choose to also support other output formats. Servers should support the full content type of <code>application/fhir+ndjson</code> as well as abbreviated representations including <code>application/ndjson</code> and <code>ndjson</code>.</p></li>
-</ul>
-<h5 id="response---success">Response - Success</h5>
-<ul>
-<li>HTTP Status Code of <code>202 Accepted</code> </li>
-<li><code>Content-Location</code> header with a url for subsequent status requests</li>
-<li>Optionally a FHIR OperationOutcome in the body</li>
-</ul>
-<h5 id="response---error-eg-unsupported-search-parameter">Response - Error (e.g. unsupported search parameter)</h5>
-<ul>
-<li>HTTP Status Code of <code>4XX</code> or <code>5XX</code></li>
-<li>Optionally a FHIR OperationOutcome in the body</li>
-</ul>
-<hr/>
-<h3 id="bulk-data-delete-request">Bulk Data Delete Request:</h3>
-<p>After a bulk data request has been kicked-off, clients can send a delete request to the url provided in the <code>Content-Location</code> header to cancel the request.</p>
-<h5 id="endpoint">Endpoint</h5>
-<p><code>DELETE [polling content location]</code></p>
-<h5 id="response---success-1">Response - Success</h5>
-<ul>
-<li>HTTP Status Code of <code>202 Accepted</code></li>
-<li>Optionally a FHIR OperationOutcome in the body</li>
-</ul>
-<h5 id="response---error-status">Response - Error Status</h5>
-<ul>
-<li>HTTP status code of <code>4XX</code> or <code>5XX</code></li>
-<li>Optionally a FHIR OperationOutcome in the body</li>
-</ul>
-<hr/>
-<h3 id="bulk-data-status-request">Bulk Data Status Request:</h3>
-<p>After a bulk data request has been kicked-off, clients can poll the url provided in the <code>Content-Location</code> header to obtain the status of the request. </p>
-<p>Note: Clients should follow an <a href="https://en.wikipedia.org/wiki/Exponential_backoff">exponential backoff</a> approach when polling for status. Servers may supply a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After">Retry-After header</a> with a http date or a delay time in seconds. When provided, clients should use this information to inform the timing of future polling requests.</p>
-<p>Note: The <code>Accept</code> header for this request should be <code>application/json</code>. In the case that errors prevent the export from completing, the response will contain a JSON-encoded FHIR OperationOutcome resource. </p>
-<h5 id="endpoint-1">Endpoint</h5>
-<p><code>GET [polling content location]</code></p>
-<h5 id="response---in-progress-status">Response - In-Progress Status</h5>
-<ul>
-<li>HTTP Status Code of <code>202 Accepted</code></li>
-<li>Optionally an <code>X-Progress</code> header with a text description of the status of the request that's less than 100 characters. The format of this description is at the server's discretion and may be a percentage complete value or a more general status such as "in progress". Clients can try to parse this value, display it to the user, or log it.</li>
-</ul>
-<h5 id="response---error-status-1">Response - Error Status</h5>
-<ul>
-<li>HTTP status code of <code>5XX</code></li>
-<li>Optionally a JSON FHIR OperationOutcome in the body</li>
-<li>Even if some resources cannot successfully be exported, the overall export operation may still succeed. In this case, the <code>Response.error</code> array of the completion Response must be populated (see below) with one or more files in ndjson format containing <code>OperationOutcome</code> resources to indicate what went wrong.</li>
-</ul>
-<h5 id="response---complete-status">Response - Complete Status</h5>
-<ul>
-<li><p>HTTP status of <code>200 OK</code></p></li>
-<li><p><code>Content-Type header</code> of <code>application/json</code></p></li>
-<li><p>Optionally an <code>Expires</code> header indicating when the files listed will no longer be available.</p></li>
-<li><p>A body containing a json object providing metadata and links to the generated bulk data files.</p>
-<p>Required Fields:</p></li>
-<li><p><code>transactionTime</code> - a FHIR instant type that indicates the server's time when the query is run. No resources that have a modified data after this instant should be in the response.</p></li>
-<li><p><code>request</code> - the full url of the original bulk data kick-off request</p></li>
-<li><p><code>requiresAccessToken</code> - boolean value indicating whether downloading the generated files will require an authentication token. Note: This may be false in the case of signed S3 urls or an internal file server within an organization's firewall.</p></li>
-<li><p><code>output</code> - array of bulk data file items with one entry for each generated file. Note: If no data is returned from the kick-off request, the server should return an empty array. </p></li>
-<li><p><code>error</code> - array of error file items following the same structure as the <code>output</code> array. Note: If no errors occurred, the server should return an empty array.  Note: Only the <code>OperationOutcome</code> resource type is currently supported, so a server will generate ndjson files where each row is an <code>OperationOutcome</code> resource.</p>
-<p>Each file item should contain the following fields:</p></li>
-<li><p><code>type</code> - the FHIR resource type that is contained in the file. Note: Each file may only contain resources of one type, but a server may create more than one file for each resources type returned. The number of resources contained in a file is may vary between servers. If no data is found for a resource, the server should not return an output item for it in the response.</p></li>
-<li><p><code>url</code> - the path to the file. The format of the file should reflect that requested in the <code>_outputFormat</code> parameter of the initial kick-off request.</p>
-<p>Each file item may optionally contain the following field:</p></li>
-<li><p><code>count</code> - the number of resources in the file, represented as a JSON number.</p>
-<p>Example response body:</p>
-<pre><code class="json language-json">{
-  "transactionTime": "[instant]",
-  "request" : "[base]/Patient/$export?_type=Patient,Observation", 
-  "requiresAccessToken" : true,
-  "output" : [{
-    "type" : "Patient",
-    "url" : "http://serverpath2/patient_file_1.ndjson"
-  },{
-    "type" : "Patient",
-    "url" : "http://serverpath2/patient_file_2.ndjson"
-  },{
-    "type" : "Observation",
-    "url" : "http://serverpath2/observation_file_1.ndjson"
-  }],
-  "error" : [{
-    "type" : "OperationOutcome",
-    "url" : "http://serverpath2/err_file_1.ndjson"
-  }]
-}</code></pre></li>
-</ul>
-<hr/>
-<h3 id="file-requests">File Requests:</h3>
-<p>Using the urls supplied in the completed status request body, clients can download the generated bulk data files (one or more per resource type). Note: These files may be served by a file server rather than a FHIR specific server. Also, if the <code>requiresAccessToken</code> field in the status body is set to <code>true</code> the request must include a valid access token in the <code>Authorization</code> header in these requests (i.e., <code>Authorization: Bearer {{token}}</code>).</p>
-<h5 id="endpoint-2">Endpoint</h5>
-<p><code>GET [url from status request output field]</code></p>
-<h5 id="headers-1">Headers</h5>
-<ul>
-<li><code>Accept</code> (optional, defaults to <code>application/fhir+ndjson</code>)</li>
-</ul>
-<p>Specifies the format of the file being returned. Optional, but currently only application/fhir+ndjson is supported.</p>
-<h5 id="response---success-2">Response - Success</h5>
-<ul>
-<li>HTTP status of <code>200 OK</code></li>
-<li><code>Content-Type</code> header of <code>application/fhir+ndjson</code></li>
-<li>Body of FHIR resources in newline delimited json - <a href="http://ndjson.org/">ndjson</a> format</li>
-</ul>
-<h5 id="response---error">Response - Error</h5>
-<ul>
-<li>HTTP Status Code of <code>4XX</code> or <code>5XX</code></li>
-</ul>
+  <h3 id="patterns">Patterns</h3>
+  <ul>
+    <li><a href="async-bulk.html">Asynchronous Bulk Data Request</a> - for use in FHIR <a href="operations.html">Operations</a>
+      and <a href="http.html">Defined Interactions</a> that return a large amount of data. This pattern returns a
+      manifest with links to data files containing FHIR resources.
+    </li>
+    <li><a href="async-bundle.html">Asynchronous Interaction Request</a> - for use in FHIR <a
+        href="operations.html">Operations</a> and <a href="http.html">Defined Interactions</a> that are not processed
+      synchronously or may take a lot of time to process. For example, a server that accepts a high volume of sensor data and
+      queues it for saving, or an operation that re-indexes the data in a server to add a new search parameter. This
+      pattern returns a <a href="bundle.html">Bundle Resource</a>.</li>
+  </ul>
 
-[%file newfooter%]
+  [%file newfooter%]
 </body>
+
 </html>
-
-

--- a/source/hierarchy.xml
+++ b/source/hierarchy.xml
@@ -149,7 +149,10 @@ signatures.html
         <page title="_filter Parameter" filename="search_filter.html"/>
         <page title="Search Parameter Registry" filename="searchparameter-registry.html"/>
         <page title="FHIRPath Patch" filename="fhirpatch.html"/>
-        <page title="Asynchronous API" filename="async.html"/>
+        <page title="Asynchronous API" filename="async.html">
+          <page title="Asynchronous Bulk Data Request" filename="async-bulk.html"/>
+          <page title="Asynchronous Interaction Request" filename="async-bundle.html"/>
+        </page>
       </page>
       <page title="Operations" filename="operations.html">
         <page title="Example" filename="op-example-request.html"/>


### PR DESCRIPTION
First pass at addressing https://jira.hl7.org/browse/FHIR-35936

This is following up from discussion at the January 2022 working group meeting where FHIR-I agreed to update the async page with content from the DSTU2 Bulk IG and change the maturity level to reflect current adoption. We think it probably makes sense to break the operation into a FMM4 page for the bulk export pattern and a FMM0 page for interactions that asynchronously return smaller data sets.