### PR TITLE
Fix extension URLs to conform to spec

### DIFF
--- a/implementations/r3maps/R3toR4/ImplementationGuide.map
+++ b/implementations/r3maps/R3toR4/ImplementationGuide.map
@@ -51,7 +51,7 @@ group resource(source src, target tgt, source pck) extends BackboneElement {
   src.name -> tgt.name;
   src.description -> tgt.description;
   src.acronym as vs ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-ImplementationGuide.package.resource.acronym',  ext.value = vs;
-  src.source : uri as vs ->  tgt.reference as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri' "sourceUri";
+  src.source : uri as vs ->  tgt.reference as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri' "sourceUri";
   src.source : Reference as vs0 -> tgt.reference as vt0 then reference(vs0, vt0) "sourceRef";
   src.exampleFor as vs0 -> tgt.example = create('canonical') as vt0 then Reference2Canonical(vs0, vt0);
 }

--- a/implementations/r3maps/R3toR4/Observation.map
+++ b/implementations/r3maps/R3toR4/Observation.map
@@ -37,10 +37,10 @@ group Observation(source src : ObservationR3, target tgt : Observation) extends 
   src.referenceRange as vs0 -> tgt.referenceRange as vt0 then referenceRange(vs0, vt0);
   src.related as vs0 where type = 'has-member' -> tgt.hasMember as vt0 then related(vs0, vt0) "related1";
   src.related as vs0 where type = 'derived-from' -> tgt.derivedFrom as vt0 then related(vs0, vt0) "related2";
-  src.related as vs0 where type = 'sequel-to' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.sequelTo',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related3";
-  src.related as vs0 where type = 'replaces' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.replaces',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related4";
-  src.related as vs0 where type = 'qualified-by' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.qualifiedBy',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related5";
-  src.related as vs0 where type = 'interfered-by' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.interferedBy',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related6";
+  src.related as vs0 where type = 'sequel-to' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.sequelTo',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related3";
+  src.related as vs0 where type = 'replaces' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.replaces',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related4";
+  src.related as vs0 where type = 'qualified-by' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.qualifiedBy',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related5";
+  src.related as vs0 where type = 'interfered-by' ->  tgt.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.interferedBy',  ext.value = create('Reference') as vt0 then related(vs0, vt0) "related6";
   src.component as vs0 -> tgt.component as vt0 then component(vs0, vt0);
 }
 

