### PR TITLE
J# 36131 and partial J# 36205 changed EvidenceVariable structure and updated examples

### DIFF
--- a/source/evidencevariable/codesystem-characteristic-offset.xml
+++ b/source/evidencevariable/codesystem-characteristic-offset.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="characteristic-offset"/>
+  <meta>
+    <lastUpdated value="2022-03-04T16:55:11+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>This code system http://terminology.hl7.org/CodeSystem/characteristic-offset defines the following codes:</p>
+      
+      <table class="codes">
+        
+        <tr>
+          
+          <td style="white-space:nowrap">
+            
+            <b>Code</b>
+          
+          </td>
+          
+          <td>
+            
+            <b>Display</b>
+          
+          </td>
+          
+          <td>
+            
+            <b>Definition</b>
+          
+          </td>
+        
+        </tr>
+                <tr>
+          
+          <td style="white-space:nowrap">UNL
+            
+            <a name="characteristic-offset-UNL"> </a>
+          
+          </td>
+          
+          <td>Upper Normal Limit</td>
+          
+          <td>The upper bound of the reference range.</td>
+        
+        </tr>
+
+        <tr>
+          
+          <td style="white-space:nowrap">LNL
+            
+            <a name="characteristic-offset-LNL"> </a>
+          
+          </td>
+          
+          <td>Lower Normal Limit</td>
+          
+          <td>The lower bound of the reference range.</td>
+        
+        </tr>
+      
+      </table>
+    
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://terminology.hl7.org/CodeSystem/characteristic-offset"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.1.1455"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="CharacteristicOffset"/>
+  <title value="CharacteristicOffset"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2022-03-04T16:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Reference point for characteristic.valueQuantity."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/characteristic-offset"/>
+  <content value="complete"/>
+  <concept>
+    <code value="UNL"/>
+    <display value="Upper Normal Limit"/>
+    <definition value="The upper bound of the reference range."/>
+  </concept>
+  <concept>
+    <code value="LNL"/>
+    <display value="Lower Normal Limit"/>
+    <definition value="The lower bound of the reference range."/>
+  </concept>
+</CodeSystem>

--- a/source/evidencevariable/evidencevariable-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
+++ b/source/evidencevariable/evidencevariable-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EvidenceVariable xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/evidencevariable.xsd">
   <id value="example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
-  <text>
-    <status value="generated" />
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <p>
-        Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis
-      </p>
-	</div>
-  </text>
-  <name value="Stroke Thrombolysis Trialists’ 2014-2016 IPD-MA Cohort"/>
-  <title value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+	<text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+		  <p>
+			Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis
+		  </p>
+		</div>
+	</text>
+	<name value="Stroke Thrombolysis Trialists’ 2014-2016 IPD-MA Cohort"/>
+	<title value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
 	<status value="draft"/>
 	<relatedArtifact>
 		<type value="citation"/>
@@ -31,56 +31,59 @@
     </document>
 	</relatedArtifact>
 	<actual value="true"/>
-	<characteristicCombination>
-		<code value="any-of" />
-	</characteristicCombination>
 	<characteristic>
-		<definitionReference>
-			<reference value="Group/ECASSIII-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="ECASS III Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/IST3-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="IST3 Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/ECASS-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="ECASS Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/ECASSII-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="ECASSII Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/EPITHET-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="EPITHET Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/ATLANTIS-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="ATLANTIS Trial Cohort"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<reference value="Group/NINDS-Trial-Cohort"/>
-			<type value="Group"/>
-			<display value="NINDS Trial Cohort"/>
-		</definitionReference>
+		<description value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis" />
+		<combination>
+			<code value="any-of" />
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/ECASSIII-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="ECASS III Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/IST3-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="IST3 Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/ECASS-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="ECASS Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/ECASSII-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="ECASSII Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/EPITHET-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="EPITHET Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/ATLANTIS-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="ATLANTIS Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<reference value="Group/NINDS-Trial-Cohort"/>
+					<type value="Group"/>
+					<display value="NINDS Trial Cohort"/>
+				</definitionReference>
+			</characteristic>
+		</combination>
 	</characteristic>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
+++ b/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
@@ -12,7 +12,9 @@
 	  <name value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
 	  <title value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
 	<status value="draft"/>
-	<note value="Short names for Evidence sources are detailed in &quot;References to studies included in this review&quot;" />
+	<note>
+		<text value="Short names for Evidence sources are detailed in 'References to studies included in this review'" />
+	</note>
 	<relatedArtifact>
 		<type value="citation"/>
 		<label value="Wardlaw 2014"/>

