### PR TITLE
ResearchStudy, completed J# 37691 for adding extension studyRegistration and other changes

### DIFF
--- a/source/researchstudy/codesystem-research-study-classifiers.xml
+++ b/source/researchstudy/codesystem-research-study-classifiers.xml
@@ -252,6 +252,11 @@
 		<code value="research-study-status"/>
 		<display value="Research Study Status"/>
 		<concept>
+			<code value="overall-study"/>
+			<display value="Overall study"/>
+			<definition value="Used for documenting the start and end of the overall study, distinct from progress states."/>
+		</concept>
+		<concept>
 			<code value="active"/>
 			<display value="Active"/>
 			<definition value="Study is opened for accrual."/>
@@ -333,16 +338,12 @@
 		</concept>
 	</concept>
 	<concept>
-		<code value="research-study-statusDate-activity"/>
-		<display value="Research Study Status-related Activity"/>
+		<code value="research-study-registration-activity"/>
+		<display value="Research Study Registration Activity"/>
 		<concept>
 			<code value="record-verification"/>
 			<display value="Record Verification"/>
 			<definition value="Record has been verified."/>
-		</concept>
-		<concept>
-			<code value="overall-study"/>
-			<display value="Overall study"/>
 		</concept>
 		<concept>
 			<code value="primary-outcome-data-collection"/>

--- a/source/researchstudy/implementationguide-ResearchStudy-core.xml
+++ b/source/researchstudy/implementationguide-ResearchStudy-core.xml
@@ -15,5 +15,10 @@
         <reference value="StructureDefinition/researchStudy-siteRecruitment"/>
       </reference>
     </resource>
+      <resource>
+        <reference>
+          <reference value="StructureDefinition/researchStudy-studyRegistration"/>
+        </reference>
+      </resource>
   </definition>
 </ImplementationGuide>

--- a/source/researchstudy/researchstudy-introduction.xml
+++ b/source/researchstudy/researchstudy-introduction.xml
@@ -41,9 +41,14 @@ draw the attention of reviewers and implementers to the following issue:
 <p>Some studies need to find sites according to specific criteria - for example site has a freezer capable of very low temperatures and a centrifuge.</p>
 
   <p>
+    <b>Extension: StudyRegistration</b>
+  </p>
+<p>Used to separate study registration activities from study progress status.</p>
+
+  <p>
     <b>Deprecated Extension: RelatesTo</b>
   </p>
-<p>Many clinical studies have a component sub-study and the partOf attribute should be used for this. There may also be documents such as a PDF of the protocol or consent forms or more complex relations to other studies people organizations or artefacts and these should be linked using relatedAretfact. 
+<p>Many clinical studies have a component sub-study and the partOf attribute should be used for this. There may also be documents such as a PDF of the protocol or consent forms or more complex relations to other studies people organizations or artefacts and these should be linked using relatedAretfact.
 
 In the May 2021 release the <a href="http://hl7.org/fhir/2021May/extension-researchstudy-relatesto.html">relatesTo</a> extension was created.  Since then the RelatesTo datatype has been enhanced and the relatedAretfact now provides all the functionality that was in the extension.  This extension has now been removed.  Since there are already (March 2022) some known uses of the extension a link to the previous definition is provided above for reference.  Implementers should now stop using the extension.</p>
 

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -898,8 +898,8 @@
     </element>
     <element id="ResearchStudy.progressStatus.state">
       <path value="ResearchStudy.progressStatus.state"/>
