### PR TITLE
Fix typo in Identity paragraph

### DIFF
--- a/source/http.html
+++ b/source/http.html
@@ -175,7 +175,7 @@ For the purposes of this specification, the following rules apply:
 </p>
 <ul>
  <li>The query part of the URL (anything after <code>?</code>) is ignored</li>
- <li>The comparison of the document portion of the URL (i.e. not the server/port) is case sensitive</li>
+ <li>The comparison of the document portion of the URL (i.e. not the server:port) is case sensitive</li>
  <li>The protocols <code>http:</code> and <code>https:</code> SHALL NOT be used to refer to different underlying objects</li>
  <li>If a port is specified, then the ports must be identical or the objects are different (due to
    the prevalence of port mapping and/or interface engines running on different ports). Ports should


### PR DESCRIPTION
## HL7 FHIR Pull Request

This pull request is associated with: https://jira.hl7.org/browse/FHIR-19668

## Description

Typo in Identity paragraph - server/port should be server:port
