### PR TITLE
J# 36332, J# 34446

### DIFF
--- a/source/citation/codesystem-cited-artifact-status-type.xml
+++ b/source/citation/codesystem-cited-artifact-status-type.xml
@@ -258,7 +258,21 @@
           
           <td>The content has been approved for a state transition, with the focus of approval described in the text associated with this coding.</td>
         
-        </tr>      
+        </tr>    
+		
+        <tr>
+          
+          <td style="white-space:nowrap">unknown
+            
+            <a name="cited-artifact-status-type-unknown"> </a>
+          
+          </td>
+          
+          <td>Unknown</td>
+          
+          <td>The status of the content is not recorded in the metadata.</td>
+        
+        </tr>    
       
       </table>
     
@@ -374,5 +388,10 @@
     <code value="approved"/>
     <display value="Approved"/>
     <definition value="The content has been approved for a state transition, with the focus of approval described in the text associated with this coding."/>
+  </concept>
+  <concept>
+    <code value="unknown"/>
+    <display value="Unknown"/>
+    <definition value="The status of the content is not recorded in the metadata."/>
   </concept>
 </CodeSystem>

--- a/source/citation/codesystem-related-artifact-type-expanded.xml
+++ b/source/citation/codesystem-related-artifact-type-expanded.xml
@@ -10,624 +10,898 @@
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       
+      
       <p>This code system http://terminology.hl7.org/CodeSystem/related-artifact-type-expanded defines the following codes:</p>
+      
       
       <table class="codes">
         
+        
         <tr>
+          
           
           <td style="white-space:nowrap">
             
+            
             <b>Code</b>
+          
           
           </td>
           
+          
           <td>
+            
             
             <b>Display</b>
           
+          
           </td>
+          
           
           <td>
             
+            
             <b>Definition</b>
           
+          
           </td>
+        
         
         </tr>
         
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">documentation
             
+            
             <a name="related-artifact-type-expanded-documentation"> </a>
           
+          
           </td>
+          
           
           <td>Documentation</td>
           
+          
           <td>Additional documentation for the knowledge resource. This would include additional instructions on usage as well as additional information on clinical context or appropriateness</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">justification
             
+            
             <a name="related-artifact-type-expanded-justification"> </a>
           
+          
           </td>
+          
           
           <td>Justification</td>
           
+          
           <td>The target artifact is a summary of the justification for the knowledge resource including supporting evidence, relevant guidelines, or other clinically important information. This information is intended to provide a way to make the justification for the knowledge resource available to the consumer of interventions or results produced by the knowledge resource.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">predecessor
             
+            
             <a name="related-artifact-type-expanded-predecessor"> </a>
           
+          
           </td>
+          
           
           <td>Predecessor</td>
           
+          
           <td>The previous version of the knowledge artifact, used to establish an ordering of versions of an artifact, independent of the status of each version.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">successor
             
+            
             <a name="related-artifact-type-expanded-successor"> </a>
           
+          
           </td>
+          
           
           <td>Successor</td>
           
+          
           <td>The subsequent version of the knowledge artfact, used to establish an ordering of versions of an artifact, independent of the status of each version.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">derived-from
             
+            
             <a name="related-artifact-type-expanded-derived-from"> </a>
           
+          
           </td>
+          
           
           <td>Derived From</td>
           
+          
           <td>This artifact is derived from the target artifact. This is intended to capture the relationship in which a particular knowledge resource is based on the content of another artifact, but is modified to capture either a different set of overall requirements, or a more specific set of requirements such as those involved in a particular institution or clinical setting. The artifact may be derived from one or more target artifacts.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">depends-on
             
+            
             <a name="related-artifact-type-expanded-depends-on"> </a>
           
+          
           </td>
+          
           
           <td>Depends On</td>
           
+          
           <td>This artifact depends on the target artifact. There is a requirement to use the target artifact in the implementation or interpretation of this artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">composed-of
             
+            
             <a name="related-artifact-type-expanded-composed-of"> </a>
           
+          
           </td>
+          
           
           <td>Composed Of</td>
           
+          
           <td>This artifact is composed of the target artifact. This artifact is constructed with the target artifact as a component. The target artifact is a part of this artifact. (A dataset is composed of data.)</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">part-of
             
+            
             <a name="related-artifact-type-expanded-part-of"> </a>
           
+          
           </td>
+          
           
           <td>Part Of</td>
           
+          
           <td>This artifact is a part of the target artifact. The target artifact is composed of this artifact (and possibly other artifacts).</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">amends
             
+            
             <a name="related-artifact-type-expanded-amends"> </a>
           
+          
           </td>