-      <short value="Record-Verification | Overall-Study | Primary-Outcome-Data-Collection | Registration-Submission | Registration-Submission-QC | Registration-Posting | Results-Submission | Results-Submission-QC | Results-Posting | Disposition-Submission | Disposition-Submission-QC | Disposition-Posting | Update-Submission | Update-Posting"/>
-      <definition value="Label for status or state."/>
+      <short value="Label for status or state (e.g. recruitment status)"/>
+      <definition value="Label for status or state (e.g. recruitment status)."/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/source/researchstudy/structuredefinition-extension-researchStudy-studyRegistration.xml
+++ b/source/researchstudy/structuredefinition-extension-researchStudy-studyRegistration.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="researchStudy-studyRegistration"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="brr"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <url value="http://hl7.org/fhir/StructureDefinition/researchStudy-studyRegistration"/>
+  <version value="4.6.0"/>
+  <name value="studyRegistration"/>
+  <title value="studyRegistration"/>
+  <status value="draft"/>
+  <date value="2022-07-25T00:00:00+00:00"/>
+  <publisher value="HL7"/>
+  <description value="Dates for study registration activities."/>
+  <fhirVersion value="4.6.0"/>
+  <mapping>
+    <identity value="rim"/>
+    <uri value="http://hl7.org/v3"/>
+    <name value="RIM Mapping"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <context>
+    <type value="element"/>
+    <expression value="ResearchStudy"/>
+  </context>
+  <type value="Extension"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Extension">
+      <path value="Extension"/>
+      <short value="Dates for study registration activities"/>
+      <definition value="Dates for study registration activities."/>
+      <comment value="Used to separate study registration activities from study progress status."/>
+      <min value="0"/>
+      <max value="*"/>
+    </element>
+    
+    <!-- activity -->
+    <element id="Extension.extension:activity">
+      <path value="Extension.extension"/>
+      <sliceName value="activity"/>
+      <short value="The specific activity"/>
+      <definition value="The specific registration activity."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+      </type>
+    </element>
+    <element id="Extension.extension:activity.extension">
+      <path value="Extension.extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.extension:activity.url">
+      <path value="Extension.extension.url"/>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="activity"/>
+    </element>
+    <element id="Extension.extension:activity.value[x]">
+      <path value="Extension.extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="ResearchStudyRegistrationActivity"/>
+        </extension>
+        <strength value="extensible"/>
+        <description value="Codes for study registration activities."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/research-study-registration-activity"/>
+      </binding>
+    </element>
+
+    <!-- actual -->
+    <element id="Extension.extension:actual">
+      <path value="Extension.extension"/>
+      <sliceName value="actual"/>
+      <short value="Actual if true, else anticipated"/>
+      <definition value="Actual if true, else anticipated."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+      </type>
+    </element>
+    <element id="Extension.extension:actual.extension">
+      <path value="Extension.extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.extension:actual.url">
+      <path value="Extension.extension.url"/>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="actual"/>
+    </element>
+    <element id="Extension.extension:actual.value[x]">
+      <path value="Extension.extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="boolean"/>
+      </type>
+    </element>
+    
+    <!-- period -->
+    <element id="Extension.extension:period">
+      <path value="Extension.extension"/>
+      <sliceName value="period"/>
+      <short value="Date range"/>
+      <definition value="Date range."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+      </type>
+    </element>
+    <element id="Extension.extension:period.extension">
+      <path value="Extension.extension.extension"/>
+      <max value="0"/>
+    </element>
+    <element id="Extension.extension:period.url">
+      <path value="Extension.extension.url"/>
+      <type>
+        <code value="uri"/>
+      </type>
+      <fixedUri value="period"/>
+    </element>
+    <element id="Extension.extension:period.value[x]">
+      <path value="Extension.extension.value[x]"/>
+      <min value="1"/>
+      <type>
+        <code value="Period"/>
+      </type>
+    </element>
+
+  </differential>
+</StructureDefinition>

--- a/source/researchstudy/valueset-research-study-registration-activity.xml
+++ b/source/researchstudy/valueset-research-study-registration-activity.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="research-study-statusDate-activity"/>
+  <id value="research-study-registration-activity"/>
   <meta>
     <lastUpdated value="2020-12-28T16:55:11.085+11:00"/>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
@@ -15,14 +15,14 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="1"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/research-study-statusDate-activity"/>
+  <url value="http://hl7.org/fhir/ValueSet/research-study-registration-activity"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>
     <value value="urn:oid:2.16.840.1.113883.4.642.1.1681"/>
   </identifier>
   <version value="4.6.0"/>
-  <name value="ResearchStudyStatusDateActivity"/>
-  <title value="ResearchStudyStatusDateActivity"/>
+  <name value="ResearchStudyRegistrationActivity"/>
+  <title value="ResearchStudyRegistrationActivity"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2022-02-10T20:40:00+00:00"/>
@@ -37,7 +37,7 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Codes for activity that changed study status."/>
+  <description value="Codes for study registration activities."/>
   <immutable value="true"/>
   <compose>
     <include>
@@ -45,7 +45,7 @@
 	  <filter>
 	    <property value="concept"/>
 	    <op value="descendent-of"/>
-	    <value value="research-study-statusDate-activity"/>
+	    <value value="research-study-registration-activity"/>
 	  </filter>
     </include>
   </compose>


### PR DESCRIPTION
- Added extension studyRegistration to ResearchStudy, and added it to its implementation guide and introduction
- Changed the valueset name of statusDate-activity to registration-activity
- Moved "overall-study" code in the hierarchy in the Research Study Classifiers codesystem
- Corrected definition and short definition for ResearchStudy.progressStatus.state