### PR TITLE
ConceptMap2 updates

### DIFF
--- a/source/conceptmap2/bundle-ConceptMap2-search-params.xml
+++ b/source/conceptmap2/bundle-ConceptMap2-search-params.xml
@@ -298,14 +298,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ConceptMap2.sourceCanonical"/>
+          <valueString value="ConceptMap2.sourceScopeCanonical"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ConceptMap2-source"/>
         <description value="The source value set that contains the concepts that are being mapped"/>
         <code value="source"/>
         <type value="reference"/>
-        <expression value="(ConceptMap2.source as canonical)"/>
-        <xpath value="f:ConceptMap2/f:sourceCanonical"/>
+        <expression value="(ConceptMap2.sourceScope as canonical)"/>
+        <xpath value="f:ConceptMap2/f:sourceScopeCanonical"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -358,14 +358,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ConceptMap2.sourceUri"/>
+          <valueString value="ConceptMap2.sourceScopeUri"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ConceptMap2-source-uri"/>
         <description value="The source value set that contains the concepts that are being mapped"/>
         <code value="source-uri"/>
         <type value="reference"/>
-        <expression value="(ConceptMap2.source as uri)"/>
-        <xpath value="f:ConceptMap2/f:sourceUri"/>
+        <expression value="(ConceptMap2.sourceScope as uri)"/>
+        <xpath value="f:ConceptMap2/f:sourceScopeUri"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -398,14 +398,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ConceptMap2.targetCanonical"/>
+          <valueString value="ConceptMap2.targetScopeCanonical"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ConceptMap2-target"/>
         <description value="The target value set which provides context for the mappings"/>
         <code value="target"/>
         <type value="reference"/>
-        <expression value="(ConceptMap2.target as canonical)"/>
-        <xpath value="f:ConceptMap2/f:targetCanonical"/>
+        <expression value="(ConceptMap2.targetScope as canonical)"/>
+        <xpath value="f:ConceptMap2/f:targeScopeCanonical"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -458,14 +458,14 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ConceptMap2.targetUri"/>
+          <valueString value="ConceptMap2.targetScopeUri"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ConceptMap2-target-uri"/>
         <description value="The target value set which provides context for the mappings"/>
         <code value="target-uri"/>
         <type value="reference"/>
-        <expression value="(ConceptMap2.target as uri)"/>
-        <xpath value="f:ConceptMap2/f:targetUri"/>
+        <expression value="(ConceptMap2.targetScope as uri)"/>
+        <xpath value="f:ConceptMap2/f:targetScopeUri"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/conceptmap2/conceptmap2-103.xml
+++ b/source/conceptmap2/conceptmap2-103.xml
@@ -34,11 +34,11 @@
     </jurisdiction>
     <purpose value="Show example rule based mappings"/>
     <copyright value="Creative Commons 0"/>
-    <sourceCanonical value="http://snomed.info/sct?fhir_vs"/>
-    <targetCanonical value="http://hl7.org/fhir/sid/icd-10-us"/>
+    <sourceScopeCanonical value="http://snomed.info/sct?fhir_vs"/>
+    <!-- <targetScopeCanonical value="http://hl7.org/fhir/sid/icd-10-cm"/> -->
     <group>
         <source value="http://snomed.info/sct"/>
-        <target value="http://hl7.org/fhir/sid/icd-10-us"/>
+        <target value="http://hl7.org/fhir/sid/icd-10-cm"/>
         <!-- Unspecified fracture of shaft of unspecified ulna (initial encounter for closed fracture) -->
         <element>
             <!-- Fracture of shaft of ulna -->

--- a/source/conceptmap2/conceptmap2-cdshooks-indicator.xml
+++ b/source/conceptmap2/conceptmap2-cdshooks-indicator.xml
@@ -7,8 +7,8 @@
   <status value="draft"/>
   <experimental value="false"/>
   <description value="This concept map defines a mapping from CDS Hooks indicator to request priority."/>
