### PR TITLE
Partial correction J# 32310

### DIFF
--- a/source/researchstudy/codesystem-research-study-classifiers.xml
+++ b/source/researchstudy/codesystem-research-study-classifiers.xml
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<id value="research-study-classifiers"/>
+	<meta>
+    	<lastUpdated value="2022-05-15T16:55:11.085+11:00"/>
+    	<profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+	</meta>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+		<valueCode value="brr"/>
+	</extension>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+		<valueCode value="trial-use"/>
+	</extension>
+	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+		<valueInteger value="0"/>
+	</extension>
+	<url value="http://hl7.org/fhir/research-study-classifiers"/>
+	<identifier>
+		<system value="urn:ietf:rfc:3986"/>
+		<value value="urn:oid:2.16.840.1.113883.4.642.1.1686"/>
+	</identifier>
+	<version value="4.6.0"/>
+	<name value="ResearchStudyClassifiers"/>
+	<title value="ResearchStudy Classifiers Code System"/>
+	<status value="draft"/>
+	<experimental value="false"/>
+	<date value="2022-05-15T16:55:11.085+11:00"/>
+	<publisher value="HL7 (FHIR Project)"/>
+	<contact>
+		<telecom>
+			<system value="url"/>
+			<value value="http://hl7.org/fhir"/>
+		</telecom>
+		<telecom>
+			<system value="email"/>
+			<value value="fhir@lists.hl7.org"/>
+		</telecom>
+	</contact>	
+	<description value="Codes for use in ResearchStudy Resource. This resource (this entire set of content) is being used for active development of a ResearchStudyClassifiers CodeSystem for use for supporting multiple value sets in the FHIR ResearchStudy StructureDefinition."/>
+	<caseSensitive value="true"/>
+	<valueSet value="http://hl7.org/fhir/ValueSet/research-study-classifiers"/>
+	<content value="complete"/>
+	<concept>
+		<code value="research-study-label-type"/>
+		<display value="Research Study Label Type"/>
+		<concept>
+			<code value="short"/>
+			<display value="Short"/>
+			<definition value="A short form of the name - what is used in everyday conversation."/>
+		</concept>
+		<concept>
+			<code value="public"/>
+			<display value="Public"/>
+			<definition value="A name that is understandable to non-technical readers."/>
+		</concept>
+		<concept>
+			<code value="scientific"/>
+			<display value="Scientific"/>
+			<definition value="A full name that is suitable for use in an academic or technical setting."/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-classifier"/>
+		<display value="Research Study Classifier"/>
+		<concept>
+			<code value="research-study-prim-purp-type"/>
+			<display value="Research Study Primary Purpose Type"/>
+			<concept>
+				<code value="treatment"/>
+				<display value="Treatment"/>
+				<definition value="One or more interventions are being evaluated for treating a disease, syndrome, or condition."/>
+			</concept>
+			<concept>
+				<code value="prevention"/>
+				<display value="Prevention"/>
+				<definition value="One or more interventions are being assessed for preventing the development of a specific disease or health condition."/>
+			</concept>
+			<concept>
+				<code value="diagnostic"/>
+				<display value="Diagnostic"/>
+				<definition value="One or more interventions are being evaluated for identifying a disease or health condition."/>
+			</concept>
+			<concept>
+				<code value="supportive-care"/>
+				<display value="Supportive Care"/>
+				<definition value="One or more interventions are evaluated for maximizing comfort, minimizing side effects, or mitigating against a decline in the participant&apos;s health or function."/>
+			</concept>
+			<concept>
+				<code value="screening"/>
+				<display value="Screening"/>
+				<definition value="One or more interventions are assessed or examined for identifying a condition, or risk factors for a condition, in people who are not yet known to have the condition or risk factor."/>
+			</concept>
+			<concept>
+				<code value="health-services-research"/>
+				<display value="Health Services Research"/>
+				<definition value="One or more interventions for evaluating the delivery, processes, management, organization, or financing of healthcare."/>
+			</concept>
+			<concept>
+				<code value="basic-science"/>
+				<display value="Basic Science"/>
+				<definition value="One or more interventions for examining the basic mechanism of action (for example, physiology or biomechanics of an intervention)."/>
+			</concept>
+			<concept>
+				<code value="device-feasibility"/>
+				<display value="Device Feasibility"/>
+				<definition value="An intervention of a device product is being evaluated to determine the feasibility of the product or to test a prototype device and not health outcomes. Such studies are conducted to confirm the design and operating specifications of a device before beginning a full clinical trial."/>
+			</concept>
+		</concept>
+		<concept>
+			<code value="research-study-phase"/>
+			<display value="Research Study Phase"/>
+			<concept>
+				<code value="n-a"/>
+				<display value="N/A"/>
+				<definition value="Trials without phases (for example, studies of devices or behavioral interventions)."/>
+			</concept>
+			<concept>
+				<code value="early-phase-1"/>
+				<display value="Early Phase 1"/>
+				<definition value="Designation for optional exploratory trials conducted in accordance with the United States Food and Drug Administration&apos;s (FDA) 2006 Guidance on Exploratory Investigational New Drug (IND) Studies. Formerly called Phase 0."/>
+			</concept>
+			<concept>
+				<code value="phase-1"/>
+				<display value="Phase 1"/>
+				<definition value="Includes initial studies to determine the metabolism and pharmacologic actions of drugs in humans, the side effects associated with increasing doses, and to gain early evidence of effectiveness; may include healthy participants and/or patients."/>
+			</concept>
+			<concept>
+				<code value="phase-1-phase-2"/>
+				<display value="Phase 1/Phase 2"/>
+				<definition value="Trials that are a combination of phases 1 and 2."/>
+			</concept>
+			<concept>
+				<code value="phase-2"/>
+				<display value="Phase 2"/>
+				<definition value="Includes controlled clinical studies conducted to evaluate the effectiveness of the drug for a particular indication or indications in participants with the disease or condition under study and to determine the common short-term side effects and risks."/>
+			</concept>
+			<concept>
+				<code value="phase-2-phase-3"/>
+				<display value="Phase 2/Phase 3"/>
+				<definition value="Trials that are a combination of phases 2 and 3."/>
+			</concept>
+			<concept>
+				<code value="phase-3"/>
+				<display value="Phase 3"/>
+				<definition value="Includes trials conducted after preliminary evidence suggesting effectiveness of the drug has been obtained, and are intended to gather additional information to evaluate the overall benefit-risk relationship of the drug."/>
+			</concept>
+			<concept>
+				<code value="phase-4"/>
+				<display value="Phase 4"/>
+				<definition value="Studies of FDA-approved drugs to delineate additional information including the drug&apos;s risks, benefits, and optimal use."/>
+			</concept>
+		</concept>
+		<concept>
+			<code value="research-study-focus-type"/>
+			<display value="Research Study Focus Type"/>
+			<concept>
+				<code value="medication"/>
+				<display value="Medication"/>
+				<definition value=""/>
+			</concept>
+			<concept>
+				<code value="device"/>
+				<display value="Device"/>
+				<definition value=""/>
+			</concept>
+			<concept>
+				<code value="intervention"/>
+				<display value="Intervention"/>
+				<definition value=""/>
+			</concept>
+			<concept>
+				<code value="factor"/>
+				<display value="Factor"/>
+				<definition value=""/>
+			</concept>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-classification-type"/>
+		<display value="Research Study Classification Type"/>
+		<concept>
+			<code value="phase"/>
+			<display value="Phase"/>
+		</concept>
+		<concept>
+			<code value="category"/>
+			<display value="Category"/>
+		</concept>
+		<concept>
+			<code value="keyword"/>
+			<display value="Keyword"/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-party-organization-type"/>
+		<display value="Research Study Party Organization Type"/>
+		<concept>
+			<code value="nih"/>
+			<display value="NIH"/>
+		</concept>
+		<concept>
+			<code value="fda"/>
+			<display value="FDA"/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-party-role"/>
+		<display value="Research Study Party Role"/>
+		<concept>
+			<code value="sponsor"/>
+			<display value="Sponsor"/>
+		</concept>
+		<concept>
+			<code value="lead-sponsor"/>
+			<display value="Lead Sponsor"/>
+		</concept>
+		<concept>
+			<code value="sponsor-investigatory"/>
+			<display value="Sponsor-Investigator"/>
+		</concept>
+		<concept>
+			<code value="primary-investigator"/>
+			<display value="Primary Investigator"/>
+		</concept>
+		<concept>
+			<code value="collaborator"/>
+			<display value="Collaborator"/>
+		</concept>
+		<concept>
+			<code value="funding-source"/>
+			<display value="Funding Source"/>
+		</concept>
+		<concept>
+			<code value="recruitment-contact"/>
+			<display value="Recruitment Contact"/>
+		</concept>
+		<concept>
+			<code value="sub-investigator"/>
+			<display value="Sub-investigator"/>
+		</concept>
+		<concept>
+			<code value="study-director"/>
+			<display value="Study Director"/>
+		</concept>
+		<concept>
+			<code value="study-chair"/>
+			<display value="Study Chair"/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-status"/>
+		<display value="Research Study Status"/>
+		<concept>
+			<code value="active"/>
+			<display value="Active"/>
+			<definition value="Study is opened for accrual."/>
+		</concept>
+		<concept>
+			<code value="active-but-not-recruiting"/>
+			<display value="Active, not recruiting"/>
+			<definition value="The study is ongoing, and participants are receiving an intervention or being examined, but potential participants are not currently being recruited or enrolled."/>
+		</concept>
+		<concept>
+			<code value="administratively-completed"/>
+			<display value="Administratively Completed"/>
+			<definition value="Study is completed prematurely and will not resume; patients are no longer examined nor treated."/>
+		</concept>
+		<concept>
+			<code value="approved"/>
+			<display value="Approved"/>
+			<definition value="Protocol is approved by the review board."/>
+		</concept>
+		<concept>
+			<code value="closed-to-accrual"/>
+			<display value="Closed to Accrual"/>
+			<definition value="Study is closed for accrual; patients can be examined and treated."/>
+		</concept>
+		<concept>
+			<code value="closed-to-accrual-and-intervention"/>
+			<display value="Closed to Accrual and Intervention"/>
+			<definition value="Study is closed to accrual and intervention, i.e. the study is closed to enrollment, all study subjects have completed treatment or intervention but are still being followed according to the primary objective of the study."/>
+		</concept>
+		<concept>
+			<code value="completed"/>
+			<display value="Completed"/>
+			<definition value="The study closed according to the study plan. There will be no further treatments, interventions or data collection."/>
+		</concept>
+		<concept>
+			<code value="disapproved"/>
+			<display value="Disapproved"/>
+			<definition value="Protocol was disapproved by the review board."/>
+		</concept>
+		<concept>
+			<code value="enrolling-by-invitation"/>
+			<display value="Enrolling by invitation"/>
+			<definition value="The study is selecting its participants from a population, or group of people, decided on by the researchers in advance. These studies are not open to everyone who meets the eligibility criteria but only to people in that particular population, who are specifically invited to participate."/>
+		</concept>
+		<concept>
+			<code value="in-review"/>
+			<display value="In Review"/>
+			<definition value="Protocol is submitted to the review board for approval."/>
+		</concept>
+		<concept>
+			<code value="not-yet-recruiting"/>
+			<display value="Not yet recruiting"/>
+			<definition value="The study has not started recruiting participants."/>
+		</concept>
+		<concept>
+			<code value="recruiting"/>
+			<display value="Recruiting"/>
+			<definition value="The study is currently recruiting participants."/>
+		</concept>
+		<concept>
+			<code value="temporarily-closed-to-accrual"/>
+			<display value="Temporarily Closed to Accrual"/>
+			<definition value="Study is temporarily closed for accrual; can be potentially resumed in the future; patients can be examined and treated."/>
+		</concept>
+		<concept>
+			<code value="temporarily-closed-to-accrual-and-intervention"/>
+			<display value="Temporarily Closed to Accrual and Intervention"/>
+			<definition value="Study is temporarily closed for accrual and intervention and potentially can be resumed in the future."/>
+		</concept>
+		<concept>
+			<code value="terminated"/>
+			<display value="Terminated"/>
+			<definition value="The study has stopped early and will not start again. Participants are no longer being examined or treated."/>
+		</concept>
+		<concept>
+			<code value="withdrawn"/>
+			<display value="Withdrawn"/>
+			<definition value="Protocol was withdrawn by the lead organization."/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-statusDate-activity"/>
+		<display value="Research Study Status-related Activity"/>
+		<concept>
+			<code value="record-verification"/>
+			<display value="Record Verification"/>
+			<definition value="Record has been verified."/>
+		</concept>
+		<concept>
+			<code value="overall-study"/>
+			<display value="Overall study"/>
+		</concept>
+		<concept>
+			<code value="primary-outcome-data-collection"/>
+			<display value="Primary outcome data collection"/>
+		</concept>
+		<concept>
+			<code value="registration-submission"/>
+			<display value="Registration submission"/>
+		</concept>
+		<concept>
+			<code value="registration-submission-qc"/>
+			<display value="Registration submission Quality Check"/>
+		</concept>
+		<concept>
+			<code value="registration-posting"/>
+			<display value="Registration posting"/>
+		</concept>
+		<concept>
+			<code value="results-submission"/>
+			<display value="Results submission"/>
+		</concept>
+		<concept>
+			<code value="results-submission-qc"/>
+			<display value="Results submission Quality Check"/>
+		</concept>
+		<concept>
+			<code value="results-posting"/>
+			<display value="Results posting"/>
+		</concept>
+		<concept>
+			<code value="disposition-submission"/>
+			<display value="Disposition submission"/>
+		</concept>
+		<concept>
+			<code value="disposition-submission-qc"/>
+			<display value="Disposition submission Quality Check"/>
+		</concept>
+		<concept>
+			<code value="disposition-posting"/>
+			<display value="Disposition posting"/>
+		</concept>
+		<concept>
+			<code value="update-submission"/>
+			<display value="Update submission	"/>
+		</concept>
+		<concept>
+			<code value="update-posting"/>
+			<display value="Update posting"/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-reason-stopped"/>
+		<display value="Research Study Reason Stopped"/>
+		<concept>
+			<code value="accrual-goal-met"/>
+			<display value="Accrual Goal Met"/>
+			<definition value="The study prematurely ended because the accrual goal was met."/>
+		</concept>
+		<concept>
+			<code value="closed-due-to-toxicity"/>
+			<display value="Closed due to toxicity"/>
+			<definition value="The study prematurely ended due to toxicity."/>
+		</concept>
+		<concept>
+			<code value="closed-due-to-lack-of-study-progress"/>
+			<display value="Closed due to lack of study progress"/>
+			<definition value="The study prematurely ended due to lack of study progress."/>
+		</concept>
+		<concept>
+			<code value="temporarily-closed-per-study-design"/>
+			<display value="Temporarily closed per study design"/>
+			<definition value="The study prematurely ended temporarily per study design."/>
+		</concept>
+	</concept>
+	<concept>
+		<code value="research-study-objective-type"/>
+		<display value="Research Study Objective Type"/>
+		<concept>
+			<code value="primary"/>
+			<display value="Primary"/>
+			<definition value="The main question to be answered, and the one that drives any statistical planning for the study—e.g., calculation of the sample size to provide the appropriate power for statistical testing."/>
+		</concept>
+		<concept>
+			<code value="secondary"/>
+			<display value="Secondary"/>
+			<definition value="Question to be answered in the study that is of lesser importance than the primary objective."/>
+		</concept>
+		<concept>
+			<code value="exploratory"/>
+			<display value="Exploratory"/>
+			<definition value="Exploratory questions to be answered in the study."/>
+		</concept>
+	</concept>
+</CodeSystem>

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -204,7 +204,7 @@
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchStudyTitleType"/>
+          <valueString value="ResearchStudyLabelType"/>
         </extension>
         <strength value="extensible"/>
         <description value="desc."/>
