### PR TITLE
FHIR-17301 - Remove confidentiality from Composition

### DIFF
--- a/source/composition/bundle-Composition-search-params.xml
+++ b/source/composition/bundle-Composition-search-params.xml
@@ -65,26 +65,6 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="Composition-confidentiality"/>
-        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="normative"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="Composition.confidentiality"/>
-        </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/Composition-confidentiality"/>
-        <description value="As defined by affinity domain"/>
-        <code value="confidentiality"/>
-        <type value="token"/>
-        <expression value="Composition.confidentiality"/>
-        <xpath value="f:Composition/f:confidentiality"/>
-        <xpathUsage value="normal"/>
-      </SearchParameter>
-    </resource>
-  </entry>
-  <entry>
-    <resource>
-      <SearchParameter>
         <id value="Composition-context"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>

--- a/source/composition/composition-example-mixed.xml
+++ b/source/composition/composition-example-mixed.xml
@@ -27,7 +27,6 @@
 		<display value="Harold Hippocrates, MD"/>
 	</author>
 	<title value="Discharge Summary (Neonatal Service)"/>
-	<confidentiality value="N"/>
 	<attester>
 		<mode>
 			<coding>

--- a/source/composition/composition-example.xml
+++ b/source/composition/composition-example.xml
@@ -40,7 +40,6 @@
 		<display value="Harold Hippocrates, MD"/>
 	</author>
 	<title value="Consultation Note"/>
-	<confidentiality value="N"/>
 	<attester>
 		<mode>
 			<coding>