+          
           
           <td>Amends</td>
           
+          
           <td>This artifact amends or changes the target artifact. This artifact adds additional information that is functionally expected to replace information in the target artifact. This artifact replaces a part but not all of the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">amended-with
             
+            
             <a name="related-artifact-type-expanded-amended-with"> </a>
           
+          
           </td>
+          
           
           <td>Amended With</td>
           
+          
           <td>This artifact is amended with or changed by the target artifact. There is information in this artifact that should be functionally replaced with information in the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">appends
             
+            
             <a name="related-artifact-type-expanded-appends"> </a>
           
+          
           </td>
+          
           
           <td>Appends</td>
           
+          
           <td>This artifact adds additional information to the target artifact. The additional information does not replace or change information in the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">appended-with
             
+            
             <a name="related-artifact-type-expanded-appended-with"> </a>
           
+          
           </td>
+          
           
           <td>Appended With</td>
           
+          
           <td>This artifact has additional information in the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">cites
             
+            
             <a name="related-artifact-type-expanded-cites"> </a>
           
+          
           </td>
+          
           
           <td>Cites</td>
           
+          
           <td>This artifact cites the target artifact. This may be a bibliographic citation for papers, references, or other relevant material for the knowledge resource. This is intended to allow for citation of related material, but that was not necessarily specifically prepared in connection with this knowledge resource.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">cited-by
             
+            
             <a name="related-artifact-type-expanded-cited-by"> </a>
           
+          
           </td>
+          
           
           <td>Cited By</td>
           
+          
           <td>This artifact is cited by the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">comments-on
             
+            
             <a name="related-artifact-type-expanded-comments-on"> </a>
           
+          
           </td>
+          
           
           <td>Is Comment On</td>
           
+          
           <td>This artifact contains comments about the target artifact. </td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">comment-in
             
+            
             <a name="related-artifact-type-expanded-comment-in"> </a>
           
+          
           </td>
+          
           
           <td>Has Comment In</td>
           
+          
           <td>This artifact has comments about it in the target artifact.  The type of comments may be expressed in the targetClassifier element such as reply, review, editorial, feedback, solicited, unsolicited, structured, unstructured.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">contains
             
+            
             <a name="related-artifact-type-expanded-contains"> </a>
           
+          
           </td>
+          
           
           <td>Contains</td>
           
+          
           <td>This artifact is a container in which the target artifact is contained. A container is a data structure whose instances are collections of other objects. (A database contains the dataset.)</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">contained-in
             
+            
             <a name="related-artifact-type-expanded-contained-in"> </a>
           
+          
           </td>
+          
           
           <td>Contained In</td>
           
+          
           <td>This artifact is contained in the target artifact. The target artifact is a data structure whose instances are collections of other objects.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">corrects
             
+            
             <a name="related-artifact-type-expanded-corrects"> </a>
           
+          
           </td>
+          
           
           <td>Corrects</td>
           
+          
           <td>This artifact identifies errors and replacement content for the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">correction-in
             
+            
             <a name="related-artifact-type-expanded-correction-in"> </a>
           
+          
           </td>
+          
           
           <td>Correction In</td>
           
+          
           <td>This artifact has corrections to it in the target artifact. The target artifact identifies errors and replacement content for this artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">replaces
             
+            
             <a name="related-artifact-type-expanded-replaces"> </a>
           
+          
           </td>
+          
           
           <td>Replaces</td>
           
+          
           <td>This artifact replaces or supersedes the target artifact. The target artifact may be considered deprecated.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">replaced-with
             
+            
             <a name="related-artifact-type-expanded-replaced-with"> </a>
           
+          
           </td>
+          
           
           <td>Replaced With</td>
           
+          
           <td>This artifact is replaced with or superseded by the target artifact. This artifact may be considered deprecated.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">retracts
             
+            
             <a name="related-artifact-type-expanded-retracts"> </a>
           
+          
           </td>
+          
           
           <td>Retracts</td>
           
+          
           <td>This artifact retracts the target artifact. The content that was published in the target artifact should be considered removed from publication and should no longer be considered part of the public record.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">retracted-by
             
+            
             <a name="related-artifact-type-expanded-retracted-by"> </a>
           
+          
           </td>
+          
           
           <td>Retracted By</td>
           
+          
           <td>This artifact is retracted by the target artifact. The content that was published in this artifact should be considered removed from publication and should no longer be considered part of the public record.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">signs
             
+            
             <a name="related-artifact-type-expanded-signs"> </a>
           
+          
           </td>
+          
           
           <td>Signs</td>
           
+          
           <td>This artifact is a signature of the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">similar-to
             