--- a/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
+++ b/source/evidencevariable/evidencevariable-example-Wardlaw2014Analysis1.16.3EvidenceSet.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EvidenceVariable xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/evidencevariable.xsd">
-  <id value="example-Wardlaw2014Analysis1.16.3EvidenceSet"/>
-  <text>
-    <status value="generated" />
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <p>
-        &quot;Wardlaw 2014 Analysis 1.16.3 Evidence set&quot; is a grouping of six Evidence results used in a meta-analysis.
-      </p>
-	</div>
-  </text>
-  <name value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
-  <title value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
+	  <id value="example-Wardlaw2014Analysis1.16.3EvidenceSet"/>
+	  <text>
+		<status value="generated" />
+		<div xmlns="http://www.w3.org/1999/xhtml">
+		  <p>
+			&quot;Wardlaw 2014 Analysis 1.16.3 Evidence set&quot; is a grouping of six Evidence results used in a meta-analysis.
+		  </p>
+		</div>
+	  </text>
+	  <name value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
+	  <title value="Wardlaw 2014 Analysis 1.16.3 Evidence set"/>
 	<status value="draft"/>
-	<note>
-		<text value="Short names for Evidence sources are detailed in &quot;References to studies included in this review&quot;"/>
-	</note>
+	<note value="Short names for Evidence sources are detailed in &quot;References to studies included in this review&quot;" />
 	<relatedArtifact>
 		<type value="citation"/>
 		<label value="Wardlaw 2014"/>
@@ -25,44 +23,47 @@
     </document>
 	</relatedArtifact>
 	<actual value="true"/>
-	<characteristicCombination>
-		<code value="any-of" />
-	</characteristicCombination>
 	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="NINDS 1995"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="ECASS 1995"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="ECASS II 1998"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="ATLANTIS B 1999"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="ATLANTIS A 2000"/>
-		</definitionReference>
-	</characteristic>
-	<characteristic>
-		<definitionReference>
-			<type value="Evidence"/>
-			<display value="IST3 2012"/>
-		</definitionReference>
+		<description value="'Wardlaw 2014 Analysis 1.16.3 Evidence set' is a grouping of six Evidence results used in a meta-analysis." />
+		<combination>
+			<code value="any-of" />
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="NINDS 1995"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="ECASS 1995"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="ECASS II 1998"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="ATLANTIS B 1999"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="ATLANTIS A 2000"/>
+				</definitionReference>
+			</characteristic>
+			<characteristic>
+				<definitionReference>
+					<type value="Evidence"/>
+					<display value="IST3 2012"/>
+				</definitionReference>
+			</characteristic>
+		</combination>
 	</characteristic>
 	<handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-alive-independent-90day.xml
@@ -12,9 +12,6 @@
   <title value="Alive and not functionally dependent at 90 days"/>
   <status value="draft"/>
   <actual value="false"/>
-  <characteristicCombination>
-	<code value="all-of" />
-  </characteristicCombination>
   <characteristic>
     <description value="not functionally dependent at 90 days"/>
     <definitionCodeableConcept>
@@ -26,6 +23,13 @@
     </definitionCodeableConcept>
     <exclude value="true"/>
     <timeFromEvent>
+	  <eventCodeableConcept>
+		<coding>
+			<system value="http://hl7.org/fhir/evidence-variable-event"/>
+			<code value="study-start"/>
+			<display value="Study Start"/>
+		</coding>
+	  </eventCodeableConcept>
       <quantity>
         <value value="90"/>
         <unit value="day"/>
@@ -45,13 +49,13 @@
     </definitionCodeableConcept>
     <exclude value="true"/>
     <timeFromEvent>
-	  <event>
+	  <eventCodeableConcept>
 		<coding>
 			<system value="http://hl7.org/fhir/evidence-variable-event"/>
 			<code value="study-start"/>
 			<display value="Study Start"/>
 		</coding>
-	  </event>
+	  </eventCodeableConcept>
       <quantity>
         <value value="90"/>
         <unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
@@ -12,51 +12,54 @@
   <title value="Dead or functionally dependent at 90 days"/>
   <status value="draft"/>
   <actual value="false"/>
-  <characteristicCombination>
-	<code value="any-of" />
-  </characteristicCombination>
   <characteristic>