-  <sourceCanonical value="http://cds-hooks.hl7.org/ValueSet/indicator"/>
-  <targetCanonical value="http://hl7.org/fhir/ValueSet/request-priority"/>
+  <sourceScopeCanonical value="http://cds-hooks.hl7.org/ValueSet/indicator"/>
+  <targetScopeCanonical value="http://hl7.org/fhir/ValueSet/request-priority"/>
   <group>
     <element>
       <code value="info"/>

--- a/source/conceptmap2/conceptmap2-example-2.xml
+++ b/source/conceptmap2/conceptmap2-example-2.xml
@@ -18,8 +18,8 @@
   </contact>
   <description value="An example mapping"/>
   <purpose value="To illustrate mapping features"/>
-  <sourceUri value="http://example.org/fhir/example1"/>
-  <targetUri value="http://example.org/fhir/example2"/>
+  <sourceScopeUri value="http://example.org/fhir/example1"/>
+  <targetScopeUri value="http://example.org/fhir/example2"/>
   <group>
     <source value="http://example.org/fhir/example1"/>
     <target value="http://example.org/fhir/example2"/>

--- a/source/conceptmap2/conceptmap2-example-specimen-type.xml
+++ b/source/conceptmap2/conceptmap2-example-specimen-type.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ConceptMap xmlns="http://hl7.org/fhir" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/conceptmap.xsd">
+<ConceptMap2 xmlns="http://hl7.org/fhir" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/conceptmap.xsd">
   <id value="102"/>
   <url value="http://hl7.org/fhir/ConceptMap/102"/>
   <version value="20130725"/>
@@ -20,8 +20,8 @@
       <value value="http://www.phconnect.org/group/laboratorymessagingcommunityofpractice/forum/attachment/download?id=3649725%3AUploadedFile%3A145786"/>
     </telecom>
   </contact>
-  <sourceCanonical value="http://terminology.hl7.org/ValueSet/v2-0487"/>
-  <targetCanonical value="http://snomed.info/sct?fhir_vs"/>
+  <sourceScopeCanonical value="http://terminology.hl7.org/ValueSet/v2-0487"/>
+  <targetScopeCanonical value="http://snomed.info/sct?fhir_vs"/>
   <group>
     <source value="http://terminology.hl7.org/CodeSystem/v2-0487"/>
     <target value="http://snomed.info/sct"/>
