### PR TITLE
Allow Parameters to be referenced in limited cases FHIR-26368

### DIFF
--- a/source/auditevent/structuredefinition-AuditEvent.xml
+++ b/source/auditevent/structuredefinition-AuditEvent.xml
@@ -183,7 +183,7 @@
       <mapping>
         <identity value="fhirprovenance"/>
         <map value="Provenance.activity"/>
-      </mapping>    
+      </mapping>
       <mapping>
         <identity value="dicom"/>
         <map value="EventTypeCode"/>
@@ -383,7 +383,7 @@
         <identity value="dicom"/>
         <map value="EventOutcomeIndicator EventOutcomeIndicator"/>
       </mapping>
-    </element>    
+    </element>
 	<element id="AuditEvent.outcome.detail">
       <path value="AuditEvent.outcome.detail"/>
       <short value="Additional outcome detail"/>
@@ -411,7 +411,7 @@
         <identity value="rim"/>
         <map value=".outboundRelationship[typeCode=OUT].target.text"/>
       </mapping>
-    </element>    
+    </element>
 	<element id="AuditEvent.authorization">
       <path value="AuditEvent.authorization"/>
       <short value="Authorization related to the event"/>
@@ -490,7 +490,7 @@
         <identity value="w3c.prov"/>
         <map value="Activity.Activity"/>
       </mapping>
-    </element>    
+    </element>
 	<element id="AuditEvent.patient">
       <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
         <valueCode value="trial-use"/>
@@ -695,7 +695,7 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>		
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
       </type>
       <isSummary value="true"/>
       <mapping>
@@ -1038,7 +1038,7 @@
     <element id="AuditEvent.entity.what">
       <path value="AuditEvent.entity.what"/>
       <short value="Specific instance of resource"/>
-      <definition value="Identifies a specific instance of the entity. The reference should be version specific."/>
+      <definition value="Identifies a specific instance of the entity. The reference should be version specific. This is allowed to be a Parameters resource."/>
 	  <comment value="Use .what.display when all you have is a string (e.g. ParticipantObjectName)."/>
       <min value="0"/>
       <max value="1"/>
@@ -1260,7 +1260,7 @@
       </type>
       <type>
         <code value="base64Binary"/>
-      </type>	  
+      </type>
       <mapping>
         <identity value="w5"/>
         <map value="FiveWs.context"/>

--- a/source/bundle/structuredefinition-Bundle.xml
+++ b/source/bundle/structuredefinition-Bundle.xml
@@ -352,7 +352,7 @@
     <element id="Bundle.entry.resource">
       <path value="Bundle.entry.resource"/>
       <short value="A resource in the bundle"/>
-      <definition value="The Resource for the entry. The purpose/meaning of the resource is determined by the Bundle.type."/>
+      <definition value="The Resource for the entry. The purpose/meaning of the resource is determined by the Bundle.type. This is allowed to be a Parameters resource if and only if it is referenced by something else within the Bundle that provides context/meaning."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/domainresource/structuredefinition-DomainResource.xml
+++ b/source/domainresource/structuredefinition-DomainResource.xml
@@ -127,7 +127,7 @@
     <element id="DomainResource.contained">
       <path value="DomainResource.contained"/>
       <short value="Contained, inline Resources"/>
-      <definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, nor can they have their own independent transaction scope."/>
+      <definition value="These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, nor can they have their own independent transaction scope. This is allowed to be a Parameters resource if and only if it is referenced by a resource that provides context/meaning."/>
       <comment value="This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels."/>
       <alias value="inline resources"/>
       <alias value="anonymous resources"/>

--- a/source/messageheader/structuredefinition-MessageHeader.xml
+++ b/source/messageheader/structuredefinition-MessageHeader.xml
@@ -627,7 +627,7 @@
     <element id="MessageHeader.focus">
       <path value="MessageHeader.focus"/>
       <short value="The actual content of the message"/>
-      <definition value="The actual data of the message - a reference to the root/focus class of the event."/>
+      <definition value="The actual data of the message - a reference to the root/focus class of the event. This is allowed to be a Parameters resource."/>
       <comment value="The data is defined where the transaction type is defined. The transaction data is always included in the bundle that is the full message.  Only the root resource is specified.  The resources it references should be contained in the bundle but are not also listed here.  Multiple repetitions are allowed to cater for merges and other situations with multiple focal targets."/>
       <requirements value="Every message event is about actual data, a single resource, that is identified in the definition of the event, and perhaps some or all linked resources."/>
       <min value="0"/>