-		<description value="functionally dependent at 90 days"/>
-		<definitionCodeableConcept>
-			<coding>
-				<system value="http://snomed.info/sct"/>
-				<code value="718705001"/>
-				<display value="Functionally dependent (finding)"/>
-			</coding>
-		</definitionCodeableConcept>
-		<timeFromEvent>
-			<event>
-				<coding>
-					<system value="http://hl7.org/fhir/evidence-variable-event"/>
-					<code value="study-start"/>
-					<display value="Study Start"/>
-				</coding>
-			</event>
-			<quantity>
-				<value value="90"/>
-				<unit value="day"/>
-				<system value="http://unitsofmeasure.org"/>
-				<code value="d"/>
-			</quantity>
-		</timeFromEvent>
-  </characteristic>
-  <characteristic>
-		<description value="dead at 90 days"/>
-		<definitionCodeableConcept>
-			<coding>
-				<system value="http://snomed.info/sct"/>
-				<code value="419099009"/>
-				<display value="Dead (finding)"/>
-			</coding>
-		</definitionCodeableConcept>
-		<timeFromEvent>
-			<quantity>
-				<value value="90"/>
-				<unit value="day"/>
-				<system value="http://unitsofmeasure.org"/>
-				<code value="d"/>
-			</quantity>
-		</timeFromEvent>
+	  <description value="Dead or functionally dependent at 90 days"/>
+	  <combination>
+		  <code value="any-of" />
+		  <characteristic>
+				<description value="functionally dependent at 90 days"/>
+				<definitionCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct"/>
+						<code value="718705001"/>
+						<display value="Functionally dependent (finding)"/>
+					</coding>
+				</definitionCodeableConcept>
+				<timeFromEvent>
+					<eventCodeableConcept>
+						<coding>
+							<system value="http://hl7.org/fhir/evidence-variable-event"/>
+							<code value="study-start"/>
+							<display value="Study Start"/>
+						</coding>
+					</eventCodeableConcept>
+					<quantity>
+						<value value="90"/>
+						<unit value="day"/>
+						<system value="http://unitsofmeasure.org"/>
+						<code value="d"/>
+					</quantity>
+				</timeFromEvent>
+		  </characteristic>
+		  <characteristic>
+				<description value="dead at 90 days"/>
+				<definitionCodeableConcept>
+					<coding>
+						<system value="http://snomed.info/sct"/>
+						<code value="419099009"/>
+						<display value="Dead (finding)"/>
+					</coding>
+				</definitionCodeableConcept>
+				<timeFromEvent>
+					<quantity>
+						<value value="90"/>
+						<unit value="day"/>
+						<system value="http://unitsofmeasure.org"/>
+						<code value="d"/>
+					</quantity>
+				</timeFromEvent>
+		  </characteristic>
+	  </combination>
   </characteristic>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -11,13 +11,8 @@
   </text>
   <title value="Fatal Intracranial Hemorrhage Within Seven Days"/>
   <status value="draft"/>
-  <note>
-    <text value="Death must be due to intracranial hemorrhage"/>
-  </note>
+  <note value="Death must be due to intracranial hemorrhage"/>
   <actual value="true"/>
-  <characteristicCombination>
-	<code value="all-of" />
-  </characteristicCombination>
   <characteristic>
     <description value="intracranial hemorrhage within 7 days"/>
     <definitionCodeableConcept>
@@ -29,13 +24,13 @@
     </definitionCodeableConcept>
     <timeFromEvent>
 			<description value="within 7 days"/>
-			<event>
+			<eventCodeableConcept>
 				<coding>
 					<system value="http://hl7.org/fhir/evidence-variable-event"/>
 					<code value="study-start"/>
 					<display value="Study Start"/>
 				</coding>
-			</event>
+			</eventCodeableConcept>
 			<range>
 				<low>
 					<value value="0"/>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -11,7 +11,9 @@
   </text>
   <title value="Fatal Intracranial Hemorrhage Within Seven Days"/>
   <status value="draft"/>
-  <note value="Death must be due to intracranial hemorrhage"/>
+  <note>
+	<text value="Death must be due to intracranial hemorrhage"/>
+  </note>
   <actual value="true"/>
   <characteristic>
     <description value="intracranial hemorrhage within 7 days"/>

--- a/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
@@ -20,13 +20,13 @@
       <expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 0 and 2"/>
     </definitionExpression>
     <timeFromEvent>
-	  <event>
+	  <eventCodeableConcept>
 		<coding>
 			<system value="http://hl7.org/fhir/evidence-variable-event"/>
 			<code value="study-start"/>
 			<display value="Study Start"/>
 		</coding>
-	  </event>
+	  </eventCodeableConcept>
       <quantity>
         <value value="90"/>
         <unit value="day"/>

