### PR TITLE
FHIR-15687 - Fix the cmd-2 group.unmapped constraint behavior.

### DIFF
--- a/source/conceptmap2/structuredefinition-ConceptMap2.xml
+++ b/source/conceptmap2/structuredefinition-ConceptMap2.xml
@@ -773,9 +773,9 @@
       <constraint>
         <key value="cmd-2"/>
         <severity value="error"/>
-        <human value="If the mode is &#39;fixed&#39;, a code or valueSet must be provided"/>
-        <expression value="(mode = &#39;fixed&#39;) implies (code.exists() or valueSet.exists())"/>
-        <xpath value="(f:mode/@value != &#39;fixed&#39;) or exists(f:code) or exists(f:valueSet)"/>
+        <human value="If the mode is &#39;fixed&#39;, either a code or valueSet must be provided, but not both."/>
+        <expression value="(mode = &#39;fixed&#39;) implies ((code.exists() and valueSet.empty()) or (code.empty() and valueSet.exists()))"/>
+        <xpath value="(f:mode/@value != &#39;fixed&#39;) or (exists(f:code) and not(exists(f:valueSet))) or (not(exists(f:code)) and exists(f:valueSet))"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ConceptMap2"/>
       </constraint>
     </element>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

Fix the cmd-2 group.unmapped constraint behavior to be mutually exclusive, so that "If the mode is 'fixed';, either a code or valueSet must be provided, but not both."
