### PR TITLE
J# 36779 CodeSystem Characteristic Combination changes

### DIFF
--- a/source/evidencevariable/codesystem-characteristic-combination.xml
+++ b/source/evidencevariable/codesystem-characteristic-combination.xml
@@ -35,8 +35,9 @@
           </td>
         
         </tr>
-        
-                <tr>
+
+
+        <tr>
           
           <td style="white-space:nowrap">all-of
             
@@ -49,7 +50,6 @@
           <td>Combine characteristics with AND.</td>
         
         </tr>
-
 
 
         <tr>
@@ -67,7 +67,6 @@
         </tr>
 
 
-
         <tr>
           
           <td style="white-space:nowrap">at-least
@@ -81,7 +80,6 @@
           <td>Meet at least the threshold number of characteristics for definition.</td>
         
         </tr>
-
 
 
         <tr>
@@ -99,6 +97,20 @@
         </tr>
 
 
+        <tr>
+          
+          <td style="white-space:nowrap">statistical
+            
+            <a name="characteristic-combination-statistical"> </a>
+          
+          </td>
+          
+          <td>Statistical</td>
+          
+          <td>Combine characteristics statistically. Use method to specify the statistical method.</td>
+        
+        </tr>
+
 
         <tr>
           
@@ -110,10 +122,25 @@
           
           <td>Net effect</td>
           
-          <td> Combine characteristics statistically.</td>
+          <td>Combine characteristics by addition of benefits and subtraction of harms.</td>
         
         </tr>
-      
+
+
+        <tr>
+          
+          <td style="white-space:nowrap">dataset
+            
+            <a name="characteristic-combination-dataset"> </a>
+          
+          </td>
+          
+          <td>Dataset</td>
+          
+          <td>Combine characteristics as a collection used as the dataset.</td>
+        
+        </tr>
+		
       </table>
     
     </div>
@@ -174,8 +201,18 @@
     <definition value="Meet at most the threshold number of characteristics for definition."/>
   </concept>
   <concept>
+    <code value="statistical"/>
+    <display value="Statistical"/>
+    <definition value="Combine characteristics statistically. Use method to specify the statistical method."/>
+  </concept>
+  <concept>
     <code value="net-effect"/>
     <display value="Net effect"/>
-    <definition value=" Combine characteristics statistically."/>
+    <definition value="Combine characteristics by addition of benefits and subtraction of harms."/>
+  </concept>
+  <concept>
+    <code value="dataset"/>
+    <display value="Dataset"/>
+    <definition value="Combine characteristics as a collection used as the dataset."/>
   </concept>
 </CodeSystem>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -637,7 +637,7 @@
     </element>
     <element id="EvidenceVariable.characteristic.defByCombination.code">
       <path value="EvidenceVariable.characteristic.defByCombination.code"/>
-      <short value="all-of | any-of | at-least | at-most | net-effect"/>
+      <short value="all-of | any-of | at-least | at-most | statistical | net-effect | dataset"/>
       <definition value="Used to specify if two or more characteristics are combined with OR or AND."/>
       <requirements value="If code is &quot;at-least&quot; or &quot;at-most&quot; then threshold SHALL be used. If code is neither &quot;at-least&quot; nor &quot;at-most&quot; then threshold SHALL NOT be used."/>
       <min value="1"/>


### PR DESCRIPTION
When modeling the use of EvidenceVariable Resource to define evidence variables used in meta-analyses, we discovered two additional types of combinations of characteristics that are not supported by the required code set (all-of, any-of, at-least, at-most, net-effect).

A 'statistical' code is needed when the Evidence Variable is defined as a statistical combination of other characteristics.  The code 'statistical' can have display 'Statistical' and definition 'Combine characteristics statistically. Use method to specify the statistical method.'

The definition for the code 'net-effect' will need to change from 'Combine characteristics statistically.' to 'Combine characteristics by addition of benefits and subtraction of harms.'

A 'dataset' code is needed when the Evidence Variable is defined as a collection of other characteristics where each characteristic is an observed value used in the statistical analysis. In modeling a meta-analysis this may be achieved by referencing an Evidence Resource as the characteristic.definitionReference.  The code 'dataset' can have display 'Dataset' and definition 'Combine characteristics as a collection used as the dataset.'