--- a/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
@@ -20,13 +20,13 @@
 			<expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 3 and 6"/>
 		</definitionExpression>
 		<timeFromEvent>
-			<event>
+			<eventCodeableConcept>
 				<coding>
 					<system value="http://hl7.org/fhir/evidence-variable-event"/>
 					<code value="study-start"/>
 					<display value="Study Start"/>
 				</coding>
-			</event>
+			</eventCodeableConcept>
 			<quantity>
 				<value value="90"/>
 				<unit value="day"/>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -251,6 +251,14 @@
         <map value="FiveWs.status"/>
       </mapping>
     </element>
+    <element id="EvidenceVariable.experimental">
+      <path value="EvidenceVariable.experimental"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
     <element id="EvidenceVariable.date">
       <path value="EvidenceVariable.date"/>
       <short value="Date last changed"/>
@@ -270,49 +278,6 @@
       <mapping>
         <identity value="w5"/>
         <map value="FiveWs.recorded"/>
-      </mapping>
-    </element>
-    <element id="EvidenceVariable.description">
-      <path value="EvidenceVariable.description"/>
-      <short value="Natural language description of the evidence variable"/>
-      <definition value="A free text natural language description of the evidence variable from a consumer&#39;s perspective."/>
-      <comment value="This description can be used to capture details such as why the evidence variable was built, comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the evidence variable as conveyed in the &#39;text&#39; field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the evidence variable is presumed to be the predominant language in the place the evidence variable was created)."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="markdown"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="workflow"/>
-        <map value="Definition.description"/>
-      </mapping>
-    </element>
-    <element id="EvidenceVariable.note">
-      <path value="EvidenceVariable.note"/>
-      <short value="Used for footnotes or explanatory notes"/>
-      <definition value="A human-readable string to clarify or explain concepts about the resource."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="Annotation"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.useContext">
-      <path value="EvidenceVariable.useContext"/>
-      <short value="The context that the content is intended to support"/>
-      <definition value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate evidence variable instances."/>
-      <comment value="When multiple useContexts are specified, there is no expectation that all or any of the contexts apply."/>
-      <requirements value="Assist in searching for appropriate content."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="UsageContext"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="workflow"/>
-        <map value="Definition.useContext"/>
       </mapping>
     </element>
     <element id="EvidenceVariable.publisher">
@@ -351,6 +316,81 @@
         <identity value="workflow"/>
         <map value="Definition.contact"/>
       </mapping>
+    </element>
+    <element id="EvidenceVariable.description">
+      <path value="EvidenceVariable.description"/>
+      <short value="Natural language description of the evidence variable"/>
+      <definition value="A free text natural language description of the evidence variable from a consumer&#39;s perspective."/>
+      <comment value="This description can be used to capture details such as why the evidence variable was built, comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the evidence variable as conveyed in the &#39;text&#39; field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the evidence variable is presumed to be the predominant language in the place the evidence variable was created)."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Definition.description"/>
+      </mapping>
+    </element>
+    <element id="EvidenceVariable.note">
+      <path value="EvidenceVariable.note"/>
+      <short value="Used for footnotes or explanatory notes"/>
+      <definition value="A human-readable string to clarify or explain concepts about the resource."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.useContext">
+      <path value="EvidenceVariable.useContext"/>
+      <short value="The context that the content is intended to support"/>
+      <definition value="The content was developed with a focus and intent of supporting the contexts that are listed. These contexts may be general categories (gender, age, ...) or may be references to specific programs (insurance plans, studies, ...) and may be used to assist with indexing and searching for appropriate evidence variable instances."/>
+      <comment value="When multiple useContexts are specified, there is no expectation that all or any of the contexts apply."/>
+      <requirements value="Assist in searching for appropriate content."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="UsageContext"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="workflow"/>
+        <map value="Definition.useContext"/>
+      </mapping>
+    </element>
+    <element id="EvidenceVariable.copyright">
+      <path value="EvidenceVariable.copyright"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.approvalDate">
+      <path value="EvidenceVariable.approvalDate"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="dateTime"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.lastReviewDate">
+      <path value="EvidenceVariable.lastReviewDate"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="dateTime"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.effectivePeriod">
+      <path value="EvidenceVariable.effectivePeriod"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Period"/>
+      </type>
     </element>
     <element id="EvidenceVariable.author">
       <path value="EvidenceVariable.author"/>
@@ -430,48 +470,10 @@
         <code value="boolean"/>
       </type>
     </element>
