### PR TITLE
FHIR-22829 - fix typos for 'secondary findings'

### DIFF
--- a/source/observation/codesystem-secondary-finding.xml
+++ b/source/observation/codesystem-secondary-finding.xml
@@ -17,7 +17,7 @@
   <title value="Genetic Observation Secondary Findings"/>
   <status value="draft"/>
   <experimental value="false"/>
-  <description value="Codes to denote a guideline or policy statement.when a genetic test result is being shared as a secondary finding."/>
+  <description value="Codes to denote a guideline or policy statement when a genetic test result is being shared as a secondary finding."/>
   <caseSensitive value="true"/>
   <valueSet value="http://hl7.org/fhir/ValueSet/secondary-finding"/>
   <content value="complete"/>

--- a/source/observation/structuredefinition-extension-observation-secondaryFinding.xml
+++ b/source/observation/structuredefinition-extension-observation-secondaryFinding.xml
@@ -64,7 +64,7 @@
           <valueString value="SecondaryFinding"/>
         </extension>
         <strength value="extensible"/>
-        <description value="Codes to denote a guideline or policy statement.when a genetic test result is being shared as a secondary finding."/>
+        <description value="Codes to denote a guideline or policy statement when a genetic test result is being shared as a secondary finding."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/secondary-finding"/>
       </binding>
     </element>

--- a/source/observation/valueset-secondary-finding.xml
+++ b/source/observation/valueset-secondary-finding.xml
@@ -13,8 +13,8 @@
     <system value="urn:ietf:rfc:3986"/>
     <value value="urn:oid:2.16.840.1.113883.4.642.3.1285"/>
   </identifier>
-  <name value="ObservationCategoryCodes"/>
-  <title value="Observation Category Codes"/>
+  <name value="GeneticObservationSecondaryFindings"/>
+  <title value="Genetic Observation Secondary Findings"/>
   <status value="draft"/>
   <publisher value="FHIR Project team"/>
   <contact>
@@ -23,7 +23,7 @@
       <value value="http://hl7.org/fhir"/>
     </telecom>
   </contact>
-  <description value="Codes to denote a guideline or policy statement.when a genetic test result is being shared as a secondary finding."/>
+  <description value="Codes to denote a guideline or policy statement when a genetic test result is being shared as a secondary finding."/>
   <compose>
     <include>
       <system value="http://hl7.org/fhir/secondary-finding"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request
FHIR-22829 

## Description
Corrections for ValueSet name and title (copy/paste errors), and fix typo in descriptions for value set, code system, and extension.
