### PR TITLE
Fix zulip notification link + enforce setup and build order

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -33,6 +33,7 @@ jobs:
         which java
 
 - job: buildAndPublishSpecification
+  dependsOn: setupEnvironment
   steps:
   # Trigger a publish to test if all changes produce a valid, publishable java implementation of the specification
   - task: Gradle@2
@@ -72,7 +73,7 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for master branch:thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildNumber)&_a=summary&view=logs) 
+            -d $"content=PR Build success for master branch:thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results) 
             Published webpage can be viewed [here](https://build.fhir.org/)
             "
 
@@ -86,5 +87,5 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=Build failed for master branch :thumbs_down:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildNumber)&_a=summary&view=logs)
+            -d $"content=Build failed for master branch :thumbs_down:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -34,6 +34,7 @@ jobs:
         which java
 
 - job: buildAndPublishSpecification
+  dependsOn: setupEnvironment
   steps:
   # Trigger a publish to test if all changes produce a valid, publishable java implementation of the specification
   - task: Gradle@2
@@ -74,7 +75,7 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for branch $TARGET_DIRECTORY :thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildNumber)&_a=summary&view=logs)
+            -d $"content=PR Build success for branch $TARGET_DIRECTORY :thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$TARGET_DIRECTORY)
             "
   - task: Bash@3
@@ -88,5 +89,5 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=Build failed for branch $TARGET_DIRECTORY :thumbs_down:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildNumber)&_a=summary&view=logs)
+            -d $"content=Build failed for branch $TARGET_DIRECTORY :thumbs_down:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             "


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

1. Fixes the zulip notification link. It was invalid, and rerouted to the pipeline landing, which is less useful.

2. Makes the buildAndPublishSpecification step depend on the success of setup. This was previously unenforced; gradlew was running regardless because Java exists on each agent, but it was unlikely to be the version in the setup step.