@@ -786,11 +786,11 @@
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchStudyClassificationClassifier"/>
+          <valueString value="ResearchStudyClassifiers"/>
         </extension>
         <strength value="extensible"/>
         <description value="desc."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/research-study-classification-classifier"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/research-study-classifiers"/>
       </binding>
     </element>
 

--- a/source/researchstudy/valueset-research-study-classification-type.xml
+++ b/source/researchstudy/valueset-research-study-classification-type.xml
@@ -1,40 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="research-study-reason-stopped"/>
+  <id value="research-study-classification-type"/>
   <meta>
     <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
   <text>
-    <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
-      <ul>
-        <li>Include all codes defined in 
-          <a href="codesystem-research-study-reason-stopped.html">
-            <code>http://terminology.hl7.org/CodeSystem/research-study-reason-stopped</code>
-          </a>
-        </li>
-      </ul>
+      <p>Hello world</p>
     </div>
   </text>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
     <valueCode value="brr"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="0"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/research-study-reason-stopped"/>
+  <url value="http://hl7.org/fhir/ValueSet/research-study-classification-type"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.825"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.830"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudyReasonStopped"/>
-  <title value="ResearchStudyReasonStopped"/>
+  <name value="ResearchStudyClassificationType"/>
+  <title value="ResearchStudyClassificationType"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -49,15 +42,15 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Codes for why the study ended prematurely."/>
+  <description value="Codes for the main intent of the study."/>
   <immutable value="true"/>
   <compose>
     <include>
       <system value="http://hl7.org/fhir/research-study-classifiers"/>
