### PR TITLE
J# 36860 CDS

### DIFF
--- a/source/plandefinition/structuredefinition-PlanDefinition.xml
+++ b/source/plandefinition/structuredefinition-PlanDefinition.xml
@@ -336,6 +336,7 @@
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/EvidenceVariable"/>
       </type>
       <type>
         <code value="canonical"/>


### PR DESCRIPTION
Added PlanDefinition.subjectReference (subjext[x]) to reference EvidenceVariable (in addition to Group)