### PR TITLE
J# 36333 ArtifactAssessment is now a DomainResource instead of MetadataResource

### DIFF
--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -23,9 +23,6 @@
   <extension url="http://hl7.org/fhir/build/StructureDefinition/entered-in-error-status">
     <valueCode value=".status = retired"/>
   </extension>
-  <extension url="http://hl7.org/fhir/build/StructureDefinition/template">
-    <valueString value="MetadataResource"/>
-  </extension>
   <url value="http://hl7.org/fhir/StructureDefinition/Citation"/>
   <version value="4.6.0"/>
   <name value="Citation"/>
@@ -69,7 +66,7 @@
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="Citation"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MetadataResource"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DomainResource"/>
   <derivation value="specialization"/>
   <differential>
     <element id="Citation">


### PR DESCRIPTION
ArtifactAssessment was approved as a DomainResource but inadvertently created as a MetadataResource. This has now been fixed.