-    <element id="EvidenceVariable.characteristicCombination">
-      <path value="EvidenceVariable.characteristicCombination"/>
-      <short value="Used to specify how two or more characteristics are combined"/>
-      <definition value="Used to specify how two or more characteristics are combined."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="BackboneElement"/>
-      </type>
-    </element>
-    <element id="EvidenceVariable.characteristicCombination.code">
-      <path value="EvidenceVariable.characteristicCombination.code"/>
-      <short value="all-of | any-of | at-least | at-most | net-effect"/>
-      <definition value="Used to specify if two or more characteristics are combined with OR or AND."/>
-      <requirements value="If code is &quot;at-least&quot; or &quot;at-most&quot; then threshold SHALL be used. If code is neither &quot;at-least&quot; nor &quot;at-most&quot; then threshold SHALL NOT be used."/>
-      <min value="1"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="CharacteristicCombination"/>
-        </extension>
-        <strength value="required"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/characteristic-combination"/>
-      </binding>
-    </element>
-    <element id="EvidenceVariable.characteristicCombination.threshold">
-      <path value="EvidenceVariable.characteristicCombination.threshold"/>
-      <short value="Provides the value of &quot;n&quot; when &quot;at-least&quot; or &quot;at-most&quot; codes are used"/>
-      <definition value="Provides the value of &quot;n&quot; when &quot;at-least&quot; or &quot;at-most&quot; codes are used."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="positiveInt"/>
-      </type>
-    </element>
     <element id="EvidenceVariable.characteristic">
       <path value="EvidenceVariable.characteristic"/>
-      <short value="What defines the members of the evidence element"/>
-      <definition value="A characteristic that defines the members of the evidence element. Multiple characteristics are applied with &quot;and&quot; semantics."/>
+      <short value="A defining factor of the EvidenceVariable."/>
+      <definition value="A defining factor of the EvidenceVariable. Multiple characteristics are applied with &quot;and&quot; semantics."/>
       <comment value="Characteristics can be defined flexibly to accommodate different use cases for membership criteria, ranging from simple codes, all the way to using an expression language to express the criteria."/>
       <min value="0"/>
       <max value="*"/>
@@ -479,6 +481,16 @@
         <code value="BackboneElement"/>
       </type>
       <isSummary value="true"/>
+    </element>
+    <element id="EvidenceVariable.characteristic.linkId">
+      <path value="EvidenceVariable.characteristic.linkId"/>
+      <short value="Label for internal linking"/>
+      <definition value="Label used for when a characteristic refers to another characteristic"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="id"/>
+      </type>
     </element>
     <element id="EvidenceVariable.characteristic.description">
       <path value="EvidenceVariable.characteristic.description"/>
@@ -491,34 +503,25 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="EvidenceVariable.characteristic.type">
-      <path value="EvidenceVariable.characteristic.type"/>
-      <short value="Expresses the type of characteristic"/>
-      <definition value="Used to expressing the type of characteristic."/>
+    <element id="EvidenceVariable.characteristic.note">
+      <path value="EvidenceVariable.characteristic.note"/>
+      <short value="Used for footnotes or explanatory notes"/>
+      <definition value="A human-readable string to clarify or explain concepts about the characteristic."/>
       <min value="0"/>
-      <max value="1"/>
+      <max value="*"/>
       <type>
-        <code value="CodeableConcept"/>
+        <code value="string"/>
       </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="UsageContextType"/>
-        </extension>
-        <strength value="example"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/usage-context-type"/>
-      </binding>
     </element>
     <element id="EvidenceVariable.characteristic.definition[x]">
       <path value="EvidenceVariable.characteristic.definition[x]"/>
-      <short value="What code or expression defines members?"/>
-      <definition value="Define members of the evidence element using Codes (such as condition, medication, or observation), Expressions ( using an expression language such as FHIRPath or CQL) or DataRequirements (such as Diabetes diagnosis onset in the last year)."/>
-      <requirements value="Need to be able to define members in simple codes when the membership aligns well with terminology, with common criteria such as observations in a value set or lab tests within a year, or with expression language to support criteria that do not fit in the above."/>
-      <min value="1"/>
+      <short value="Defines the characteristic (without using type and value)"/>
+      <definition value="Defines the characteristic using a single DataType element."/>
+      <requirements value="If characteristic.definition[x] is used then characteristic.type[x] and characteristic.value[x] shall not be used."/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/EvidenceVariable"/>
       </type>
       <type>
         <code value="canonical"/>
@@ -529,6 +532,62 @@
       </type>
       <type>
         <code value="Expression"/>
