### PR TITLE
J#36709 and J# 32314, and J# 31652

### DIFF
--- a/source/researchstudy/bundle-ResearchStudy-search-params.xml
+++ b/source/researchstudy/bundle-ResearchStudy-search-params.xml
@@ -43,7 +43,7 @@
       </SearchParameter>
     </resource>
   </entry>
-  
+
   <entry>
     <resource>
       <SearchParameter>
@@ -245,8 +245,8 @@
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
-  </entry>  
-  
+  </entry>
+
   <entry>
     <resource>
       <SearchParameter>
@@ -298,7 +298,7 @@
           <valueString value="ResearchStudy.status"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ResearchStudy-status"/>
-        <description value="active | administratively-completed | approved | closed-to-accrual | closed-to-accrual-and-intervention | completed | disapproved | in-review | temporarily-closed-to-accrual | temporarily-closed-to-accrual-and-intervention | withdrawn"/>
+        <description value="active | active-but-not-recruiting | administratively-completed | approved | closed-to-accrual | closed-to-accrual-and-intervention | completed | disapproved | enrolling-by-invitation | in-review | not-yet-recruiting | recruiting | temporarily-closed-to-accrual | temporarily-closed-to-accrual-and-intervention | terminated | withdrawn"/>
         <code value="status"/>
         <type value="token"/>
         <expression value="ResearchStudy.status"/>

--- a/source/researchstudy/codesystem-research-study-status.xml
+++ b/source/researchstudy/codesystem-research-study-status.xml
@@ -47,6 +47,11 @@
     <definition value="Study is opened for accrual."/>
   </concept>
   <concept>
+    <code value="active-but-not-recruiting"/>
+    <display value="Active, not recruiting"/>
+    <definition value="The study is ongoing, and participants are receiving an intervention or being examined, but potential participants are not currently being recruited or enrolled."/>
+  </concept>
+  <concept>
     <code value="administratively-completed"/>
     <display value="Administratively Completed"/>
     <definition value="Study is completed prematurely and will not resume; patients are no longer examined nor treated."/>
@@ -77,9 +82,24 @@
     <definition value="Protocol was disapproved by the review board."/>
   </concept>
   <concept>
+    <code value="enrolling-by-invitation"/>
+    <display value="Enrolling by invitation"/>
+    <definition value="The study is selecting its participants from a population, or group of people, decided on by the researchers in advance. These studies are not open to everyone who meets the eligibility criteria but only to people in that particular population, who are specifically invited to participate."/>
+  </concept>
+  <concept>
     <code value="in-review"/>
     <display value="In Review"/>
     <definition value="Protocol is submitted to the review board for approval."/>
+  </concept>
+  <concept>
+    <code value="not-yet-recruiting"/>
+    <display value="Not yet recruiting"/>
+    <definition value="The study has not started recruiting participants."/>
+  </concept>
+  <concept>
+    <code value="recruiting"/>
+    <display value="Recruiting"/>
+    <definition value="The study is currently recruiting participants."/>
   </concept>
   <concept>
     <code value="temporarily-closed-to-accrual"/>
@@ -90,6 +110,11 @@
     <code value="temporarily-closed-to-accrual-and-intervention"/>
     <display value="Temporarily Closed to Accrual and Intervention"/>
     <definition value="Study is temporarily closed for accrual and intervention and potentially can be resumed in the future."/>
+  </concept>
+  <concept>
+    <code value="terminated"/>
+    <display value="Terminated"/>
+    <definition value="The study has stopped early and will not start again. Participants are no longer being examined or treated."/>
   </concept>
   <concept>
     <code value="withdrawn"/>

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -822,7 +822,7 @@
     </element>
     <element id="ResearchStudy.associatedParty.role">
       <path value="ResearchStudy.associatedParty.role"/>
