### PR TITLE
J# 36250 fixed the CitationArtifactClassifier codesystem

### DIFF
--- a/source/citation/codesystem-citation-artifact-classifier.xml
+++ b/source/citation/codesystem-citation-artifact-classifier.xml
@@ -48,35 +48,219 @@
         
         
         </tr>
-        
+                  
         <tr>
           
-          <td style="white-space:nowrap">dataset
+          <td style="white-space:nowrap">audio
             
-            <a name="citation-artifact-classifier-dataset"> </a>
+            <a name="citation-artifact-classifier-audio"> </a>
+          
+          </td>
+          
+          <td>Audio file</td>
+          
+          <td>The article cited is an audio file.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D001877
+            
+            <a name="citation-artifact-classifier-D001877"> </a>
+          
+          </td>
+          
+          <td>Book</td>
+          
+          <td>Non-periodical written or printed works consisting of sheets of pages fastened or bound together within covers.</td>
+        
+        </tr>
+                                        				
+        <tr>
+          
+          <td style="white-space:nowrap">cds-artifact
+            
+            <a name="citation-artifact-classifier-cds-artifact"> </a>
+          
+          </td>
+          
+          <td>Clinical Decision Support Artifact</td>
+          
+          <td>The artifact is used for decision support for healthcare decisions.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D016420
+            
+            <a name="citation-artifact-classifier-D016420"> </a>
+          
+          </td>
+          
+          <td>Comment</td>
+          
+          <td>Comment</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">common-share
+            
+            <a name="citation-artifact-classifier-common-share"> </a>
+          
+          </td>
+          
+          <td>Common Share</td>
+          
+          <td>Citation Resource containing value added data that is openly shared</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D019991
+            
+            <a name="citation-artifact-classifier-D019991"> </a>
+          
+          </td>
+          
+          <td>Database</td>
+          
+          <td>A structured file of information or a set of logically related data stored and retrieved using computer-based means.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D064886
+            
+            <a name="citation-artifact-classifier-D064886"> </a>
           
           </td>
           
           <td>Dataset</td>
           
-          <td>Dataset</td>
+          <td>Works consisting of organized collections of data, which have been stored permanently in a formalized manner suitable for communication, interpretation, or processing.</td>
         
         </tr>
-        
+
         <tr>
           
-          <td style="white-space:nowrap">webpage
+          <td style="white-space:nowrap">dataset-unpublished
             
-            <a name="citation-artifact-classifier-webpage"> </a>
+            <a name="citation-artifact-classifier-dataset-unpublished"> </a>
           
           </td>
           
-          <td>Webpage</td>
+          <td>Dataset Unpublished</td>
           
-          <td>Webpage</td>
+          <td>An organized collection of data that is not stored permanently for communication.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">Electronic
+            
+            <a name="citation-artifact-classifier-Electronic"> </a>
+          
+          </td>
+          
+          <td>Electronic</td>
+          
+          <td>the journal is published in electronic format only</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">Electronic-eCollection
+            
+            <a name="citation-artifact-classifier-Electronic-eCollection"> </a>
+          
+          </td>
+          
+          <td>Electronic-eCollection</td>
+          
+          <td>used for electronic-only journals that publish individual articles first and then later collect them into an &quot;issue&quot; date that is typically called an eCollection.</td>
+        
+        
+        </tr>
+		
+        <tr>
+		
+          <td style="white-space:nowrap">Electronic-Print
+            
+            <a name="citation-artifact-classifier-Electronic-Print"> </a>
+          
+          </td>
+          
+          <td>Electronic-Print</td>
+          
+          <td>the journal is published first in electronic format followed by print (this value is currently used for just one journal, Nucleic Acids Research)</td>
+
+        </tr>
+		        
+        <tr>
+          
+          <td style="white-space:nowrap">executable-app
+            
+            <a name="citation-artifact-classifier-executable-app"> </a>
+          
+          </td>
+          
+          <td>Executable app</td>
+          
+          <td>Executable app</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">fhir-resource
+            
+            <a name="citation-artifact-classifier-fhir-resource"> </a>
+          
+          </td>
+          
+          <td>FHIR Resource</td>
+          
+          <td>The article cited is a FHIR resource.</td>
+        
+        </tr>		
+        
+        <tr>
+          
+          <td style="white-space:nowrap">image
+            
+            <a name="citation-artifact-classifier-image"> </a>
+          
+          </td>
+          
+          <td>Image file</td>
+          
+          <td>The article cited is an image file.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">interactive-form
+            
+            <a name="citation-artifact-classifier-interactive-form"> </a>
+          
+          </td>
+          
+          <td>Interactive Form</td>
+          
+          <td>A user interface that supports data entry and data display.</td>
         
         </tr>
         