--- a/source/composition/composition-introduction.xml
+++ b/source/composition/composition-introduction.xml
@@ -113,15 +113,15 @@ CDA is a primary design input to the Composition resource (other principal input
 differences between CDA and the Composition resource:
 </p>
 <ul>
- <li>A composition is a logical construct- its identifier matches to the CDA ClinicalDocument.setId. 
+ <li>A composition is a logical construct - its <code>identifier</code> matches to the CDA <code>ClinicalDocument.setId</code>. 
  Composition resources are wrapped into <a href="documents.html">Document</a> structures, for exchange
  of the whole package (the composition and its parts), and this wrapped, sealed entity is equivalent to a CDA document, 
- where the Bundle.id is equivalent in function to ClinicalDocument.id (but it is not identical when interconverting, since it's a transform between them).</li>
+ where the where the <code>Bundle.identifier</code> is equivalent to <code>ClinicalDocument.id</code> and <code>Bundle.meta.security</code> is equivalent to <code>ClinicalDocument.confidentialityCode</code>.</li>
  <li>The composition section defines a section (or sub-section) of the document, but unlike CDA, the section entries are 
    actually references to other <a href="resourcelist.html">resources</a> that hold the supporting data content for the section. 
    This design means that the data can be reused in many other ways. 
    </li>
-  <li>Unlike CDA, the context defined in the <code>Composition</code> (the confidentiality, subject, author, event, event period and encounter) apply to the composition and do not specifically apply to the resources referenced from 
+  <li>Unlike CDA, the context defined in the <code>Composition</code> (the subject, author, event, event period and encounter) apply to the composition and do not specifically apply to the resources referenced from 
   the <code>section.entry</code>. There is no context flow model in FHIR, so each resource referenced from 
   within a <code>Composition</code> expresses its own individual context.  In this way, clinical content can 
   safely be extracted from the composition.</li>

--- a/source/composition/connectathon-example-scenario21.xml
+++ b/source/composition/connectathon-example-scenario21.xml
@@ -2,8 +2,14 @@
 <Bundle xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhir" xsi:schemaLocation="http://hl7.org/fhir ../../publish/bundle.xsd">
   <id value="500bee81-d973-4afe-b592-d39fe71e38"/>
   <meta>
-    <lastUpdated value="2013-05-28T22:12:21Z"/>
     <!-- Time the bundle was built -->
+    <lastUpdated value="2013-05-28T22:12:21Z"/>
+    <!-- Represents the document's overall confidentialtiy-->
+    <security>
+      <system value="http://terminology.hl7.org/CodeSystem/v3-Confidentiality"/>
+      <code value="N"/>
+      <display value="normal"/>
+    </security>
     <!-- This tag specifies unambiguously that this is a FHIR document bundle -->
     <tag>
       <system value="http://hl7.org/fhir/tag"/>
@@ -40,7 +46,6 @@
         </type>
         <title value="Progress Note"/>
         <status value="final"/>
-        <confidentiality value="n"/>
         <!-- Who the document is about. The patient with the ID of sample -->
         <subject>
           <reference value="http://hl7.org.nz/fhir/Patient/patsypregnant"/>

--- a/source/composition/document-example-dischargesummary.xml
+++ b/source/composition/document-example-dischargesummary.xml
@@ -5,6 +5,13 @@
  xmlns="http://hl7.org/fhir">
 
   <id value="father"/>
+    <meta>
+      <security>
+        <system value="http://terminology.hl7.org/CodeSystem/v3-Confidentiality"/>
+        <code value="N"/>
+        <display value="normal"/>
+      </security>
+    </meta>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
     <value value="urn:uuid:0c3151bd-1cbf-4d64-b04d-cd9187a4c6e0"/>
@@ -42,7 +49,6 @@
           <display value="Doctor Dave"/>
         </author>
         <title value="Discharge Summary"/>
-        <confidentiality value="N"/>
         <section>
           <title value="Reason for admission"/>
           <code>

--- a/source/composition/structuredefinition-Composition.xml
+++ b/source/composition/structuredefinition-Composition.xml
@@ -510,38 +510,6 @@
         <code value="Annotation"/>
       </type>
     </element>
-    <element id="Composition.confidentiality">
-      <path value="Composition.confidentiality"/>
-      <short value="As defined by affinity domain"/>
-      <definition value="The code specifying the level of confidentiality of the Composition."/>
-      <comment value="The exact use of this element, and enforcement and issues related to highly sensitive documents are out of scope for the base specification, and delegated to implementation profiles (see security section).  This element is labeled as a modifier because highly confidential documents must not be treated as if they are not."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="code"/>
-      </type>
-      <isSummary value="true"/>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="DocumentConfidentiality"/>
-        </extension>
-        <strength value="required"/>
-        <description value="Codes specifying the level of confidentiality of the composition."/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-Confidentiality|2.0.0"/>
-      </binding>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".confidentialityCode"/>
-      </mapping>
-      <mapping>
-        <identity value="cda"/>
-        <map value=".confidentialityCode"/>
-      </mapping>
-      <mapping>
-        <identity value="fhirdocumentreference"/>
-        <map value="DocumentReference.securityLabel"/>
-      </mapping>
-    </element>
     <element id="Composition.attester">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/uml-dir">
         <valueCode value="down"/>

--- a/source/documentreference/structuredefinition-DocumentReference.xml
+++ b/source/documentreference/structuredefinition-DocumentReference.xml
@@ -926,7 +926,7 @@
       </binding>
       <mapping>
         <identity value="fhircomposition"/>
-        <map value="Composition.confidentiality, Composition.meta.security"/>
+        <map value="Bundle.meta.security"/>
       </mapping>
       <mapping>
         <identity value="v2"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: https://jira.hl7.org/browse/FHIR-17301

## Description

Composition.confidentiality is redundant with meta.security. Per the tracker item - removing this field and its associated search parameter from Composition.

The "note for CDA aware readers" text was updated to remove confidentiality from the context list; while I was there, I did https://jira.hl7.org/browse/FHIR-30766 as well and updated the note about ClinicalDocument.id mapping to Bundle.identifier.

Also updated examples to remove the field. There are 2 examples that are actually on Bundle, so I added the meta.security tag in those instances (since the point of the tracker was that Bundle.meta.security is the correct location for this information.

Finally, updated DocumentReference's mapping for securityLabel. Technically it's not to Composition any more, but the equivalent field in a composition to DocumentReference.securityLabel is its parent Bundle.meta.security.
