### PR TITLE
Completed J# 36333 properly where ArtifactAssessment is now a DomainResource

### DIFF
--- a/source/artifactassessment/structuredefinition-ArtifactAssessment.xml
+++ b/source/artifactassessment/structuredefinition-ArtifactAssessment.xml
@@ -20,9 +20,6 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
     <valueCode value="cds"/>
   </extension>
-  <extension url="http://hl7.org/fhir/build/StructureDefinition/template">
-    <valueString value="MetadataResource"/>
-  </extension>
   <url value="http://hl7.org/fhir/StructureDefinition/ArtifactAssessment"/>
   <version value="4.6.0"/>
   <name value="ArtifactAssessment"/>
@@ -66,7 +63,7 @@
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="ArtifactAssessment"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MetadataResource"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DomainResource"/>
   <derivation value="specialization"/>
   <differential>
     <element id="ArtifactAssessment">

--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -23,6 +23,9 @@
   <extension url="http://hl7.org/fhir/build/StructureDefinition/entered-in-error-status">
     <valueCode value=".status = retired"/>
   </extension>
+  <extension url="http://hl7.org/fhir/build/StructureDefinition/template">
+    <valueString value="MetadataResource"/>
+  </extension>
   <url value="http://hl7.org/fhir/StructureDefinition/Citation"/>
   <version value="4.6.0"/>
   <name value="Citation"/>
@@ -66,7 +69,7 @@
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="Citation"/>
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DomainResource"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/MetadataResource"/>
   <derivation value="specialization"/>
   <differential>
     <element id="Citation">


### PR DESCRIPTION
Made it so ArtifactAssessment is now a DomainResource, and Citation resource is restored back to a MetadataResource. The latter was accidently made a DomainResource by me in one of my recent commits.