+      </type>
+      <type>
+        <code value="id"/>
+      </type>
+      <isSummary value="true"/>
+    </element>
+    <element id="EvidenceVariable.characteristic.type[x]">
+      <path value="EvidenceVariable.characteristic.type[x]"/>
+      <short value="Expresses the type of characteristic"/>
+      <definition value="Used to express the type of characteristic."/>
+      <requirements value="If characteristic.type[x] is used then characteristic.value[x]  must be used and characteristic.definition[x] shall not be used."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/EvidenceVariable"/>
+      </type>
+      <type>
+        <code value="id"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="UsageContextType"/>
+        </extension>
+        <strength value="example"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/usage-context-type"/>
+      </binding>
+    </element>
+    <element id="EvidenceVariable.characteristic.value[x]">
+      <path value="EvidenceVariable.characteristic.value[x]"/>
+      <short value="Defines the characteristic when coupled with characteristic.type[x]"/>
+      <definition value="Defines the characteristic when paired with characteristic.type[x]."/>
+      <requirements value="If characteristic.value[x] is used then characteristic.type[x]  must be used and characteristic.definition[x] shall not be used."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <type>
+        <code value="boolean"/>
+      </type>
+      <type>
+        <code value="Quantity"/>
+      </type>
+      <type>
+        <code value="Range"/>
+      </type>
+      <type>
+        <code value="Reference"/>
+      </type>
+      <type>
+        <code value="id"/>
       </type>
       <isSummary value="true"/>
     </element>
@@ -576,6 +635,23 @@
       </type>
       <meaningWhenMissing value="False"/>
     </element>
+    <element id="EvidenceVariable.characteristic.offset">
+      <path value="EvidenceVariable.characteristic.offset"/>
+      <short value="Reference point for characteristic.valueQuantity"/>
+      <definition value="Defines the reference point for comparison when characteristic.valueQuantity is not compared to zero."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CharacteristicOffset"/>
+        </extension>
+        <strength value="example"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/characteristic-offset"/>
+      </binding>
+    </element>
     <element id="EvidenceVariable.characteristic.timeFromEvent">
       <path value="EvidenceVariable.characteristic.timeFromEvent"/>
       <short value="Observation time from study specified event"/>
@@ -594,13 +670,22 @@
         <code value="string"/>
       </type>
     </element>
-    <element id="EvidenceVariable.characteristic.timeFromEvent.event">
-      <path value="EvidenceVariable.characteristic.timeFromEvent.event"/>
+    <element id="EvidenceVariable.characteristic.timeFromEvent.event[x]">
+      <path value="EvidenceVariable.characteristic.timeFromEvent.event[x]"/>
       <short value="The event used as a base point (reference point) in time"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="CodeableConcept"/>
+      </type>
+      <type>
+        <code value="Reference"/>
+      </type>
+      <type>
+        <code value="dateTime"/>
+      </type>
+      <type>
+        <code value="id"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -631,11 +716,11 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent.note">
       <path value="EvidenceVariable.characteristic.timeFromEvent.note"/>
       <short value="Used for footnotes or explanatory notes"/>
-      <definition value="A human-readable string to clarify or explain concepts about the resource."/>
+      <definition value="A human-readable string to clarify or explain concepts about the timeFromEvent."/>
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="Annotation"/>
+        <code value="string"/>
       </type>
     </element>
     <element id="EvidenceVariable.characteristic.groupMeasure">
@@ -654,6 +739,50 @@
         <strength value="required"/>
         <valueSet value="http://hl7.org/fhir/ValueSet/group-measure"/>
       </binding>
+    </element>
+    <element id="EvidenceVariable.characteristic.combination">
+      <path value="EvidenceVariable.characteristic.combination"/>
+      <short value="Used to specify how two or more characteristics are combined"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.characteristic.combination.code">
+      <path value="EvidenceVariable.characteristic.combination.code"/>
+      <short value="all-of | any-of | at-least | at-most | net-effect"/>
+      <definition value="Used to specify if two or more characteristics are combined with OR or AND."/>
+      <requirements value="If code is &quot;at-least&quot; or &quot;at-most&quot; then threshold SHALL be used. If code is neither &quot;at-least&quot; nor &quot;at-most&quot; then threshold SHALL NOT be used."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CharacteristicCombination"/>
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/characteristic-combination"/>
+      </binding>
+    </element>
+    <element id="EvidenceVariable.characteristic.combination.threshold">
+      <path value="EvidenceVariable.characteristic.combination.threshold"/>
+      <short value="Provides the value of &quot;n&quot; when &quot;at-least&quot; or &quot;at-most&quot; codes are used"/>
+      <definition value="Provides the value of &quot;n&quot; when &quot;at-least&quot; or &quot;at-most&quot; codes are used."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="positiveInt"/>
+      </type>
+    </element>
+    <element id="EvidenceVariable.characteristic.combination.characteristic">
+      <path value="EvidenceVariable.characteristic.combination.characteristic"/>
+      <short value="A defining factor of the characteristic."/>
+      <min value="1"/>
+      <max value="*"/>
+      <contentReference value="#EvidenceVariable.characteristic"/>
     </element>
     <element id="EvidenceVariable.handling">
       <path value="EvidenceVariable.handling"/>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -253,6 +253,8 @@
     </element>
     <element id="EvidenceVariable.experimental">
       <path value="EvidenceVariable.experimental"/>
