### PR TITLE
Moehrke security pages

### DIFF
--- a/source/secpriv-module.html
+++ b/source/secpriv-module.html
@@ -122,8 +122,11 @@ Full audit trails can be constructed and used to detect anomalous access pattern
 For general security considerations and principles, see <a href="security.html">Security</a>.
 Please leverage mature Security Frameworks covering device security, cloud security, big-data security, service-to-service security, etc.
 See <a href="https://nccoe.nist.gov/projects/building_blocks/mobile_device_security"> NIST Mobile Device Security</a>
-and <a href="https://www.owasp.org/index.php/Mobile_Top_10_2016-Top_10">OWASP Mobile Security</a>. 
+and <a href="https://www.owasp.org">OWASP</a>. 
 These security frameworks include prioritized lists of most important concerns.
+</p>
+<p>
+Recent evidence indicates lack of implementer attention to addressing common security vulnerabilities emphasized by <a href="https://owasp.org/www-project-api-security/">OWASP top 10 API</a>.   Reviewing the <a href="https://owasp.org/www-project-top-ten/">OWASP Top Ten</a>and <a href="https://owasp.org/www-project-mobile-top-10/">OWASP mobile top 10</a> and ensuring those vulnerabilities are mitigated is important for good security.
 </p>
 <a name="privacy"></a>
 <h3>Privacy</h3>
@@ -175,6 +178,9 @@ see <a href="security.html#authentication">Security: Authentication</a> as an
 externally-reviewed authorization mechanism with a real-world deployment base -
 but we note that community efforts are underway to explore a variety of
 approaches to authorization. 
+</p><p>
+Resource Servers MUST enforce the authorization associated with the access token. This enforcement includes verification of the token, verification of the token expiration, and might include using introspection to verify the token has not been revoked. This enforcement includes constraining results returned to the scopes authorized by the access token. The Resource server might have further access controls beyond those in the token to enforce, such as Consent or business rules.
+</p><p>
 For further details, see <a href="security.html#binding">Security: Authorization and Access Control</a>.
 
 </p>
@@ -210,6 +216,10 @@ be conveyed using standard codes from <a href="valueset-security-role-type.html"
 </p><p>
 A purpose of use should be asserted for each requested action on a Resource.  Purpose of use 
 should be conveyed using standard codes from <a href="v3/PurposeOfUse/vs.html">Purpose of Use Vocabulary</a>.
+</p><p>
+The FHIR core specification does not include a "User" resource, as a User resource would be general IT and used well
+beyond healthcare workflows. A RESTful User resource is defined in 
+the <a href="https://en.wikipedia.org/wiki/System_for_Cross-domain_Identity_Management">System for Cross-domain Identity Management (SCIM) specification</a>.
 </p><p>
 When using OAuth, the requested action on a Resource for specified one or more purpose of use and 
 the role of the user are managed by the OAuth authorization service (AS) and may be communicated 
@@ -253,6 +263,8 @@ For details, see
 <em>Approach:</em> The AuditEvent resource can inform this report.
 </p><p>
 There are many motivations to provide a Patient with some report on how their data was used. There is a very restricted version of this in HIPAA as an "Accounting of Disclosures", there are others that would include more accesses. The result is a human readable report. The raw material used to create this report can be derived from a well recorded 'security audit log', specifically based on AuditEvent. The format of the report delivered to the Patient is not further discussed but might be: printed on paper, PDF, comma separated file, or FHIR Document made up of filtered and crafted AuditEvent Resources.  The report would indicate, to the best ability, Who accessed What data from Where at When for Why purpose. The 'best ability' recognizes that some events happen during emergent conditions where some knowledge is not knowable. The report usually does need to be careful not to abuse the Privacy rights of the individual that accessed the data (Who).  The report would describe the data that was accessed (What), not duplicate the data. 
+</p><p>
+In order to enable Privacy Accounting of Disclosures and Access Logs, and to enable privacy office and security office audit log analysis, <a href="auditevent.html#patient">all AuditEvent records should include a reference to the Patient/Subject</a> of the activity being recorded. Reasonable efforts should be taken to assure the Patient/Subject is recorded, but it is recognized that there are times when this is not reasonable. See deeper details on AuditEvent.
 </p><p>
 Some events are known to be subject to the Accounting of Disclosures report when the event happens, thus can be recorded as an Accounting of Disclosures  - See <a href="auditevent-example-disclosure.html">example Accounting of Disclosures</a>.  Other events must be pulled from the security audit log. A security audit log will record ALL actions upon data regardless of if they are reportable to the Patient. This is true because the security audit log is used for many other purposes. - See <a href="security.html#audit">Audit Logging</a>. These recorded AuditEvents may need to be manipulated to protect organization or employee (provider) privacy constraints. Given the large number of AuditEvents, there may be multiple records of the same actual access event, so the reporting will need to de-duplicate.
 