-	  <filter>
+      <filter>
 	    <property value="concept"/>
 	    <op value="descendent-of"/>
-	    <value value="research-study-reason-stopped"/>
+	    <value value="research-study-classification-type"/>
 	  </filter>
     </include>
   </compose>

--- a/source/researchstudy/valueset-research-study-classifiers.xml
+++ b/source/researchstudy/valueset-research-study-classifiers.xml
@@ -1,43 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="research-study-reason-stopped"/>
+  <id value="research-study-classifiers"/>
   <meta>
-    <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
+    <lastUpdated value="2022-02-10T20:40:00+00:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
-  <text>
-    <status value="generated"/>
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <ul>
-        <li>Include all codes defined in 
-          <a href="codesystem-research-study-reason-stopped.html">
-            <code>http://terminology.hl7.org/CodeSystem/research-study-reason-stopped</code>
-          </a>
-        </li>
-      </ul>
-    </div>
-  </text>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
     <valueCode value="brr"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="0"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/research-study-reason-stopped"/>
+  <url value="http://hl7.org/fhir/ValueSet/research-study-classifiers"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.825"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.1.1687"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudyReasonStopped"/>
-  <title value="ResearchStudyReasonStopped"/>
+  <name value="ResearchStudyClassifiers"/>
+  <title value="Research Study Classifiers"/>
   <status value="draft"/>
   <experimental value="false"/>