+            
             <a name="related-artifact-type-expanded-similar-to"> </a>
           
+          
           </td>
+          
           
           <td>Similar To</td>
           
+          
           <td>This artifact has characteristics in common with the target artifact. This relationship may be used in systems to “deduplicate” knowledge artifacts from different sources, or in systems to show “similar items”.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">supports
             
+            
             <a name="related-artifact-type-expanded-supports"> </a>
           
+          
           </td>
+          
           
           <td>Supports</td>
           
+          
           <td>This artifact provides additional support for the target artifact. The type of support  is not documentation as it does not describe, explain, or instruct regarding the target artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">supported-with
             
+            
             <a name="related-artifact-type-expanded-supported-with"> </a>
           
+          
           </td>
+          
           
           <td>Supported With</td>
           
+          
           <td>The target artifact contains additional information related to the knowledge artifact but is not documentation as the additional information does not describe, explain, or instruct regarding the knowledge artifact content or application. This could include an associated dataset.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">transforms
             
+            
             <a name="related-artifact-type-expanded-transforms"> </a>
           
+          
           </td>
+          
           
           <td>Transforms</td>
           
+          
           <td>This artifact was generated by transforming the target artifact (e.g., format or language conversion). This is intended to capture the relationship in which a particular knowledge resource is based on the content of another artifact, but changes are only apparent in form and there is only one target artifact with the “transforms” relationship type.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">transformed-into
             
+            
             <a name="related-artifact-type-expanded-transformed-into"> </a>
           
+          
           </td>
+          
           
           <td>Transformed Into</td>
           
+          
           <td>This artifact was transformed into the target artifact (e.g., by format or language conversion).</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">transformed-with
             
+            
             <a name="related-artifact-type-expanded-transformed-with"> </a>
           
+          
           </td>
+          
           
           <td>Transformed With</td>
           
+          
           <td>This artifact was generated by transforming a related artifact (e.g., format or language conversion), noted separately with the “transforms” relationship type. This transformation used the target artifact to inform the transformation. The target artifact may be a conversion script or translation guide.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">cite-as
             
+            
             <a name="related-artifact-type-expanded-cite-as"> </a>
           
+          
           </td>
+          
           
           <td>Citation for</td>
           
+          
           <td>The related artifact is the citation for this artifact.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">created-with
             
+            
             <a name="related-artifact-type-expanded-created-with"> </a>
           
+          
           </td>
+          
           
           <td>Created With</td>
           
+          
           <td>This artifact was created with the target artifact. The target artifact is a tool or support material used in the creation of the artifact, and not content that the artifact was derived from.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">documents
             
+            
             <a name="related-artifact-type-expanded-documents"> </a>
           
+          
           </td>
+          
           
           <td>Documents</td>
           
+          
           <td>This artifact provides additional documentation for the target artifact. This could include additional instructions on usage as well as additional information on clinical context or appropriateness.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">reprint
             
+            
             <a name="related-artifact-type-expanded-reprint"> </a>
           
+          
           </td>
+          
           
           <td>Reprint</td>
           
+          
           <td>A copy of the artifact in a publication with a different artifact identifier.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">reprint-of
             
+            
             <a name="related-artifact-type-expanded-reprint-of"> </a>
           
+          
           </td>
+          
           
           <td>Reprint Of</td>
           
+          
           <td>The original version of record for which the current artifact is a copy.</td>
+        
         
         </tr>
 
 
 
+        
         <tr>
+          
           
           <td style="white-space:nowrap">specification-of
             
+            
             <a name="related-artifact-type-expanded-specification-of"> </a>
+          
           
           </td>
           
+          
           <td>Specification of</td>
+          
           
           <td>The target artifact is a precise description of a concept in this artifact. This may be used when the RelatedArtifact datatype is used in elements contained in this artifact.</td>
         
+        
         </tr>
 		
+      
       </table>
+    
     
     </div>
   </text>
@@ -643,7 +917,7 @@
   <url value="http://terminology.hl7.org/CodeSystem/related-artifact-type-expanded"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.1.1505"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.1.0"/>
   </identifier>
   <version value="4.6.0"/>
   <name value="RelatedArtifactTypeExpanded"/>

--- a/source/citation/list-Citation-examples.xml
+++ b/source/citation/list-Citation-examples.xml
@@ -6,18 +6,6 @@
   <mode value="working"/>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
-      <valueString value="Systematic Meta Review"/>
-    </extension>
-    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
-      <valueString value="citation-example-systematic-meta-review"/>
-    </extension>
-    <item>
-      <reference value="Citation/citation-example-systematic-meta-review"/>
-      <display value="Systematic Meta Review"/>
-    </item>
-  </entry>
-  <entry>
-    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
       <valueString value="NInFEA Citation"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">