@@ -356,6 +368,16 @@ to the Requesting Client would be de-identified.
 <em>Consideration:</em> This assumes the system knows the type and intensity of the de-identification algorithm, where 
 de-identification is best viewed as a process, not an algorithm - a process that reduces Privacy risk while enabling a targeted and authorized use-case.
 </p><p>
+<ul>
+<li>
+<b>Direct-Identifier</b> - ISO/IEC 20889:2018 - attribute that alone enables unique identification of a data principal within a specific operational context. The operational context includes the information that the entity processing (e.g. de-identifying) the data processes, together with information that third parties and potential attackers can possess or that is in the public domain.
+</li><li>
+<b>Indirect-Identifier</b> - ISO/IEC 20889:2018 - attribute that, together with other attributes that can be in the dataset or external to it, enables unique identification of a data principal within a specific operational context.
+</li><li>
+<b>Quasi-Identifier</b> - ISO/IEC 20889:2018 - attribute in a dataset that, when considered in conjunction with other attributes in the dataset, singles out a data principal.
+</li></ul>
+Note that often Quasi-Identifier and Indirect-Identifier are often considered the same way.
+</p><p>
 <em>Modifying an element:</em> The de-identification process may determine that specific elements need to be modified to lower privacy 
 risk. Some methods of modifying are: eliminating the element, setting to a static value (e.g. "removed"), fuzzing (e.g. adjusting by 
 some random value), masking (e.g. encryption), pseudonym (e.g. replace with an alias), etc. <a href="narrative.html">Narrative</a> and <a href="datatypes.html#Attachment">Attachment</a> elements present particularly difficult challenges.
@@ -381,8 +403,8 @@ need to be consistent with each other.
 </p><p>
 Some identifiers in Observation Resource:
 <ul>
-<li>Direct Identifiers: .identifier, .subject, .performer, .encounter, .focus, .note, .specimen, .basedOn</li>
-<li>Indirect Identifiers: .category, .code, .issued, .effective[x], .method, .bodySite, .interpretation, .value[x], .component</li>
+<li><b>Direct-Identifiers</b>: .identifier, .subject, .performer, .encounter, .focus, .note, .specimen, .basedOn</li>
+<li><b>Indirect-Identifiers</b>: .category, .code, .issued, .effective[x], .method, .bodySite, .interpretation, .value[x], .component</li>
 </ul>
 </p>
 <p>
@@ -400,7 +422,9 @@ different risk than internal sharing of data within a tightly managed organizati
 <em>Security-label:</em> The resulting Resource should be marked with security-label to indicate that it has been de-identified. This would assure that downstream use doesn't mistake this Resource as representing full fidelity. These security-labels come from the Security Integrity Observation ValueSet. Some useful security-tag vocabulary: ANONYED, MASKED, PSEUDED, REDACTED
 </p><p>
 Further Standards: 
-<a href="http://www.iso.org/iso/catalogue_detail?csnumber=42807">Health: ISO Pseudonymization</a>, 
+<a href="https://www.iso.org/standard/45123.html">ISO/IEC 29100 Information technology - Security techniques - Privacy framework</a>, 
+<a href="https://www.iso.org/standard/69373.html">ISO/IEC 20889 Privacy enhancing data de-identification terminology and classification of techniques</a>, 
+<a href="https://www.iso.org/standard/63553.html">ISO/TS 25237 Health informatics - Pseudonymization</a>, 
 <a href="http://nvlpubs.nist.gov/nistpubs/ir/2015/NIST.IR.8053.pdf">NIST IR 8053 - De-Identification of Personal Information</a>, 
 <a href="http://wiki.ihe.net/index.php/Healthcare_De-Identification_Handbook">IHE De-Identification Handbook</a>, 
 <a href="http://dicom.nema.org/medical/dicom/current/output/html/part15.html#chapter_E">DICOM (Part 15, Chapter E)</a>