+                
         <tr>
           
           <td style="white-space:nowrap">D016428
@@ -104,147 +288,7 @@
           <td>Letter</td>
         
         </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D016420
-            
-            <a name="citation-artifact-classifier-D016420"> </a>
-          
-          </td>
-          
-          <td>Comment</td>
-          
-          <td>Comment</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D016425
-            
-            <a name="citation-artifact-classifier-D016425"> </a>
-          
-          </td>
-          
-          <td>Published Erratum</td>
-          
-          <td>Published Erratum</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">executable-app
-            
-            <a name="citation-artifact-classifier-executable-app"> </a>
-          
-          </td>
-          
-          <td>Executable app</td>
-          
-          <td>Executable app</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D000076942
-            
-            <a name="citation-artifact-classifier-D000076942"> </a>
-          
-          </td>
-          
-          <td>Preprint</td>
-          
-          <td>Scientific manuscript made available prior to PEER REVIEW.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D019991
-            
-            <a name="citation-artifact-classifier-D019991"> </a>
-          
-          </td>
-          
-          <td>Database</td>
-          
-          <td>A structured file of information or a set of logically related data stored and retrieved using computer-based means.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D001877
-            
-            <a name="citation-artifact-classifier-D001877"> </a>
-          
-          </td>
-          
-          <td>Book</td>
-          
-          <td>Non-periodical written or printed works consisting of sheets of pages fastened or bound together within covers.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">D064886
-            
-            <a name="citation-artifact-classifier-D064886"> </a>
-          
-          </td>
-          
-          <td>Dataset</td>
-          
-          <td>Works consisting of organized collections of data, which have been stored permanently in a formalized manner suitable for communication, interpretation, or processing.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">68059040
-            
-            <a name="citation-artifact-classifier-68059040"> </a>
-          
-          </td>
-          
-          <td>Video-Audio Media</td>
-          
-          <td>Used with articles which include video files or clips, or for articles which are entirely video.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">audio
-            
-            <a name="citation-artifact-classifier-audio"> </a>
-          
-          </td>
-          
-          <td>Audio file</td>
-          
-          <td>The article cited is an audio file.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">image
-            
-            <a name="citation-artifact-classifier-image"> </a>
-          
-          </td>
-          
-          <td>Image file</td>
-          
-          <td>The article cited is an audio file.</td>
-        
-        </tr>
-        
+		
         <tr>
           
           <td style="white-space:nowrap">machine-code
@@ -258,135 +302,7 @@
           <td>The article cited is machine code.</td>
         
         </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">protocol