-  <date value="2020-12-28T16:55:11+11:00"/>
+  <date value="2022-02-10T20:40:00+00:00"/>
   <publisher value="HL7 (FHIR Project)"/>
   <contact>
     <telecom>
@@ -49,7 +37,7 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Codes for why the study ended prematurely."/>
+  <description value="Codes that convey the type of label that is provided."/>
   <immutable value="true"/>
   <compose>
     <include>
@@ -57,7 +45,7 @@
 	  <filter>
 	    <property value="concept"/>
 	    <op value="descendent-of"/>
-	    <value value="research-study-reason-stopped"/>
+	    <value value="research-study-classifier"/>
 	  </filter>
     </include>
   </compose>

--- a/source/researchstudy/valueset-research-study-focus-type.xml
+++ b/source/researchstudy/valueset-research-study-focus-type.xml
@@ -1,40 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="research-study-reason-stopped"/>
+  <id value="research-study-focus-type"/>
   <meta>
     <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
   <text>
-    <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
-      <ul>
-        <li>Include all codes defined in 
-          <a href="codesystem-research-study-reason-stopped.html">
-            <code>http://terminology.hl7.org/CodeSystem/research-study-reason-stopped</code>
-          </a>
-        </li>
-      </ul>
+      <p>Hello world</p>
     </div>
   </text>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
     <valueCode value="brr"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="0"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/research-study-reason-stopped"/>