+      <short value="For testing purposes, not real usage"/>
+      <definition value="A Boolean value to indicate that this resource is authored for testing purposes (or education/evaluation/marketing) and is not intended to be used for genuine usage."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -340,7 +342,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="string"/>
+        <code value="Annotation"/>
       </type>
     </element>
     <element id="EvidenceVariable.useContext">
@@ -362,6 +364,8 @@
     </element>
     <element id="EvidenceVariable.copyright">
       <path value="EvidenceVariable.copyright"/>
+      <short value="Use and/or publishing restrictions"/>
+      <definition value="A copyright statement relating to the resource and/or its contents. Copyright statements are generally legal restrictions on the use and publishing of the resource."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -370,6 +374,8 @@
     </element>
     <element id="EvidenceVariable.approvalDate">
       <path value="EvidenceVariable.approvalDate"/>
+      <short value="When the resource was approved by publisher"/>
+      <definition value="The date on which the resource content was approved by the publisher. Approval happens once when the content is officially approved for usage."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -378,6 +384,8 @@
     </element>
     <element id="EvidenceVariable.lastReviewDate">
       <path value="EvidenceVariable.lastReviewDate"/>
+      <short value="When the resource was last reviewed"/>
+      <definition value="The date on which the resource content was last reviewed. Review happens periodically after approval but does not change the original approval date."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -386,6 +394,8 @@
     </element>
     <element id="EvidenceVariable.effectivePeriod">
       <path value="EvidenceVariable.effectivePeriod"/>
+      <short value="When the resource is expected to be used"/>
+      <definition value="The period during which the resource content was or is planned to be in active use."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -472,7 +482,7 @@
     </element>
     <element id="EvidenceVariable.characteristic">
       <path value="EvidenceVariable.characteristic"/>
-      <short value="A defining factor of the EvidenceVariable."/>
+      <short value="A defining factor of the EvidenceVariable"/>
       <definition value="A defining factor of the EvidenceVariable. Multiple characteristics are applied with &quot;and&quot; semantics."/>
       <comment value="Characteristics can be defined flexibly to accommodate different use cases for membership criteria, ranging from simple codes, all the way to using an expression language to express the criteria."/>
       <min value="0"/>
@@ -485,7 +495,7 @@
     <element id="EvidenceVariable.characteristic.linkId">
       <path value="EvidenceVariable.characteristic.linkId"/>
       <short value="Label for internal linking"/>
-      <definition value="Label used for when a characteristic refers to another characteristic"/>
+      <definition value="Label used for when a characteristic refers to another characteristic."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -510,7 +520,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="string"/>
+        <code value="Annotation"/>
       </type>
     </element>
     <element id="EvidenceVariable.characteristic.definition[x]">
@@ -655,6 +665,7 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent">
       <path value="EvidenceVariable.characteristic.timeFromEvent"/>
       <short value="Observation time from study specified event"/>
+      <definition value="Observation time from study specified event."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -664,6 +675,7 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent.description">
       <path value="EvidenceVariable.characteristic.timeFromEvent.description"/>
       <short value="Human readable description"/>
+      <definition value="Human readable description."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -673,6 +685,7 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent.event[x]">
       <path value="EvidenceVariable.characteristic.timeFromEvent.event[x]"/>
       <short value="The event used as a base point (reference point) in time"/>
+      <definition value="The event used as a base point (reference point) in time."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -698,6 +711,7 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent.quantity">
       <path value="EvidenceVariable.characteristic.timeFromEvent.quantity"/>
       <short value="Used to express the observation at a defined amount of time after the study start"/>