@@ -40,8 +40,10 @@
         <comment value="HL7 term is a historical term. mapped to Pus"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="47002008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="47002008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -59,8 +61,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="7970006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="7970006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -71,8 +75,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="81723002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="81723002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -107,8 +113,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -151,8 +159,10 @@
         <comment value="submitted (PLR155) with parent of  167874004^knee joint synovial fluid (specimen), with specimen source topography 32361000^Popliteal fossa structure (body structure)"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="32361000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="32361000"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -171,8 +181,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="339008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="339008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -183,8 +195,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="339008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="339008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -195,13 +209,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="59843005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="59843005"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -241,8 +259,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="439336003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="439336003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -260,8 +280,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="80657008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="80657008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -272,13 +294,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="11585000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="11585000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -289,8 +315,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="339008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="339008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -301,8 +329,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="86273004"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="86273004"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -320,8 +350,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="41570003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="41570003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -383,13 +415,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="54535009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="54535009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="71252005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="71252005"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -417,13 +453,17 @@
         <comment value="Prefer to have aspirate of the pus oozing out from cleaned insertion site - if swab is all that can be obtained, then swab after cleaning, otherwise you may get a contaminated specimen and a falsely identified infected central line. Do not just swab the reddened area - that will just collect skin flora       "/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="386144009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="386144009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="285570007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="285570007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -472,8 +512,10 @@
         <comment value="TBD in detail"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="445085009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="445085009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -484,8 +526,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="27925004"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="27925004"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -547,8 +591,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="31113003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="31113003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -567,8 +613,10 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead: not an acceptable specimen for micro - not specific enough term"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -580,8 +628,10 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -599,13 +649,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="36213007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="36213007"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="32849002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="32849002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -691,13 +745,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="321667001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="321667001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -716,13 +774,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="321667001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="321667001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -771,8 +833,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="303112003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="303112003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -783,8 +847,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="83670000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="83670000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -840,8 +906,10 @@
         <comment value="this term is not specific enough, choose from terms that more accurately describe the specimen"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="272626006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="272626006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -852,8 +920,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="41695006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="41695006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -865,8 +935,10 @@
         <comment value="Further describe the sample as tissue or pus. or by the collection method. The term boil is not specific to a body site - need to indicate source site (spm.8). preferred term is Aspirate_Boil"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="59843005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="59843005"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -884,13 +956,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -901,8 +977,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="66051006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="66051006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -913,13 +991,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="235157009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="235157009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -931,13 +1013,17 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -969,8 +1055,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="45647009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="45647009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -997,13 +1085,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="79121003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="79121003"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1023,18 +1115,24 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="127490009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="127490009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1053,8 +1151,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="303113008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="303113008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1096,8 +1196,10 @@
         <comment value="TBD in detail"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="445085009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="445085009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1108,8 +1210,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="55434001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="55434001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1151,8 +1255,10 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead: stool is what is expected, should use stool sample"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="419954003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="419954003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1224,8 +1330,10 @@
         <comment value="TBD in detail"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="255560000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="255560000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1251,13 +1359,17 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead: stool is what is expected, should use stool sample"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="21306003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="21306003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1276,8 +1388,10 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1288,8 +1402,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="67889009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="67889009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1300,8 +1416,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="64033007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="64033007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1312,8 +1430,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="397394009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="397394009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1324,13 +1444,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="173830003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="173830003"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1348,13 +1472,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="67889009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="67889009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="44567001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="44567001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1404,8 +1532,10 @@
         <comment value="The HL7 term is a historical term Mapped to CSF obtained by lumbar puncture"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="303949008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="303949008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1424,8 +1554,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="4147007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="4147007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1443,8 +1575,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="414781009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="414781009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1463,13 +1597,17 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="2095001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="2095001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1495,13 +1633,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="6853008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="6853008"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1513,18 +1655,24 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="127492001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="127492001"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="69695003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="69695003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1565,8 +1713,10 @@
         <comment value="be more precise use ulcer, tumor, vesicle"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="74262004"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="74262004"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -1614,8 +1764,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="12921003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="12921003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1627,8 +1779,10 @@
         <comment value="need to know what kind of lesion, so map to: UlcerTissue_penile, VesicleFluid_penile, Wound_penile, Mass tissue_penile, Necrotic tissue_penile, AbscessAspirate_penile, Anything else?"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="18911002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="18911002"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -1639,8 +1793,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="397158004"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="397158004"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1693,8 +1849,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="255587001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="255587001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1706,13 +1864,17 @@
         <comment value="Historical term -though in this case more often used for discharge"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="13648007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="13648007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1723,8 +1885,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="41329004"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="41329004"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1735,8 +1899,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="6902008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="6902008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1747,8 +1913,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="6902008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="6902008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1803,8 +1971,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="129300006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="129300006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1822,8 +1992,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="47002008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="47002008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1834,8 +2006,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="47002008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="47002008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1870,13 +2044,17 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead: stool is what is expected, should use stool sample"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="34402009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="34402009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1887,8 +2065,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="34402009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="34402009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1899,8 +2079,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="64033007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="64033007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1911,8 +2093,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="64033007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="64033007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1945,8 +2129,10 @@
         <comment value="TBD in detail"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="9454009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="9454009"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1957,8 +2143,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="20233005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="20233005"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -1984,13 +2172,17 @@
         <comment value="Preferred is aspiration with sterile syringe from inflamed area. Specify body location of shunt site"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="257351008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="257351008"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2001,13 +2193,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="446860008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="446860008"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="279107003"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="279107003"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2034,8 +2230,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="240977001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="240977001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2053,8 +2251,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="4147007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="4147007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2161,8 +2361,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="64033007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="64033007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2173,8 +2375,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="5713008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="5713008"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2185,8 +2389,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="4335006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="4335006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2198,8 +2404,10 @@
         <comment value="Historical term - consider what is being drained and indicate that in SPM-4 instead"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2210,8 +2418,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="58088002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="58088002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2238,13 +2448,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="129112001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="129112001"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="44567001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="44567001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2291,8 +2505,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="255588006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="255588006"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2303,8 +2519,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="279572002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="279572002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2315,8 +2533,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="129112001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="129112001"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2370,8 +2590,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="78533007"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="78533007"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2389,13 +2611,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="225271002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="225271002"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="431938005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="431938005"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2406,13 +2632,17 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="225109005"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="225109005"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="25990002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="25990002"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2439,13 +2669,17 @@
         <comment value="NEW specimenTERM 7"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="176178006"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="176178006"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="89837001"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="89837001"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -2551,8 +2785,10 @@
         <relationship value="equivalent"/>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="122462000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="122462000"/>