-      <short value="sponsor | sponsor-investigator | primary-investigator | collaborator | funding-source | recruitment-contact | sub-investigator | study-director | study-chair"/>
+      <short value="sponsor | lead-sponsor | sponsor-investigator | primary-investigator | collaborator | funding-source | recruitment-contact | sub-investigator | study-director | study-chair"/>
       <definition value="Type of association."/>
       <min value="1"/>
       <max value="1"/>

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -267,7 +267,7 @@
         <map value=".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"/>
       </mapping>
     </element>
-   
+
     <element id="ResearchStudy.relatedArtifact">
       <path value="ResearchStudy.relatedArtifact"/>
       <short value="References and dependencies"/>
@@ -405,7 +405,7 @@
         <map value="InterventionalStudyProtocolVersion; InterventionalStudyProtocol.allocationCode; InterventionalStudyProtocol.blindedRoleCode; InterventionalStudyProtocol.blindingSchemaCode; InterventionalStudyProtocol.controlTypeCode"/>
       </mapping>
     </element>
-    
+
     <!-- Focus -->
     <element id="ResearchStudy.focus">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
@@ -513,7 +513,7 @@
         <map value="StudyCondition.code"/>
       </mapping>
     </element>
-    
+
     <element id="ResearchStudy.keyword">
       <path value="ResearchStudy.keyword"/>
       <short value="Used to search for the study"/>
@@ -793,7 +793,7 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/research-study-classification-classifier"/>
       </binding>
     </element>
-    
+
     <!--Association -->
     <element id="ResearchStudy.associatedParty">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
@@ -832,11 +832,22 @@
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="ResearchStudyPartyRole"/>
-        </extension>        
+        </extension>
         <strength value="extensible"/>
         <description value="desc."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/research-study-party-role"/>
       </binding>
+    </element>
+    <element id="ResearchStudy.associatedParty.period">
+      <path value="ResearchStudy.associatedParty.period"/>
+      <short value="When active in the role"/>
+      <definition value="Identifies the start date and the end date of the associated party in the role."/>
+	  <comment value="The cardinality is 0..* due to the fact that an associated party may be intermittently active in a given role over multiple time periods." />
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="Period"/>
+      </type>
     </element>
     <element id="ResearchStudy.associatedParty.classifier">
       <path value="ResearchStudy.associatedParty.classifier"/>
@@ -874,7 +885,7 @@
     <!-- State -->
     <element id="ResearchStudy.currentState">
       <path value="ResearchStudy.currentState"/>
-      <short value="active | administratively-completed | approved | closed-to-accrual | closed-to-accrual-and-intervention | completed | disapproved | in-review | temporarily-closed-to-accrual | temporarily-closed-to-accrual-and-intervention | withdrawn"/>
+      <short value="active | active-but-not-recruiting | administratively-completed | approved | closed-to-accrual | closed-to-accrual-and-intervention | completed | disapproved | enrolling-by-invitation | in-review | not-yet-recruiting | recruiting | temporarily-closed-to-accrual | temporarily-closed-to-accrual-and-intervention | terminated | withdrawn"/>
       <definition value="Current status of the study."/>
       <min value="0"/>
       <max value="*"/>
@@ -890,8 +901,8 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/research-study-status"/>
       </binding>
     </element>
-    
-    <!-- Progress -->  
+
+    <!-- Progress -->
     <element id="ResearchStudy.statusDate">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
         <valueCode value="40,410"/>
@@ -1264,7 +1275,7 @@
         <code value="markdown"/>
       </type>
     </element>
-    
+
     <!-- Results -->
     <element id="ResearchStudy.outcomeMeasure">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">


### PR DESCRIPTION
For ClinicalTrials.gov use, added codes to ResearchStudyStatus codesystem: for not-yet-recruiting, recruiting, enrolling-by-invitation, active-but-not-recruiting, and terminated.

Add the new element associatedParty.period with cardinality of 0..*
Datatype would be Period;
Description:
Short Def. - when active in the role;
Long Def. - Identifies the start date and the end date of the associated party in the role.
Comment: the cardinality is 0..* due to the fact that an associated party may be intermittently active in a given role over multiple time periods.

Added lead-sponsor code to ResearchStudy.associatedParty.role