+  <url value="http://hl7.org/fhir/ValueSet/research-study-focus-type"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.825"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.828"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudyReasonStopped"/>
-  <title value="ResearchStudyReasonStopped"/>
+  <name value="ResearchStudyFocusType"/>
+  <title value="ResearchStudyFocusType"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -49,15 +42,15 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Codes for why the study ended prematurely."/>
+  <description value="Codes for the main intent of the study."/>
   <immutable value="true"/>
   <compose>
     <include>
       <system value="http://hl7.org/fhir/research-study-classifiers"/>
-	  <filter>
+      <filter>
 	    <property value="concept"/>
 	    <op value="descendent-of"/>
-	    <value value="research-study-reason-stopped"/>
+	    <value value="research-study-focus-type"/>
 	  </filter>
     </include>
   </compose>

--- a/source/researchstudy/valueset-research-study-label-type.xml
+++ b/source/researchstudy/valueset-research-study-label-type.xml
@@ -21,8 +21,8 @@
     <value value="urn:oid:2.16.840.1.113883.4.642.1.1683"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudylabelType"/>
-  <title value="Research Study label Type"/>
+  <name value="ResearchStudyLabelType"/>
+  <title value="Research Study Label Type"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2022-02-10T20:40:00+00:00"/>
@@ -41,7 +41,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/research-study-label-type"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+      <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-label-type"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-objective-type.xml
+++ b/source/researchstudy/valueset-research-study-objective-type.xml
@@ -47,7 +47,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://terminology.hl7.org/CodeSystem/research-study-objective-type"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+	  <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-objective-type"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-party-org-type.xml
+++ b/source/researchstudy/valueset-research-study-party-org-type.xml
@@ -1,43 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="research-study-reason-stopped"/>
+  <id value="research-study-party-org-type"/>
   <meta>