--- a/implementations/r3maps/R3toR4/ProcedureRequest.map
+++ b/implementations/r3maps/R3toR4/ProcedureRequest.map
@@ -6,7 +6,7 @@ uses "http://hl7.org/fhir/StructureDefinition/ServiceRequest" alias ServiceReque
 imports "http://hl7.org/fhir/StructureMap/*3to4"
 
 group ServiceRequest(source src : ProcedureRequestR3, target tgt : ServiceRequest) extends DomainResource <<type+>> {
-  src as v ->  tgt.extension as vt,  vt.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  vt.value = 'ProcedureRequest' "ProcedureRequest";
+  src as v ->  tgt.extension as vt,  vt.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  vt.value = 'ProcedureRequest' "ProcedureRequest";
   src.identifier -> tgt.identifier;
   src.definition -> tgt.instantiatesCanonical;
   src.basedOn -> tgt.basedOn;

--- a/implementations/r3maps/R3toR4/Provenance.map
+++ b/implementations/r3maps/R3toR4/Provenance.map
@@ -20,16 +20,16 @@ group Provenance(source src : ProvenanceR3, target tgt : Provenance) extends Dom
 
 group agent(source src : ProvenanceR3, target tgt : Provenance) extends BackboneElement {
   src.role -> tgt.role;
-  src.who : uri as vs ->  tgt.who as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri';
+  src.who : uri as vs ->  tgt.who as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri';
   src.who : Reference as vs0 -> tgt.who as vt0 then Reference(vs0, vt0);
-  src.onBehalfOf : uri as vs ->  tgt.onBehalfOf as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri';
+  src.onBehalfOf : uri as vs ->  tgt.onBehalfOf as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri';
   src.onBehalfOf : Reference as vs0 -> tgt.onBehalfOf as vt0 then reference(vs0, vt0);
   src.relatedAgentType -> tgt.type;
 }
 
 group entity(source src : ProvenanceR3, target tgt : Provenance) extends BackboneElement {
   src.role -> tgt.role;
-  src.what : uri as vs ->  tgt.what as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri';
+  src.what : uri as vs ->  tgt.what as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri';
   src.what : Reference as vs0 -> tgt.what as vt0 then Reference(vs0, vt0);
   src.what : Identifier as vs0 -> tgt.what as vt0 then Identifier2Reference(vs0, vt0);
   src.agent as vs0 -> tgt.agent as vt0 then agent(vs0, vt0);

--- a/implementations/r3maps/R3toR4/ReferralRequest.map
+++ b/implementations/r3maps/R3toR4/ReferralRequest.map
@@ -6,7 +6,7 @@ uses "http://hl7.org/fhir/StructureDefinition/ServiceRequest" alias ServiceReque
 imports "http://hl7.org/fhir/StructureMap/*3to4"
 
 group ServiceRequest(source src : ReferralRequestR3, target tgt : ServiceRequest) extends DomainResource <<type+>> {
-  src as v ->  tgt.extension as vt,  vt.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  vt.value = 'ReferralRequest' "ReferralRequest";
+  src as v ->  tgt.extension as vt,  vt.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  vt.value = 'ReferralRequest' "ReferralRequest";
   src.identifier -> tgt.identifier;
   src.definition -> tgt.instantiatesCanonical;
   src.basedOn -> tgt.basedOn;

--- a/implementations/r3maps/R3toR4/Signature.map
+++ b/implementations/r3maps/R3toR4/Signature.map
@@ -8,9 +8,9 @@ imports "http://hl7.org/fhir/StructureMap/*3to4"
 group Signature(source src : SignatureR3, target tgt : Signature) extends Element <<type+>> {
   src.type -> tgt.type;
   src.when -> tgt.when;
-  src.who : uri as vs ->  tgt.who as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri';
+  src.who : uri as vs ->  tgt.who as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri';
   src.who : Reference as vs0 -> tgt.who as vt0 then Reference(vs0, vt0);
-  src.onBehalfOf : uri as vs ->  tgt.onBehalfOf as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/BaseType',  ext.value = 'uri';
+  src.onBehalfOf : uri as vs ->  tgt.onBehalfOf as ref,  ref.reference = vs,  ref.extension as ext,  ext.url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType',  ext.value = 'uri';
   src.onBehalfOf : Reference as vs0 -> tgt.onBehalfOf as vt0 then Reference(vs0, vt0);
   src.contentType -> tgt.sigFormat;
   src.blob -> tgt.data;

--- a/implementations/r3maps/R4toR3/ImplementationGuide.map
+++ b/implementations/r3maps/R4toR3/ImplementationGuide.map
@@ -53,8 +53,8 @@ group resource(source src, target tgt) extends BackboneElement {
   src.extension as ext where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-ImplementationGuide.package.resource.acronym' then {
     ext.value as vs0 -> tgt.acronym = vs0 "acronym2";
   } "acronym";
-  src.reference as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() -> tgt.source = create('Reference') as vt0 then Reference(vs0, vt0) "source1";
-  src.reference as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.source = create('uri') as vt0 then {
+  src.reference as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() -> tgt.source = create('Reference') as vt0 then Reference(vs0, vt0) "source1";
+  src.reference as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.source = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0) "source2a";
   } "source2";
   src.example : canonical as vs0 ->  tgt.example = true,  tgt.exampleFor as vt0 then canonical2Reference(vs0, vt0) "exampleFor";

--- a/implementations/r3maps/R4toR3/Observation.map
+++ b/implementations/r3maps/R4toR3/Observation.map
@@ -37,10 +37,10 @@ group Observation(source src : Observation, target tgt : ObservationR3) extends 
   src.referenceRange as vs0 -> tgt.referenceRange as vt0 then referenceRange(vs0, vt0);
   src.hasMember as vs0 ->  tgt.related as vt0,  vt0.type = 'has-member',  vt0.target as vt2 then Reference(vs0, vt2);
   src.derivedFrom as vs0 ->  tgt.related as vt0,  vt0.type = 'derived-from',  vt0.target as vt2 then Reference(vs0, vt2);
-  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.sequelTo' ->  tgt.related as rel,  rel.type = 'sequel-to',  rel.target as vt0 then relatedExt(vs0, vt0) "related3";
-  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.replaces' ->  tgt.related as rel,  rel.type = 'replaces',  rel.target as vt0 then relatedExt(vs0, vt0) "related4";
-  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.qualifiedBy' ->  tgt.related as rel,  rel.type = 'qualifiedBy',  rel.target as vt0 then relatedExt(vs0, vt0) "related5";
-  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/Observation.interferedBy' ->  tgt.related as rel,  rel.type = 'interfered-by',  rel.target as vt0 then relatedExt(vs0, vt0) "related6";
+  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.sequelTo' ->  tgt.related as rel,  rel.type = 'sequel-to',  rel.target as vt0 then relatedExt(vs0, vt0) "related3";
+  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.replaces' ->  tgt.related as rel,  rel.type = 'replaces',  rel.target as vt0 then relatedExt(vs0, vt0) "related4";
+  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.qualifiedBy' ->  tgt.related as rel,  rel.type = 'qualifiedBy',  rel.target as vt0 then relatedExt(vs0, vt0) "related5";
+  src.extension as vs0 where url = 'http://hl7.org/fhir/3.0/StructureDefinition/extension-Observation.interferedBy' ->  tgt.related as rel,  rel.type = 'interfered-by',  rel.target as vt0 then relatedExt(vs0, vt0) "related6";
   src.component as vs0 -> tgt.component as vt0 then component(vs0, vt0);
 }
 

--- a/implementations/r3maps/R4toR3/Provenance.map
+++ b/implementations/r3maps/R4toR3/Provenance.map
@@ -21,12 +21,12 @@ group Provenance(source src : Provenance, target tgt : ProvenanceR3) extends Dom
 
 group agent(source src : ProvenanceR3, target tgt : Provenance) extends BackboneElement {
   src.role -> tgt.role;
-  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() -> tgt.who = create('Reference') as vt0 then Reference(vs0, vt0);
-  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.who = create('uri') as vt0 then {
+  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() -> tgt.who = create('Reference') as vt0 then Reference(vs0, vt0);
+  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.who = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0);
   };
-  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() -> tgt.onBehalfOf = create('Reference') as vt0 then Reference(vs0, vt0);
-  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.onBehalfOf = create('uri') as vt0 then {
+  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() -> tgt.onBehalfOf = create('Reference') as vt0 then Reference(vs0, vt0);
+  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.onBehalfOf = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0);
   };
   src.type -> tgt.relatedAgentType;
@@ -34,8 +34,8 @@ group agent(source src : ProvenanceR3, target tgt : Provenance) extends Backbone
 
 group entity(source src : ProvenanceR3, target tgt : Provenance) extends BackboneElement {
   src.role -> tgt.role;
-  src.what as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() and identifier.empty() -> tgt.what = create('Reference') as vt0 then Reference(vs0, vt0);
-  src.what as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.what = create('uri') as vt0 then {
+  src.what as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() and identifier.empty() -> tgt.what = create('Reference') as vt0 then Reference(vs0, vt0);
+  src.what as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.what = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0);
   };
   src.what as vs0 where identifier.exists() -> tgt.what = create('Identifier') as vt0 then Reference2Identifier(vs0, vt0);

--- a/implementations/r3maps/R4toR3/Signature.map
+++ b/implementations/r3maps/R4toR3/Signature.map
@@ -8,12 +8,12 @@ imports "http://hl7.org/fhir/StructureMap/*4to3"
 group Signature(source src : SignatureR3, target tgt : Signature) extends Element <<type+>> {
   src.type -> tgt.type;
   src.when -> tgt.when;
-  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() -> tgt.who = create('Reference') as vt0 then Reference(vs0, vt0);
-  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.who = create('uri') as vt0 then {
+  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() -> tgt.who = create('Reference') as vt0 then Reference(vs0, vt0);
+  src.who as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.who = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0);
   };
-  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').empty() -> tgt.onBehalfOf = create('Reference') as vt0 then Reference(vs0, vt0);
-  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/BaseType').exists() -> tgt.onBehalfOf = create('uri') as vt0 then {
+  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').empty() -> tgt.onBehalfOf = create('Reference') as vt0 then Reference(vs0, vt0);
+  src.onBehalfOf as vs0 where extension('http://hl7.org/fhir/3.0/StructureDefinition/extension-BaseType').exists() -> tgt.onBehalfOf = create('uri') as vt0 then {
     vs0.reference as vs1 then uri(vs1, vt0);
   };
   src.sigFormat -> tgt.contentType;


### PR DESCRIPTION
As identified by @GinoCanessa [in zulip](https://chat.fhir.org/#narrow/stream/179166-implementers/topic/FHIR.20Mapping.20Language.20Question), a couple of extensions used in the mapping transforms weren't compliant with [the spec](http://hl7.org/fhir/versions.html#extensions) - this PR fixes them up.