-            
-            <a name="citation-artifact-classifier-protocol"> </a>
-          
-          </td>
-          
-          <td>Protocol</td>
-          
-          <td>The article cited is the protocol of an activity and not the results or findings.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          <td style="white-space:nowrap">fhir-resource
-            
-            <a name="citation-artifact-classifier-fhir-resource"> </a>
-          
-          </td>
-          
-          <td>FHIR Resource</td>
-          
-          <td>The article cited is a FHIR resource.</td>
-        
-        </tr>
-        
-        <tr>
-          
-          
-          <td style="white-space:nowrap">Print
-            
-            
-            <a name="citation-artifact-classifier-Print"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Print</td>
-          
-          
-          <td>the journal is published in print format only</td>
-        
-        
-        </tr>
-        
-        <tr>
-          
-          
-          <td style="white-space:nowrap">Print Electronic
-            
-            
-            <a name="citation-artifact-classifier-Print-Electronic"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Print Electronic</td>
-          
-          
-          <td>the journal is published in both print and electronic format</td>
-        
-        
-        </tr>
-        
-        <tr>
-          
-          
-          <td style="white-space:nowrap">Electronic
-            
-            
-            <a name="citation-artifact-classifier-Electronic"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Electronic</td>
-          
-          
-          <td>the journal is published in electronic format only</td>
-        
-        
-        </tr>
-        
-        <tr>
-          
-          
-          <td style="white-space:nowrap">Electronic-Print
-            
-            
-            <a name="citation-artifact-classifier-Electronic-Print"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Electronic-Print</td>
-          
-          
-          <td>the journal is published first in electronic format followed by print (this value is currently used for just one journal, Nucleic Acids Research)</td>
-        
-        
-        </tr>
-        
-        <tr>
-          
-          
-          <td style="white-space:nowrap">Electronic-eCollection
-            
-            
-            <a name="citation-artifact-classifier-Electronic-eCollection"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Electronic-eCollection</td>
-          
-          
-          <td>used for electronic-only journals that publish individual articles first and then later collect them into an &quot;issue&quot; date that is typically called an eCollection.</td>
-        
-        
-        </tr>
-        
+		
         <tr>
           
           
@@ -406,62 +322,6 @@
         
         
         </tr>
-		
-        <tr>
-          
-          
-          <td style="white-space:nowrap">common-share
-            
-            
-            <a name="citation-artifact-classifier-common-share"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Common Share</td>
-          
-          
-          <td>Citation Resource containing value added data that is openly shared</td>
-        
-        
-        </tr>
-		
-        <tr>
-          
-          
-          <td style="white-space:nowrap">project-specific
-            
-            
-            <a name="citation-artifact-classifier-project-specific"> </a>
-          
-          
-          </td>
-          
-          
-          <td>Project Specific</td>
-          
-          
-          <td>Citation Resource containing value added data specific to a project</td>
-        
-        
-        </tr>
-		
-        <tr>
-          
-          <td style="white-space:nowrap">cds-artifact
-            
-            <a name="citation-artifact-classifier-cds-artifact"> </a>
-          
-          </td>
-          
-          <td>Clinical Decision Support Artifact</td>
-          
-          <td>The artifact is used for decision support for healthcare decisions.</td>
-        
-        </tr>
-
-
 
         <tr>
           
@@ -476,40 +336,76 @@
           <td>A formula or expression used to calculate an outcome representing a predicted result.</td>
         
         </tr>
-
-
-
+		
         <tr>
           
-          <td style="white-space:nowrap">interactive-form
+          <td style="white-space:nowrap">D000076942
             
-            <a name="citation-artifact-classifier-interactive-form"> </a>
+            <a name="citation-artifact-classifier-D000076942"> </a>
           
           </td>
           
-          <td>Interactive Form</td>
+          <td>Preprint</td>
           
-          <td>A user interface that supports data entry and data display.</td>
+          <td>Scientific manuscript made available prior to PEER REVIEW.</td>
         
         </tr>
-
-
-
+        
         <tr>
           
-          <td style="white-space:nowrap">terminology
+          <td style="white-space:nowrap">Print
             
-            <a name="citation-artifact-classifier-terminology"> </a>
+            <a name="citation-artifact-classifier-Print"> </a>
           
           </td>
           
-          <td>Terminology</td>
+          <td>Print</td>
           