+      <definition value="Used to express the observation at a defined amount of time after the study start."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -707,6 +721,7 @@
     <element id="EvidenceVariable.characteristic.timeFromEvent.range">
       <path value="EvidenceVariable.characteristic.timeFromEvent.range"/>
       <short value="Used to express the observation within a period after the study start"/>
+      <definition value="Used to express the observation within a period after the study start."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -720,7 +735,7 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="string"/>
+        <code value="Annotation"/>
       </type>
     </element>
     <element id="EvidenceVariable.characteristic.groupMeasure">
@@ -779,7 +794,8 @@
     </element>
     <element id="EvidenceVariable.characteristic.combination.characteristic">
       <path value="EvidenceVariable.characteristic.combination.characteristic"/>
-      <short value="A defining factor of the characteristic."/>
+      <short value="A defining factor of the characteristic"/>
+      <definition value="A defining factor of the characteristic."/>
       <min value="1"/>
       <max value="*"/>
       <contentReference value="#EvidenceVariable.characteristic"/>
@@ -787,6 +803,7 @@
     <element id="EvidenceVariable.handling">
       <path value="EvidenceVariable.handling"/>
       <short value="continuous | dichotomous | ordinal | polychotomous"/>
+      <definition value="The method of handling in statistical analysis."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -803,6 +820,7 @@
     <element id="EvidenceVariable.category">
       <path value="EvidenceVariable.category"/>
       <short value="A grouping for ordinal or polychotomous variables"/>
+      <definition value="A grouping for ordinal or polychotomous variables."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -812,6 +830,7 @@
     <element id="EvidenceVariable.category.name">
       <path value="EvidenceVariable.category.name"/>
       <short value="Description of the grouping"/>
+      <definition value="Description of the grouping."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -821,6 +840,7 @@
     <element id="EvidenceVariable.category.value[x]">
       <path value="EvidenceVariable.category.value[x]"/>
       <short value="Definition of the grouping"/>
+      <definition value="Definition of the grouping."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/evidencevariable/valueset-characteristic-offset.xml
+++ b/source/evidencevariable/valueset-characteristic-offset.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="characteristic-offset"/>
+  <meta>
+    <lastUpdated value="2022-03-04T16:55:11+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <ul>
+        <li>Include all codes defined in 
+          <a href="codesystem-characteristic-offset.html">
+            <code>http://terminology.hl7.org/CodeSystem/characteristic-offset</code>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="draft"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/characteristic-offset"/>
+  <identifier>
+    <system value="urn:ietf:rfc:3986"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.1454"/>
+  </identifier>
+  <version value="4.6.0"/>
+  <name value="CharacteristicOffset"/>
+  <title value="CharacteristicOffset"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2022-03-04T16:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Reference point for characteristic.valueQuantity."/>
+  <immutable value="true"/>
+  <compose>
+    <include>
+      <system value="http://terminology.hl7.org/CodeSystem/characteristic-offset"/>
+    </include>
+  </compose>
+</ValueSet>


### PR DESCRIPTION
J# 36131
EvidenceVariable changes:
1.	Addition of copyright 0..1 markdown
2.	Addition of approvalDate 0..1 dateTime
3.	Addition of lastReviewDate 0..1 dateTime
4.	Addition of effectivePeriod 0..1 Period
5.     Deletion of characteristicCombination
6.	Addition of characteristic.linkId 0..1 id
7.	Addition of characteristic.definition[x] 0..1 (and added a requirement saying that either definition[x] is used OR both type[x] and value[x] is used but not BOTH definition and type/value)
8.	Change datatype of characteristic.type 0..1 from CodeableConcept to type[x] CodeableConcept | Reference(EvidenceVariable) | id
9.	Addition of characteristic.value[x] 0..1 CodeableConcept | boolean | Quantity | Range | Reference()
10.	Addition of characteristic.offset 0..1 CodeableConcept
11.	Change datatype of characteristic.timeFromEvent.event 0..1 from CodeableConcept to event[x] CodeableConcept | Reference | dateTime | id
12.	Addition of characteristic.combination 0..1 BackboneElement
13.	Addition of characteristic.combination.code 1..1 code (all-of | any-of | at-least | at-most | net-effect)
14.	Addition of characteristic.combination.threshold 0..1 positiveInt
15.	Addition of characteristic.combination.characteristic 1..* see characteristic
16.	_Added characteristic.note 0..* Annotation_

**J# 36131 said to change Annotation to string for a few note elements, but that's impossible in FHIR since it requires it to be an Annotation type, so they will be left as Annotation.**

Partial J# 36205
Added EvidenceVariable.experimental

And updated EvidenceVariable examples to the new structure.