--- a/source/security-labels.html
+++ b/source/security-labels.html
@@ -72,7 +72,7 @@ that allow much finer grained management of the information.
 A security label is represented as a <a href="datatypes.html#Coding">Coding</a>, with the
 following important properties:
 </p>
-<table>
+<table  class="grid">
   <tr> <td>system</td> <td>The coding scheme from which label is taken (see <a href="terminologies-systems.html">code system URI</a>, and below) </td></tr>
   <tr> <td>code</td> <td>a code from the coding scheme that identifies the security label  and code is a value from the code system</td> </tr>
   <tr> <td>display</td> <td>The display form for the code (mostly for use when a system doesn't recognize the code)</td> </tr>
@@ -152,6 +152,16 @@ This specification defines a set of core security labels for all FHIR systems.
 All conformant FHIR Applications SHOULD use these labels where appropriate.
 For all these labels, how they are operationalized - their use and interpretation - is subject
 to the applicable Mutual Trust Framework agreement as described above.
+</p><p>
+The Security Label vocabulary has three patterns of use: (1) Bundle: Security/Privacy considerations of a data set, (2) Context: Describe security/privacy context of a request for data, and (3) Meta Data: to indicate security/privacy meta about that data. 
+</p><p>
+Bundle: A bundle is a container for a collection of data. Some uses of bundle are for communicating search results, sending data, or persisting data (See Bundle). The Bundle would carry meta about the data contained in the bundle. Specifically the confidentiality 'high water" mark, the authorized purposeOfUse, the required compartment clearance, Refrain, and Obligations that must be maintained. Where the "high water" mark is an indication of the most high confidentiality. Depending on Policy, the Bundle might include the cross-section of sensitivity or integrity, although this is usually not included. 
+</p><p>
+Context: Requests (e.g. Read, Query, message triggers) - would describe the context of the request using purposeOfUse and compartment/clearance. The request might declare the highest confidentiality desired. It is unlikely to see in a request a declaration of sensitivity or integrity. It is also unlikely to see Obligations within a Request. (See Bundle for Response, where these are appropriate)
+</p><p>
+Meta Data: All resources have a meta.security element to hold descriptions (meta) about the data relative to privacy and security risk. Thus data may be tagged with confidentiality, sensitivity, and integrity. The data might be tagged with the indication of collection context using compartment or purposeOfUse. Data would not typically be tagged with Refrain, or Obligations.
+</p><p>
+ More complex use of tagging in the data resource, bundle, context, or in Provenance, is possible.
 </p>
 
 <table class="grid">
@@ -274,7 +284,8 @@ At a minimum, implementations must ensure:
 <ul>
  <li>How, when and why to initiate the break-the-glass is well understood</li>
  <li>Appropriate authorization, consent checking, and access control is used to ensure it is used properly (e.g. if using OAuth, checking that the Authorization Server allows this)</li>
- <li>Any use is well-represented in an <a href="auditevent.html">AuditEvent</a> (todo: profile for break the glass)</li>
+ <li>Any use is well-represented in an <a href="auditevent.html">AuditEvent</a> break the glass <a href="auditevent-example-breakglass-start.html">example</a>.</li>
+ <li>Note an example <a href="operationoutcome-example-break-the-glass.html">OperationOutcome that might be used to indicate potential for break-glass</a>.</li>
 </ul>
 <p>
 See <a href="http://www.hl7.org/search/viewSearchResult.cfm?search_id=393442&amp;search_result_url=%2Fdocumentcenter%2Fpublic%2Fwg%2Fsecure%2FHL7%20Emergency%20Access%2Edoc">this paper</a> for
@@ -288,80 +299,120 @@ discussion of the issues involved in break-the-glass operations.
 <p>
 The security labels described above are a subset of the full set of security labels defined by the
 HL7 <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=345">Healthcare Privacy and Security Classification System</a>. 
-The HCS defines 5 categories of security labels that may be applied to a resource:
+Note the use of "security label" is used broadly in FHIR to for all security tags. There is a more formal definition in the security labeling community of "security label" that refers to an overall assessment, in HL7 this would be represented with a value from the ConfidentialityCode value set. For more detailed on how to implement security tagging and labeling, HL7 has published <a href="http://www.hl7.org/fhir/uv/security-label-ds4p/index.html">Data Segmentation for Privacy Implementation Guide for FHIR</a>
 </p>
 
+<p>Type of security metadata observation made about the classification of an IT resource (data, information object, service, or system capability), which may be used to make access control decisions. Security classification is defined by <a href="https://www.iso.org/standard/7243.html">ISO/IEC 2382-8:1998(E/F)/ T-REC-X.812-1995</a> as: <em>&quot;the determination of which specific degree of protection against access the data or information requires, together with a designation of that degree of protection.&quot;</em> </p>
+<p>Security classification metadata is based on an analysis of applicable policies and the risk of financial, reputational, or other harm that could result from unauthorized disclosure.</p>
 <table class="grid">
- <tr> <td><b>Security Label</b></td> <td><b>Card.</b></td> <td><b>Values</b></td>  <td><b>Description</b></td> </tr>
-
- <tr> <td>Confidentiality Classification</td> <td>0..1</td> <td><a href="v3/ConfidentialityClassification/vs.html">ConfidentialityClassification</a></td>  <td>Security label metadata classifying an IT
-resource (clinical fact, data, information
-object, service, or system capability)
-according to its level of sensitivity, which is
-based on an analysis of applicable privacy
-policies and the risk of financial,
-reputational, or other harm to an individual
-or entity that could result if made available
-or disclosed to unauthorized individuals,
-entities, or processes.
-<br/>Example Uses: Unrestricted, Normal, Very restricted</td> </tr>
-
- <tr> <td>Sensitivity Category</td> <td>0..*</td> <td><a href="v3/InformationSensitivityPolicy/vs.html">InformationSensitivityPolicy</a></td>  <td>Security label metadata that "segments" an
-IT resource by categorizing the value,
-importance, and vulnerability of an IT
-resource perceived as undesirable to share.
-<br/>Example Uses: STDs, Psychiatric care, Celebrity status
-</td> </tr>
-
- <tr> <td>Compartment Category</td> <td>0..*</td> <td><a href="v3/Compartment/vs.html">Compartment</a></td>  <td>Security label metadata that "segments" an
-IT resource by indicating that access and
-use is restricted to members of a defined
-community or project
-<br/>Note: this is a different use of "Compartment" to the <a href="compartmentdefinition.html">Patient Compartment</a> use.
-<br/>Example Uses: Research, HR records
-</td> </tr>
-
- <tr> <td>Integrity Category</td> <td>0..*</td> <td><a href="v3/SecurityIntegrityObservationValue/vs.html">SecurityIntegrityObservationValue</a></td>  <td>Security label metadata that "segments" an
-IT resource by conveying the completeness,
-veracity, reliability, trustworthiness, and
-provenance of an IT resource
-<br/>Example Uses: Anonymized, signed, patient reported
-
-</td> </tr>
-
- <tr> <td>Handling Caveat</td> <td>0..*</td> <td><a href="v3/SecurityControlObservationValue/vs.html">SecurityControlObservationValue</a></td>  <td>Security label metadata conveying dissemination
-controls and information handling instructions
-such as obligations and retention policies to which an
-IT resource custodian or receiver must comply.<br/>
-This type of handling caveat SHALL be assigned
-to a clinical fact if required by jurisdictional or
-organizational policy, which may be triggered by a
-patient consent directive
-<br/>Example Uses: do not disclose, various restrictions on use, and policy marks
-</td> </tr>
+<thead>
+<tr>
+<th>Tag Set</th>
+<th>Car.</th>
+<th>Description</th>
+<th>Example Tags</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-Confidentiality.html">Confidentiality</a></td>
+<td><code>1..1</code></td>
+<td>Security label metadata classifying an IT resource (clinical fact, data, information object, service, or system capability) according to its level of sensitivity, which is based on an analysis of applicable privacy policies and the risk of financial, reputational, or other harm to an individual or entity that could result if made available or disclosed to unauthorized individuals, entities, or processes.</td>
+<td>Unrestricted, Normal, Very Restricted</td>
+</tr>
+</tbody>
 </table>
-
-<p>
-Each of these security labels identifies a <a href="valueset.html">ValueSet</a> that
-lists a set of possible codes for the security label.
-</p>
-
-<a name="jurisdictions"></a>
-<h3>Jurisdiction Specific Security Labels</h3>
-
-<p>
-The HL7 Healthcare Classification System also allows for Realm-specific privacy law or policy category codes for use in security labels in specific domains. These
-domains are included with this specification:
-</p>
-
+<h4 id="-security-category-https-terminology-hl7-org-valueset-v3-securitycategoryobservationtype-html-"><a href="https://terminology.hl7.org/ValueSet-v3-SecurityCategoryObservationType.html">Security Category</a></h4>
+<p>Type of security metadata observation made about the category of an IT resource (data, information object, service, or system capability), which may be used to make access control decisions. Security category metadata is defined by <a href="https://www.iso.org/standard/7243.html">ISO/IEC 2382-8:1998(E/F)/ T-REC-X.812-1995</a> as: <em>&quot;a nonhierarchical grouping of sensitive information used to control access to data more finely than with hierarchical security classification alone.&quot;</em></p>
 <table class="grid">
- <tr> <td><b>Security Label</b></td> <td><b>Card.</b></td> <td><b>Values</b></td>  <td><b>Description</b></td> </tr>
-
- <tr> <td>US Privacy Law</td> <td>0..*</td> <td><a href="v3/ActUSPrivacyLaw/vs.html">ActUSPrivacyLaw</a></td>  <td>Security label metadata that "segments" an IT resource by indicating the legal provisions to which the assignment of a Confidentiality Classification complies in the US.
-
-</td> </tr>
-
+<thead>
+<tr>
+<th>Tag Set</th>
+<th>Car.</th>
+<th>Description</th>
+<th>Example Tags</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-ActPolicyType.html">Policy</a></td>
+<td><code>0..1</code></td>
+<td>Security label metadata that segments an IT resource by conveying a mandate, obligation, requirement, rule, or expectation relating to its privacy.</td>
+<td></td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-InformationSensitivityPolicy.html">Sensitivity</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by categorizing the value, importance, and vulnerability of an IT resource perceived as undesirable to share.</td>
+<td><code>STD</code>, <code>HIV</code>, <code>SUD</code></td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-Compartment.html">Compartment</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by indicating that access and use is restricted to members of a defined community or project.</td>
+<td>Care Team, Research Project</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-SecurityIntegrityObservationValue.html">Integrity</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the completeness, veracity, reliability, trustworthiness, and provenance of an IT resource.</td>
+<td>Anonymized,  Digitally signed</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-SecurityIntegrityProvenanceObservationValue.html">Provenance</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the provenance of the IT resource&#39;s asserted or reported source.</td>
+<td>Patient reported, Clinician asserted</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-SecurityTrustObservationValue.html">Trust</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the basis for trusting the source.</td>
+<td>Trust Accreditation, Trust Agreement</td>
+</tr>
+</tbody>
 </table>
+<p></p>
+<h4 id="securitycontrolobservationtype"><a href="https://terminology.hl7.org/ValueSet-v3-SecurityControlObservationType.html">Security Control</a></h4>
+<p>Type of security metadata observation made about the control of an IT resource (data, information object, service, or system capability), which may be used to make access control decisions. Security control metadata conveys instructions for secure distribution, transmission, storage or use.</p>
+<table class="grid">
+<thead>
+<tr>
+<th>Tag Set</th>
+<th>Car.</th>
+<th>Description</th>
+<th>Example Tags</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-PurposeOfUse.html">Purpose of Use</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the reason for performing one or more operations on information, which may be permitted by source system&#39;s security policy in accordance with one or more privacy policies and consent directives.</td>
+<td>Treatment, Payment, Operation, Research</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-GeneralPurposeOfUse.html">General Purpose of Use</a></td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the reason for performing one or more operations on information of purpose of use at a general level.</td>
+<td>Coverage, Patient Requested, Emergency Treatment</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-ObligationPolicy.html">Obligation</a>**</td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying the mandated workflow action that an information custodian, receiver, or user must perform.</td>
+<td>Encrypt, mask, comply with policy</td>
+</tr>
+<tr>
+<td><a href="https://terminology.hl7.org/ValueSet-v3-RefrainPolicy.html">Refrain</a>**</td>
+<td><code>0..*</code></td>
+<td>Security label metadata that segments an IT resource by conveying actions which an information custodian, receiver, or user is not permitted to perform unless otherwise authorized or permitted under specified circumstances.</td>
+<td>Do not disclose without consent, no reuse</td>
+</tr>
+</tbody>
+</table>
+<p>(**) Privacy-revealing Obligation or Refrain tags such as the Obligation Policy <code>MASK</code> (mask) or the Refrain Policy <code>NODSCLCD</code> (no disclosure without consent directive), shall not be included in the high-watermark labels of a <code>Bundle</code>, <code>DocumentReference</code>, or <code>Message Resources</code>.</p>
+<p>Other Value-sets are defined by the <a href="http://www.hl7.org/fhir/uv/security-label-ds4p/index.html">FHIR DS4P IG</a>.</p>
 
 
 

--- a/source/security.html
+++ b/source/security.html
@@ -24,17 +24,19 @@ in one section. A summary:
 <ol>
  <li>Time Keeping - all clocks should be synchronized using NTP/SNTP, and the design of the system should be robust against a system clock with the wrong value</li>
  <li><a href="#http">Communications Security</a> - all exchange of production data should be secured using TLS (e.g., https).</li>
- <li><a href="#authentication">Authentication</a> - Users/Clients must be authenticated. For web-centric, OAuth is recommended. When using OAuth, a profile of OAuth will be needed. Consider use of <a href="http://docs.smarthealthit.org/">Smart-On-FHIR</a> where appropriate.</li>
+ <li><a href="#authentication">Authentication</a> - Users/Clients must be authenticated. For web-centric, OAuth is recommended. When using OAuth, a profile of OAuth will be needed. Consider use of <a href="http://www.hl7.org/fhir/smart-app-launch/index.html">HL7 SMART-On-FHIR</a> where appropriate.</li>
  <li><a href="#binding">Authorization/Access Control</a> - FHIR defines a Security Label infrastructure to support access control management. FHIR may also define a set of resources to administer access control management, but does not define any at present</li>
  <li><a href="#audit">Audit</a> - FHIR defines <a href="provenance.html">provenance</a> and <a href="auditevent.html">audit event</a> resources suitable for tracking the origins, authorship, history, status, and access of resources</li>
  <li><a href="signatures.html">Digital Signatures</a> - FHIR includes several specifically reserved locations for digital signatures</li>
  <li><a href="#attachments">Attachments</a> - FHIR allows for binary resources and attachments. These have their own concerns</li>
  <li><a href="security-labels.html">Labels</a> - FHIR allows for set of security related tags that affect the way resources are handled</li>
- <li>Data Management Policies - FHIR defines a set of capabilities to support data exchange.
+ <li><b>Data Management Policies</b> - FHIR defines a set of capabilities to support data exchange.
      Not all the capabilities that FHIR enables may be appropriate or legal for use in some combinations of context and jurisdiction (e.g. HIPAA, GDPR). 
-     It is the responsibility of implementers to ensure that relevant regulations and other requirements are met</li>
+     It is the responsibility of implementers to ensure that relevant regulations and other requirements are met.</li>
  <li><a href="#narrative">Narrative</a> - Care must be taken when displaying the narrative from FHIR resources</li>
- <li><a href="#narrative">Input Validation</a>  - Validate all input received from other actors to assure the data is well formed and does not contain content that would cause unwanted system behaviour. Testing ensures that the input is not susceptible to data input validation errors by using techniques such as fuzzing, invalid input attacks, and injection attacks.</li>
+ <li><a href="#input">Input Validation</a>  - Validate all input received from other actors to assure the data is well formed and does not contain content that would cause unwanted system behaviour. Testing ensures that the input is not susceptible to data input validation errors by using techniques such as fuzzing, invalid input attacks, and injection attacks.</li>
+ <li><a href="#AuthZmethods">When using OAuth</a> - Consider the draft <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics">Best-Current-Practice for OAuth</a></li>
+ <li><b>Security / Privacy Event Reporting</b> - Consider legal obligations and ethical obligations to provide a means for Security and/or Privacy Event Reporting such as security vulnerability, or breach.  </li>
 </ol>
 <p>
 Time critical concerns regarding security flaws in the FHIR specification should be addressed to 
@@ -117,6 +119,7 @@ some other kind of profiled REST interface.
             Any declaration of 'required' or 'optional' requirements that could be mentioned here are only recommendations for that kind of Resource
             in general for the most common use of that Resource. Where one uses the Resource in a way that is different than this most common use, one will 
             have different risks and thus need different protections. 
+			Each Resource is indicated with the common "Security Category", and all of the Resources Security Category is shown on the <a href="resourcelist.html">Resource Types</a> page with the <a href="resourcelist.html#tabs-7">Security Category</a> tab.
       </p>
       <p>
             Most Resources will need some form of Access Control to Create, Update, or Delete. 
@@ -149,7 +152,7 @@ some other kind of profiled REST interface.
       <h3>Individual Sensitive</h3>
       <p>
             These Resources do NOT contain Patient data, but do contain individual information about other participants. 
-            These other individuals are Practitioners, PractionerRole, CareTeam, or other users.
+            These other individuals are Practitioners, PractitionerRole, CareTeam, or other users.
             These identities are needed to enable the practice of healthcare. 
             These identities are identities under general privacy regulations, and thus must consider Privacy risk. 
             Often access to these other identities are covered by business relationships.
@@ -214,19 +217,9 @@ Other than testing systems, FHIR servers should authenticate the clients.
 The server may choose to authenticate the client system and trust it, or to authenticate
 the individual user by a variety of techniques. For web-centric environments it is recommended to use 
 <a href="http://openid.net/connect/">OpenID Connect</a> (or other suitable authentication protocol) to verify identity of the end user, where it is necessary that end-users be identified to the application. 
-It is recommended that <a href="http://oauth.net/">OAuth</a> be used to authenticate and/or authorize 
-the client and user. The <a href="http://docs.smarthealthit.org/">Smart-On-FHIR</a> profile 
-on OAuth is a recommended method for using OAuth.
 </p>
 <p>
-The <a href="https://openid.net/wg/heart/">HEART Working Group</a> has developed a 
-set of privacy and security specifications that enable an individual to control the 
-authorization of access to RESTful health-related data sharing APIs, and to facilitate 
-the development of interoperable implementations of these specifications by others.
-IHE <a href="http://wiki.ihe.net/index.php/Internet_User_Authorization">IUA Profile</a> constrains OAuth token attributes to support Healthcare.
-</p>
-<p>
-All systems are shall protect authenticator mechanisms, and select the type of credential/strength of authenticator based on use-case and risk management.
+All systems shall protect authenticator mechanisms, and select the type of credential/strength of authenticator based on use-case and risk management.
 </p>
 <a name="binding"></a>
 <h2>
@@ -273,7 +266,7 @@ The rules behind the access control decision are often very complex, and potenti
  <li>Client, such as user identity, user role, location, level of assurance</li>
  <li>Resource, such as confidentiality, sensitivity, type of data, date ranges covered by the data, author of the data</li>
  <li>Patient, such as the patient identity, patient relationship to the user, patient consent policies</li>
- <li>Context of the transaction, system identity, time-of-day, purpose of use, workflow state, and transport security</li>
+ <li>Context of the transaction, system identity, time-of-day, token expiration, token scope, purpose of use, workflow state, and transport security</li>
 </ul>
 <!-- HL7 has papers on this topic. -->
 <p>For one source of further information, see the 
@@ -299,9 +292,34 @@ They include the following:
 <li>Several resources, including Bundle, Composition, Group and List, are designed to contain other resources. A security implementation should consider whether access to an individual resource, such as a Bundle, should permit access to all resources contained within the resource.</li>
 <li>FHIR defines several operations that may be supported by a server. Security implementations must evaluate whether a client can invoke these operations and what information should be returned from them. Fetch Encounter Record, Evaluate Measure, Observation Statistics, Find Patient Matches using MPI-based Logic, and Fetch Patient Record specifically provide the ability to disclose patient information.</li>
 <li>Batch and transaction processing provide ways for clients to create and update information in bulk. Security implementations should consider whether a client can initiate one of these interactions and make authorization decisions on each action in the batch/transaction.</li>
-<li>Security implementations must be aware of the <a href="security-labels.html#break-the-glass">Break the Glass protocol</a> (e.g. break the glass) (<a href="operationoutcome-example-break-the-glass.html">example</a>). </li>
+<li>Security implementations must be aware of the <a href="security-labels.html#break-the-glass">Break the Glass protocol</a> (e.g. break the glass) (<a href="auditevent-example-breakglass-start.html">example</a>). </li>
 </ul>
 
+<a name="AuthZmethods"></a>
+<h3>
+Approaches to Implementing Access Control
+</h3>
+<p>
+It is recommended that <a href="http://oauth.net/">OAuth</a> be used to authenticate and/or authorize 
+the client and user. The <a href="http://www.hl7.org/fhir/smart-app-launch/index.html">HL7 SMART-On-FHIR</a> Implementation Guide 
+on OAuth is a recommended method for using OAuth for authorizing interactions with a protected FHIR Server.
+</p>
+<p>
+The <a href="https://openid.net/wg/heart/">HEART Working Group</a> has developed a 
+set of privacy and security specifications that enable an individual to control the 
+authorization of access to RESTful health-related data sharing APIs, and to facilitate 
+the development of interoperable implementations of these specifications by others.
+IHE <a href="http://wiki.ihe.net/index.php/Internet_User_Authorization">IUA Profile</a> constrains OAuth token attributes to support Healthcare.
+</p>
+<p>
+Another proposed model for managing and enforcing patient consents relies on an OAuth 2.0 server which uses the patient consents as the applicable authorization policies at the time of issuing a token. In this model, the authorization server (OAuth 2.0 or its <a href="https://docs.kantarainitiative.org/uma/ed/uma-core-2.0-01.html">User-Managed Access profile</a>) examines the patient consent to determine whether or not to issue a token to a requesting client and what scopes to grant. The main motivation behind this model is to have a separate consent management system in charge of collecting, storing, and maintaining patient consents, as well as responding to authorization requests based on these consents. This facilitates having third-party consent management services to which organizations can outsource their consent management functions. Further details about this model are discussed in <a href="https://confluence.hl7.org/display/SEC/Veterans+Health+Administration+Sponsored+Security+and+Privacy+Papers?preview=%2F66931686%2F66939024%2FUMA_Consent_Management_Service-2017-11-27.pdf">this report</a>.
+</p>
+<p>
+An extension to this model, Cascaded Authorization, enables an OAuth/UMA authorization server to require and rely on the approval of another OAuth/UMA server before issuing a token and granting scopes. Using this model, the enterprise OAuth/UMA server at a provider organization can rely on the decisions by a Consent OAuth/UMA Server by requiring and accepting access tokens issued by that server as part of the client authorization process. This architecture preserves the independence of a consent management system, which can potentially be outsourced to third-parties, while ensuring that all authorization interfaces and interactions follow the OAuth/UMA protocols. A summary of the concepts and flows for Cascaded Authorization are discussed in <a href="https://confluence.hl7.org/display/SEC/Veterans+Health+Administration+Sponsored+Security+and+Privacy+Papers?preview=%266931686/66939023%2Cascaded_Authorization-2018-01-15.pdf">this report</a>. Further extensions to this model to leverage UMA’s capabilities to simplify some of the flows are discussed in <a href="https://confluence.hl7.org/display/SEC/Veterans+Health+Administration+Sponsored+Security+and+Privacy+Papers?preview=%266931686/66939022%2Privacy_Preserving_Authorization-2018-01-15.pdf">this report</a>. A reference implementation of Cascaded Authorization and more technical details can be found <a href="https://github.com/mojitoholic/pauldron">here</a>.
+</p>
+<p>
+Additionally, the <a href="http://www.udap.org">Unified Data Access Profiles (UDAP)</a> propose extensions to the OAuth 2.0 framework to scale authorization; authentication; trusted Dynamic Client Registration; and Client Certification and Endorsements using JSON Web Tokens and X.509 certificates.
+</p>
 <a name="AccessDenied"></a>
 <h3>
 Access Denied Response Handling


### PR DESCRIPTION
## HL7 FHIR Pull Request

Technical Corrections to the Security narrative pages. Approved by FMG February 9, 2022 https://confluence.hl7.org/pages/viewpage.action?pageId=90347728

## Description

The security.html, security-module.html, and security-labels.html pages have been improved based on public comments and reaction inspired by Alissa Knight security report. The Security wg requests that these technical corrections be applied to R4B to better inform the reader. There are no normative changes as these three html pages do not cover normative requirements.

- FHIR-25939    Need a Security Considerations categorization summary page 
- FHIR-34404    recommendation for Vendor/Product/Service to invite security vulnerabilities reporting 
- FHIR-34400    Security Page should mention oWASP page up front 
- FHIR-34362    clarify access control best practice 
- FHIR-11071    Improve security label guidance - 
- FHIR-12660    HCS use clarification 
- FHIR-33014    Add reference to SCIM to security page 
- FHIR-24674    Add definitions of direct and indirect identifiers to de-dentification text 
- FHIR-23714    Update link to SMART documentation 









