-          <td>A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology.</td>
+          <td>the journal is published in print format only</td>
+
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">Print Electronic
+            
+            <a name="citation-artifact-classifier-Print-Electronic"> </a>
+          
+          </td>
+          
+          <td>Print Electronic</td>
+          
+          <td>the journal is published in both print and electronic format</td>
         
         </tr>
-
-
+		
+        <tr>
+          
+          <td style="white-space:nowrap">project-specific
+            
+            <a name="citation-artifact-classifier-project-specific"> </a>
+          
+          </td>
+          
+          <td>Project Specific</td>
+          
+          <td>Citation Resource containing value added data specific to a project</td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">protocol
+            
+            <a name="citation-artifact-classifier-protocol"> </a>
+          
+          </td>
+          
+          <td>Protocol</td>
+          
+          <td>The article cited is the protocol of an activity and not the results or findings.</td>
+        
+        </tr>
 
         <tr>
           
@@ -524,8 +420,20 @@
           <td>A non-executable, human-readable representation of software code.</td>
         
         </tr>
-
-
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D016425
+            
+            <a name="citation-artifact-classifier-D016425"> </a>
+          
+          </td>
+          
+          <td>Published Erratum</td>
+          
+          <td>Published Erratum</td>
+        
+        </tr>
 
         <tr>
           
@@ -539,7 +447,49 @@
           
           <td>An explicit set of requirements for an item, material, component, system or service, often used to define a technical standard which is an established norm or requirement for a repeatable technical task.</td>
         
-        </tr>		
+        </tr>        
+
+        <tr>
+          
+          <td style="white-space:nowrap">terminology
+            
+            <a name="citation-artifact-classifier-terminology"> </a>
+          
+          </td>
+          
+          <td>Terminology</td>
+          
+          <td>A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology.</td>
+        
+        </tr>
+		
+        <tr>
+          
+          <td style="white-space:nowrap">D059040
+            
+            <a name="citation-artifact-classifier-D059040"> </a>
+          
+          </td>
+          
+          <td>Video-Audio Media</td>
+          
+          <td>Used with articles which include video files or clips, or for articles which are entirely video.</td>
+        
+        </tr>
+        
+        <tr>
+          
+          <td style="white-space:nowrap">webpage
+            
+            <a name="citation-artifact-classifier-webpage"> </a>
+          
+          </td>
+          
+          <td>Webpage</td>
+          
+          <td>Webpage</td>
+        
+        </tr>
         
       </table>
     
@@ -582,9 +532,79 @@
   <valueSet value="http://hl7.org/fhir/ValueSet/citation-artifact-classifier"/>
   <content value="complete"/>
   <concept>