+          </valueCoding>
         </product>
       </target>
     </element>
@@ -2608,18 +2844,24 @@
         <comment value="Prefer to have aspirate of the pus oozing out from cleaned insertion site - if swab is all that can be obtained, then swab after cleaning, otherwise you may get a contaminated specimen and a falsely identified infected central line. Do not just swab the reddened area - that will just collect skin flora"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="119295008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="119295008"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="386144009"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="386144009"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/3006873018"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="14766002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="14766002"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -2631,8 +2873,10 @@
         <comment value="Be more specific use either: 119326000^hair specimen, or 119327009^nail specimen"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="119326000"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="119326000"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
@@ -2644,15 +2888,19 @@
         <comment value="assume swab from shunt site for mapping here - clean surface of skin prior to expressing the shunt site - preferred is aspiration with sterile syringe should use SPM.8 to specify body approximate match location of shunt site"/>
         <product>
           <property value="TypeModifier"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="438660002"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="438660002"/>
+          </valueCoding>
         </product>
         <product>
           <property value="http://snomed.info/id/246380002"/>
-          <system value="http://snomed.info/sct"/>
-          <value value="257351008"/>
+          <valueCoding>
+            <system value="http://snomed.info/sct"/>
+            <code value="257351008"/>
+          </valueCoding>
         </product>
       </target> -->
     </element>
   </group>
-</ConceptMap>
+</ConceptMap2>

--- a/source/conceptmap2/conceptmap2-example.xml
+++ b/source/conceptmap2/conceptmap2-example.xml
@@ -43,8 +43,8 @@
     </jurisdiction>
     <purpose value="To help implementers map from FHIR to HL7 v3/CDA"/>
     <copyright value="Creative Commons 0"/>
-    <sourceUri value="http://hl7.org/fhir/ValueSet/address-use"/>
-    <targetUri value="http://terminology.hl7.org/ValueSet/v3-AddressUse"/>
+    <sourceScopeUri value="http://hl7.org/fhir/ValueSet/address-use"/>
+    <targetScopeUri value="http://terminology.hl7.org/ValueSet/v3-AddressUse"/>
     <group>
         <source value="http://hl7.org/fhir/address-use"/>
         <target value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>

--- a/source/conceptmap2/operationdefinition-ConceptMap2-translate.xml
+++ b/source/conceptmap2/operationdefinition-ConceptMap2-translate.xml
@@ -359,7 +359,7 @@
       </part>
     </part>
     <part>
-      <name value="originalMap"/>
+      <name value="originMap"/>
       <use value="out"/>
       <min value="0"/>
       <max value="1"/>

--- a/source/conceptmap2/structuredefinition-ConceptMap2.xml
+++ b/source/conceptmap2/structuredefinition-ConceptMap2.xml
@@ -688,9 +688,9 @@
       <constraint>
         <key value="cmd-6"/>
         <severity value="error"/>
-        <human value="One of value[x] or valueSet must exist."/>
-        <expression value="value.exists() or valueSet.exists()"/>
-        <xpath value="exists(f:value) or exists(f:valueSet)"/>
+        <human value="One of value[x] or valueSet must exist, but not both."/>
+        <expression value="(value.exists() and valueSet.empty()) or (value.empty() and valueSet.exists())"/>
+        <xpath value="(exists(f:value) and not(exists(f:valueSet))) or (not(exists(f:value)) and exists(f:valueSet))"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ConceptMap2"/>
       </constraint>
     </element>

