### PR TITLE
FHIR-34150

### DIFF
--- a/source/substancedefinition/structuredefinition-SubstanceDefinition.xml
+++ b/source/substancedefinition/structuredefinition-SubstanceDefinition.xml
@@ -416,8 +416,8 @@
         <map value="Moiety.Amount"/>
       </mapping>
     </element>
-    <element id="SubstanceDefinition.moiety.amountType">
-      <path value="SubstanceDefinition.moiety.amountType"/>
+    <element id="SubstanceDefinition.moiety.measurementType">
+      <path value="SubstanceDefinition.moiety.measurementType"/>
       <short value="The measurement type of the quantitative value"/>
       <definition value="The measurement type of the quantitative value. In capturing the actual relative amounts of substances or molecular fragments it may be necessary to indicate whether the amount refers to, for example, a mole ratio or weight ratio."/>
       <min value="0"/>
@@ -441,7 +441,7 @@
     </element>
     <element id="SubstanceDefinition.property">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
-        <valueCode value="350,825"/>      
+        <valueCode value="370,825"/>      
       </extension>
       <path value="SubstanceDefinition.property"/>
       <short value="General specifications for this substance"/>
@@ -509,7 +509,7 @@
     </element>
     <element id="SubstanceDefinition.molecularWeight">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
-        <valueCode value="448,733"/>
+        <valueCode value="468,733"/>
       </extension>
       <path value="SubstanceDefinition.molecularWeight"/>
       <short value="The molecular weight or weight range"/>
@@ -827,7 +827,7 @@
     </element>
     <element id="SubstanceDefinition.code">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
-        <valueCode value="280,922"/> <!-- was 221,880 -->
+        <valueCode value="300,922"/> <!-- was 221,880 -->
       </extension>
       <path value="SubstanceDefinition.code"/>
       <short value="Codes associated with the substance"/>
@@ -1319,8 +1319,8 @@
         <map value="Substance_Relationship.Amount.Quantity"/>
       </mapping>
     </element>
-    <element id="SubstanceDefinition.relationship.amountRatioHighLimit">
-      <path value="SubstanceDefinition.relationship.amountRatioHighLimit"/>
+    <element id="SubstanceDefinition.relationship.ratioHighLimitAmount">
+      <path value="SubstanceDefinition.relationship.ratioHighLimitAmount"/>
       <short value="For use when the numeric has an uncertain range"/>
       <definition value="For use when the numeric has an uncertain range."/>
       <min value="0"/>
@@ -1334,8 +1334,8 @@
         <map value="Substance_Relationship.Amount.Quantity.High_Limit"/>
       </mapping>
     </element>
-    <element id="SubstanceDefinition.relationship.amountType">
-      <path value="SubstanceDefinition.relationship.amountType"/>
+    <element id="SubstanceDefinition.relationship.comparator">
+      <path value="SubstanceDefinition.relationship.comparator"/>
       <short value="An operator for the amount, for example &quot;average&quot;, &quot;approximately&quot;, &quot;less than&quot;"/>
       <definition value="An operator for the amount, for example &quot;average&quot;, &quot;approximately&quot;, &quot;less than&quot;."/>
       <min value="0"/>


### PR DESCRIPTION
renamed SubstanceDefinition.moiety.amountType to SubstanceDefinition.moiety.measurementType
SubstanceDefinition.relationship.amountRatioHighLimit to ratioHighLimitAmount
SubstanceDefinition.relationship.amountType to comparator

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

_Please describe your pull request here._
