### PR TITLE
FHIR-34371 - Fix binding to correctly reference ValueSet/process-priority

### DIFF
--- a/source/explanationofbenefit/structuredefinition-ExplanationOfBenefit.xml
+++ b/source/explanationofbenefit/structuredefinition-ExplanationOfBenefit.xml
@@ -371,7 +371,7 @@
         </extension>
         <strength value="example"/>
         <description value="The timeliness with which processing is required: stat, normal, deferred."/>
-        <valueSet value="http://terminology.hl7.org/CodeSystem/processpriority"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/process-priority"/>
       </binding>
       <mapping>
         <identity value="v2"/>


### PR DESCRIPTION
…rity (rather than the code system).  The binding (in CI and R4B) for now will be to 'http://hl7.org/fhir/ValueSet/process-priority'(may be changed to THO url later).

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

Fix binding to correctly reference ValueSet/process-priority (rather than the code system). The binding (in CI and R4B) for now will be to 'http://hl7.org/fhir/ValueSet/process-priority' (may be changed to THO url later).