-    <code value="webpage"/>
-    <display value="Webpage"/>
-    <definition value="Webpage"/>
+    <code value="audio"/>
+    <display value="Audio file"/>
+    <definition value="The article cited is an audio file."/>
+  </concept>
+  <concept>
+    <code value="D001877"/>
+    <display value="Book"/>
+    <definition value="Non-periodical written or printed works consisting of sheets of pages fastened or bound together within covers."/>
+  </concept>
+  <concept>
+    <code value="cds-artifact"/>
+    <display value="Clinical Decision Support Artifact"/>
+    <definition value="The artifact is used for decision support for healthcare decisions."/>
+  </concept>
+  <concept>
+    <code value="D016420"/>
+    <display value="Comment"/>
+    <definition value="Comment"/>
+  </concept>
+  <concept>
+    <code value="common-share"/>
+    <display value="Common Share"/>
+    <definition value="Citation Resource containing value added data that is openly shared"/>
+  </concept>
+  <concept>
+    <code value="D019991"/>
+    <display value="Database"/>
+    <definition value="A structured file of information or a set of logically related data stored and retrieved using computer-based means."/>
+  </concept>
+  <concept>
+    <code value="D064886"/>
+    <display value="Dataset"/>
+    <definition value="Works consisting of organized collections of data, which have been stored permanently in a formalized manner suitable for communication, interpretation, or processing."/>
+  </concept>
+  <concept>
+    <code value="dataset-unpublished"/>
+    <display value="Dataset Unpublished"/>
+    <definition value="An organized collection of data that is not stored permanently for communication."/>
+  </concept>
+  <concept>
+    <code value="Electronic"/>
+    <display value="Electronic"/>
+    <definition value="the journal is published in electronic format only"/>
+  </concept>
+  <concept>
+    <code value="Electronic-eCollection"/>
+    <display value="Electronic-eCollection"/>
+    <definition value="used for electronic-only journals that publish individual articles first and then later collect them into an &quot;issue&quot; date that is typically called an eCollection."/>
+  </concept>
+  <concept>
+    <code value="Electronic-Print"/>
+    <display value="Electronic-Print"/>
+    <definition value="the journal is published first in electronic format followed by print (this value is currently used for just one journal, Nucleic Acids Research)"/>
+  </concept>
+  <concept>
+    <code value="executable-app"/>
+    <display value="Executable app"/>
+    <definition value="Executable app"/>
+  </concept>
+  <concept>
+    <code value="fhir-resource"/>
+    <display value="FHIR Resource"/>
+    <definition value="The article cited is a FHIR resource."/>
+  </concept>
+  <concept>
+    <code value="image"/>
+    <display value="Image file"/>
+    <definition value="The article cited is an image file."/>
+  </concept>
+  <concept>
+    <code value="interactive-form"/>
+    <display value="Interactive Form"/>
+    <definition value="A user interface that supports data entry and data display."/>
   </concept>
   <concept>
     <code value="D016428"/>
@@ -597,69 +617,24 @@
     <definition value="Letter"/>
   </concept>
   <concept>
-    <code value="D016420"/>
-    <display value="Comment"/>
-    <definition value="Comment"/>
-  </concept>
-  <concept>
-    <code value="D016425"/>
-    <display value="Published Erratum"/>
-    <definition value="Published Erratum"/>
-  </concept>
-  <concept>
-    <code value="executable-app"/>
-    <display value="Executable app"/>
-    <definition value="Executable app"/>
-  </concept>
-  <concept>
-    <code value="D000076942"/>
-    <display value="Preprint"/>
-    <definition value="Scientific manuscript made available prior to PEER REVIEW."/>
-  </concept>
-  <concept>
-    <code value="D019991"/>
-    <display value="Database"/>
-    <definition value="A structured file of information or a set of logically related data stored and retrieved using computer-based means."/>
-  </concept>
-  <concept>
-    <code value="D001877"/>
-    <display value="Book"/>
-    <definition value="Non-periodical written or printed works consisting of sheets of pages fastened or bound together within covers."/>
-  </concept>
-  <concept>
-    <code value="D064886"/>
-    <display value="Dataset"/>
-    <definition value="Works consisting of organized collections of data, which have been stored permanently in a formalized manner suitable for communication, interpretation, or processing."/>
-  </concept>
-  <concept>
-    <code value="68059040"/>
-    <display value="Video-Audio Media"/>
-    <definition value="Used with articles which include video files or clips, or for articles which are entirely video."/>
-  </concept>
-  <concept>
-    <code value="audio"/>
-    <display value="Audio file"/>
-    <definition value="The article cited is an audio file."/>
-  </concept>
-  <concept>
-    <code value="image"/>
-    <display value="Image file"/>
-    <definition value="The article cited is an audio file."/>
-  </concept>
-  <concept>
     <code value="machine-code"/>
     <display value="Machine code"/>
     <definition value="The article cited is machine code."/>
   </concept>
   <concept>
-    <code value="protocol"/>
-    <display value="Protocol"/>
-    <definition value="The article cited is the protocol of an activity and not the results or findings."/>
+    <code value="medline-base"/>
+    <display value="Medline Base"/>
+    <definition value="Citation Resource containing only data from Medline"/>
   </concept>
   <concept>