-    <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
+    <lastUpdated value="2022-05-12T12:40:00+00:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
-  <text>
-    <status value="generated"/>
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <ul>
-        <li>Include all codes defined in 
-          <a href="codesystem-research-study-reason-stopped.html">
-            <code>http://terminology.hl7.org/CodeSystem/research-study-reason-stopped</code>
-          </a>
-        </li>
-      </ul>
-    </div>
-  </text>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
     <valueCode value="brr"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="0"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/research-study-reason-stopped"/>
+  <url value="http://hl7.org/fhir/ValueSet/research-study-party-org-type"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.825"/>
+    <value value="urn:oid:2.16.840.1.113883.4.642.3.1686"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudyReasonStopped"/>
-  <title value="ResearchStudyReasonStopped"/>
+  <name value="ResearchStudyPartyOrgType"/>
+  <title value="Research Study Party Organization Type"/>
   <status value="draft"/>
   <experimental value="false"/>
-  <date value="2020-12-28T16:55:11+11:00"/>
+  <date value="2022-05-12T12:40:00+00:00"/>
   <publisher value="HL7 (FHIR Project)"/>
   <contact>
     <telecom>
@@ -49,7 +37,7 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Codes for why the study ended prematurely."/>
+  <description value="This is a ResearchStudy&#39;s party organization type."/>
   <immutable value="true"/>
   <compose>
     <include>
@@ -57,7 +45,7 @@
 	  <filter>
 	    <property value="concept"/>
 	    <op value="descendent-of"/>
-	    <value value="research-study-reason-stopped"/>
+	    <value value="research-study-party-organization-type"/>
 	  </filter>
     </include>
   </compose>

--- a/source/researchstudy/valueset-research-study-party-role.xml
+++ b/source/researchstudy/valueset-research-study-party-role.xml
@@ -41,7 +41,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/research-study-party-role"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+	  <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-party-role"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-phase.xml
+++ b/source/researchstudy/valueset-research-study-phase.xml
@@ -53,7 +53,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://terminology.hl7.org/CodeSystem/research-study-phase"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+      <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-phase"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-prim-purp-type.xml
+++ b/source/researchstudy/valueset-research-study-prim-purp-type.xml
@@ -46,7 +46,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://terminology.hl7.org/CodeSystem/research-study-prim-purp-type"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+      <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-prim-purp-type"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-status.xml
+++ b/source/researchstudy/valueset-research-study-status.xml
@@ -53,7 +53,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/research-study-status"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+	  <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-status"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>

--- a/source/researchstudy/valueset-research-study-statusDate-activity.xml
+++ b/source/researchstudy/valueset-research-study-statusDate-activity.xml
@@ -41,7 +41,12 @@
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://terminology.hl7.org/CodeSystem/research-study-statusDate-activity"/>
+      <system value="http://hl7.org/fhir/research-study-classifiers"/>
+	  <filter>
+	    <property value="concept"/>
+	    <op value="descendent-of"/>
+	    <value value="research-study-statusDate-activity"/>
+	  </filter>
     </include>
   </compose>
 </ValueSet>


### PR DESCRIPTION
ReasearchStudy Resource, CodeSystem and ValueSet adjustment

- Made one CodeSystem for ResearchStudy, and made multiple ResearchStudy ValueSets to use portions of that CodeSystem. This is so it's easier for long term maintenance than if it were multiple CodeSystems. Otherwise there would be codes that exist in multiple CodeSystems, and now they exist in one and ValueSets contain subsets of that CodeSystem.

- This solution had the go-ahead by Hugh Glover on April 26, 2022, in a BRR conference call giving Brian Alper permission to make changes to ResearchStudy. And him and I worked on these changes in this commit.

https://confluence.hl7.org/display/BRR/2022-04-26+Conference+Call