--- a/source/citation/structuredefinition-Citation.xml
+++ b/source/citation/structuredefinition-Citation.xml
@@ -927,7 +927,104 @@
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="RelatedArtifact"/>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.type">
+      <path value="Citation.citedArtifact.relatesTo.type"/>
+      <short value="documentation | justification | predecessor | successor | derived-from | depends-on | composed-of | part-of | amends | amended-with | appends | appended-with | cites | cited-by | comments-on | comment-in | contains | contained-in | corrects | correction-in | replaces | replaced-with | retracts | retracted-by | signs | similar-to | supports | supported-with | transforms | transformed-into | transformed-with | cite-as | created-with | documents | reprint | reprint-of | specification-of"/>
+      <definition value="The type of relationship to the related artifact."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="RelatedArtifactTypeExpanded"/>
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/related-artifact-type-expanded"/>
+      </binding>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.classifier">
+      <path value="Citation.citedArtifact.relatesTo.classifier"/>
+      <short value="Additional classifiers"/>
+      <definition value="Provides additional classifiers of the related artifact."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CitationArtifactClassifier"/>
+        </extension>
+        <strength value="extensible"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/citation-artifact-classifier"/>
+      </binding>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.label">
+      <path value="Citation.citedArtifact.relatesTo.label"/>
+      <short value="Short label"/>
+      <definition value="A short label that can be used to reference the citation from elsewhere in the containing artifact, such as a footnote index."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.display">
+      <path value="Citation.citedArtifact.relatesTo.display"/>
+      <short value="Brief description of the related artifact"/>
+      <definition value="A brief description of the document or knowledge resource being referenced, suitable for display to a consumer."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="string"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.citation">
+      <path value="Citation.citedArtifact.relatesTo.citation"/>
+      <short value="Bibliographic citation for the artifact"/>	  
+      <definition value="A bibliographic citation for the related artifact. This text SHOULD be formatted according to an accepted citation format."/>
+      <comment value="Additional structured information about citations should be captured as extensions."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.document">
+      <path value="Citation.citedArtifact.relatesTo.document"/>
+      <short value="What document is being referenced"/>	  
+      <definition value="The document being referenced, represented as an attachment. This is exclusive with the resource element."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Attachment"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.resource">
+      <path value="Citation.citedArtifact.relatesTo.resource"/>
+      <short value="What artifact is being referenced"/>
+      <definition value="The related artifact, such as a library, value set, profile, or other knowledge resource."/>
+	  <comment value="If the type is predecessor, this is a reference to the succeeding knowledge resource. If the type is successor, this is a reference to the prior knowledge resource"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="canonical"/>
+      </type>
+    </element>
+    <element id="Citation.citedArtifact.relatesTo.resourceReference">
+      <path value="Citation.citedArtifact.relatesTo.resourceReference"/>
+      <short value="What artifact, if not a conformance resource"/>
+      <definition value="The related artifact, if the artifact is not a canonical resource, or a resource reference to a canonical resource."/>
+	  <comment value="If both resource and resourceReference are present, they SHOULD be consistent and reference the same resource. Although relatedArtifact is intended to support references to definitional resources, there are cases where non-definitional resources can be definitional (such as Location where the kind is mode). Related artifacts SHOULD be used to reference definitional resources, and profiles SHOULD be used to make that explicit for particular use cases."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
       </type>
     </element>
     <element id="Citation.citedArtifact.publicationForm">

--- a/source/citation/valueset-related-artifact-type-expanded.xml
+++ b/source/citation/valueset-related-artifact-type-expanded.xml
@@ -9,13 +9,21 @@
   <text>
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
+      
       <ul>
+        
         <li>Include all codes defined in 
+          
           <a href="codesystem-related-artifact-type-expanded.html">
+            
             <code>http://terminology.hl7.org/CodeSystem/related-artifact-type-expanded</code>
+          
           </a>
+        
         </li>
+      
       </ul>
+    
     </div>
   </text>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
@@ -30,7 +38,7 @@
   <url value="http://hl7.org/fhir/ValueSet/related-artifact-type-expanded"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.1505"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.0"/>
   </identifier>
   <version value="4.6.0"/>
   <name value="RelatedArtifactTypeExpanded"/>


### PR DESCRIPTION
J# 36332 : Change Citation.citedArtifact.relatesTo from RelatedArtifact to BackboneElement, and uses a new valueset based on (J# 36039)

J# 34446 : Add the retired and unknown codes from the publication status codesystem (that are not defined statuses in the artifact status code system) to the cited artifact status type value set.