-    <code value="fhir-resource"/>
-    <display value="FHIR Resource"/>
-    <definition value="The article cited is a FHIR resource."/>
+    <code value="prediction-model"/>
+    <display value="Prediction Model"/>
+    <definition value="A formula or expression used to calculate an outcome representing a predicted result."/>
+  </concept>
+  <concept>
+    <code value="D000076942"/>
+    <display value="Preprint"/>
+    <definition value="Scientific manuscript made available prior to PEER REVIEW."/>
   </concept>
   <concept>
     <code value="Print"/>
@@ -672,54 +647,14 @@
     <definition value="the journal is published in both print and electronic format"/>
   </concept>
   <concept>
-    <code value="Electronic"/>
-    <display value="Electronic"/>
-    <definition value="the journal is published in electronic format only"/>
-  </concept>
-  <concept>
-    <code value="Electronic-Print"/>
-    <display value="Electronic-Print"/>
-    <definition value="the journal is published first in electronic format followed by print (this value is currently used for just one journal, Nucleic Acids Research)"/>
-  </concept>
-  <concept>
-    <code value="Electronic-eCollection"/>
-    <display value="Electronic-eCollection"/>
-    <definition value="used for electronic-only journals that publish individual articles first and then later collect them into an &quot;issue&quot; date that is typically called an eCollection."/>
-  </concept>
-  <concept>
-    <code value="medline-base"/>
-    <display value="Medline Base"/>
-    <definition value="Citation Resource containing only data from Medline"/>
-  </concept>
-  <concept>
-    <code value="common-share"/>
-    <display value="Common Share"/>
-    <definition value="Citation Resource containing value added data that is openly shared"/>
-  </concept>
-  <concept>
     <code value="project-specific"/>
     <display value="Project Specific"/>
     <definition value="Citation Resource containing value added data specific to a project"/>
   </concept>
   <concept>
-    <code value="cds-artifact"/>
-    <display value="Clinical Decision Support Artifact"/>
-    <definition value="The artifact is used for decision support for healthcare decisions."/>
-  </concept>
-  <concept>
-    <code value="prediction-model"/>
-    <display value="Prediction Model"/>
-    <definition value="A formula or expression used to calculate an outcome representing a predicted result."/>
-  </concept>
-  <concept>
-    <code value="interactive-form"/>
-    <display value="Interactive Form"/>
-    <definition value="A user interface that supports data entry and data display."/>
-  </concept>
-  <concept>
-    <code value="terminology"/>
-    <display value="Terminology"/>
-    <definition value="A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology."/>
+    <code value="protocol"/>
+    <display value="Protocol"/>
+    <definition value="The article cited is the protocol of an activity and not the results or findings."/>
   </concept>
   <concept>
     <code value="pseudocode"/>
@@ -727,8 +662,28 @@
     <definition value="A non-executable, human-readable representation of software code."/>
   </concept>
   <concept>
+    <code value="D016425"/>
+    <display value="Published Erratum"/>
+    <definition value="Published Erratum"/>
+  </concept>
+  <concept>
     <code value="standard-specification"/>
     <display value="Standard Specification"/>
     <definition value="An explicit set of requirements for an item, material, component, system or service, often used to define a technical standard which is an established norm or requirement for a repeatable technical task."/>
+  </concept>
+  <concept>
+    <code value="terminology"/>
+    <display value="Terminology"/>
+    <definition value="A structured set of codes and display values, which may be subtyped as a code system, value set, taxonomy, or ontology."/>
+  </concept>
+  <concept>
+    <code value="D059040"/>
+    <display value="Video-Audio Media"/>
+    <definition value="Used with articles which include video files or clips, or for articles which are entirely video."/>
+  </concept>
+  <concept>
+    <code value="webpage"/>
+    <display value="Webpage"/>
+    <definition value="Webpage"/>
   </concept>
 </CodeSystem>


### PR DESCRIPTION
There were three errors in the CitationArtifactClassifier codesystem which is now fixed. And the codes are now alphabetized by Display.