--- a/source/parameters/parameters-introduction.xml
+++ b/source/parameters/parameters-introduction.xml
@@ -4,7 +4,35 @@
 <a name="scope"></a>
 <h2>Scope and Usage</h2>
 <p>
-This resource is a non-persisted resource used to pass information into and back from an <a href="operations.html">operation</a>. 
+This resource is used to pass information into and back from an <a href="operations.html">operation</a>
+(whether invoked directly from REST or within a messaging environment).  It is not persisted or allowed
+to be referenced by other resources except as described below.
+</p>
+<p>
+Because Parameters does not reflect a persistent healthcare-related entity but rather just a collection
+of data passed into or out of an operation, there is generally no need to have a RESTful endpoint at
+which such instances can be created, updated, queried, etc.  However, there are a few limited cases
+where this can make sense:
+</p>
+<ul>
+  <li>
+    Parameters instances can be stored to record inbound and/or outbound information in support of
+    an <a href="auditevent.html">AuditEvent</a> instance
+  </li>
+  <li>
+    Parameters instances might be persisted either on their own or as part of a Bundle to support
+    documentation of examples for an <a href="implementationguide.html">ImplementationGuide</a>
+    and/or test data for a TestScript
+  </li>
+</ul>
+<p>
+Technically, Parameters is a specialization of Resource and as such could potentially appear anywhere
+that 'Resource' is permitted and could be referenced anywhere an element has an unconstrained type of
+Reference.  For example, it could appear in FHIR documents, as contained resources, referenced by
+extensions, in elements like Observation.focus, etc.  However, <b>such use is prohibited</b> unless the
+element containing the Resource or Reference type explicitly indicates that Parameters is permitted.
+If there is a requirement to exchange arbitrary collections of data elements, this need should typically
+be met using <a href="basic.html">Basic</a>.
 </p>
 </div>
 
@@ -12,7 +40,7 @@ This resource is a non-persisted resource used to pass information into and back
 <a name="bnr"></a>
 <h2>Boundaries and Relationships</h2>
 <p>
-This special resource has no other use than for operation parameters, and there is no RESTful end-point associated with it. 
+This special resource has no other use than for operation parameters, and there is no RESTful end-point associated with it.
 For further information, see the <a href="operations.html">operations</a> page.
 </p>
 <p>

--- a/source/parameters/structuredefinition-Parameters.xml
+++ b/source/parameters/structuredefinition-Parameters.xml
@@ -41,7 +41,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg/index.cfm"/>
     </telecom>
   </contact>
-  <description value="This resource is a non-persisted resource primarily used to pass information into and back from an [operation](operations.html). There is no RESTful endpoint associated with it."/>
+  <description value="This resource is used to pass information into and back from an operation (whether invoked directly from REST or within a messaging environment).  It is not persisted or allowed to be referenced by other resources except as described in the definition of the Parameters resource."/>
   <fhirVersion value="4.6.0"/>
   <mapping>
     <identity value="v2"/>
@@ -67,7 +67,7 @@
     <element id="Parameters">
       <path value="Parameters"/>
       <short value="Operation Request or Response"/>
-      <definition value="This resource is a non-persisted resource used to pass information into and back from an [operation](operations.html). It has no other use, and there is no RESTful endpoint associated with it."/>
+      <definition value="This resource is used to pass information into and back from an operation (whether invoked directly from REST or within a messaging environment).  It is not persisted or allowed to be referenced by other resources."/>      
       <comment value="The parameters that may be used are defined by the OperationDefinition resource."/>
       <min value="0"/>
       <max value="*"/>

--- a/source/testscript/structuredefinition-TestScript.xml
+++ b/source/testscript/structuredefinition-TestScript.xml
@@ -744,7 +744,7 @@
     <element id="TestScript.fixture.resource">
       <path value="TestScript.fixture.resource"/>
       <short value="Reference of the resource"/>
-      <definition value="Reference to the resource (containing the contents of the resource needed for operations)."/>
+      <definition value="Reference to the resource (containing the contents of the resource needed for operations). This is allowed to be a Parameters resource."/>
       <comment value="See http://build.fhir.org/resourcelist.html for complete list of resource types."/>
       <min value="0"/>
       <max value="1"/>


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-26390

- Change the description of Parameters to allow other resources to refer to it if the referring element explicitly allows Parameters.
- Update the definitions of elements that are allowed to refer to Parameters
  - AuditEvent.entity.what 
  - Bundle.entry.resource
  - DomainResource.contained
  - MessageHeader.focus
  - TestScript.fixture.resource