--- a/source/conceptmap2/structuredefinition-ConceptMap2.xml
+++ b/source/conceptmap2/structuredefinition-ConceptMap2.xml
@@ -786,6 +786,14 @@
         <xpath value="(f:mode/@value != &#39;fixed&#39;) or (exists(f:code) and not(exists(f:valueSet))) or (not(exists(f:code)) and exists(f:valueSet))"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ConceptMap2"/>
       </constraint>
+      <constraint>
+        <key value="cmd-8"/>
+        <severity value="error"/>
+        <human value="If the mode is not &#39;fixed&#39;, code, display and valueSet are not allowed"/>
+        <expression value="(mode != &#39;fixed&#39;) implies (code.empty() and display.empty() and valueSet.empty())"/>
+        <xpath value="(f:mode/@value = &#39;fixed&#39;) or not(exists(f:code) or exists(f:display) or exists(f:valueSet))"/>
+        <source value="http://hl7.org/fhir/StructureDefinition/ConceptMap2"/>
+      </constraint>
     </element>
     <element id="ConceptMap2.group.unmapped.mode">
       <path value="ConceptMap2.group.unmapped.mode"/>

--- a/source/conceptmap2/structuredefinition-ConceptMap2.xml
+++ b/source/conceptmap2/structuredefinition-ConceptMap2.xml
@@ -414,11 +414,11 @@
         <map value="no-gen-base"/>
       </mapping>
     </element>
-    <element id="ConceptMap2.source[x]">
-      <path value="ConceptMap2.source[x]"/>
+    <element id="ConceptMap2.sourceScope[x]">
+      <path value="ConceptMap2.sourceScope[x]"/>
       <short value="The source value set that contains the concepts that are being mapped"/>
-      <definition value="Identifier for the source value set that contains the concepts that are being mapped and provides context for the mappings."/>
-      <comment value="Should be a version specific reference. URIs SHOULD be absolute. If there is no source or target value set, there is no specified context for the map (not recommended).  The source value set may select codes from either an explicit (standard or local) or implicit code system."/>
+      <definition value="Identifier for the source value set that contains the concepts that are being mapped and provides context for the mappings.  Limits the scope of the map to source codes (ConceptMap2.group.element code or valueSet) that are members of this value set."/>
+      <comment value="Should be a version specific reference. URIs SHOULD be absolute. If there is no sourceScope or targetScope value set, there is no specified context for the map (not recommended).  The sourceScope value set may select codes from either an explicit (standard or local) or implicit code system."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -430,11 +430,11 @@
       </type>
       <isSummary value="true"/>
     </element>
-    <element id="ConceptMap2.target[x]">
-      <path value="ConceptMap2.target[x]"/>
+    <element id="ConceptMap2.targetScope[x]">
+      <path value="ConceptMap2.targetScope[x]"/>
       <short value="The target value set which provides context for the mappings"/>
-      <definition value="The target value set provides context for the mappings. Note that the mapping is made between concepts, not between value sets, but the value set provides important context about how the concept mapping choices are made."/>
-      <comment value="Should be a version specific reference. URIs SHOULD be absolute. If there is no source or target value set, the is no specified context for the map."/>
+      <definition value="Identifier for the target value set that provides important context about how the mapping choices are made.  Limits the scope of the map to target codes (ConceptMap2.group.element.target code or valueSet) that are members of this value set."/>
+      <comment value="Should be a version specific reference. URIs SHOULD be absolute. If there is no sourceScope or targetScope value set, there is no specified context for the map (not recommended).  The targetScope value set may select codes from either an explicit (standard or local) or implicit code system."/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

1. FHIR-32543 - Add constraint to group.unmapped for "If the mode is not 'fixed', code, display and valueSet are not allowed".
2. FHIR-32549 - Update cmd-6 constraint for value and valueSet to be mutually exclusive - only one can be present.
3. FHIR-31386 - Change ConceptMap source[x] and target[x] to sourceScope[x] and targetScope[x], plus related updates to the search parameters and examples.  Fix the  operation definition output parameter rename to 'originMap' as proposed (not 'originalMap').
