### PR TITLE
J# 37926 and J# 37942 for EvidenceVariable Resource

### DIFF
--- a/source/evidencevariable/bundle-EvidenceVariable-search-params.xml
+++ b/source/evidencevariable/bundle-EvidenceVariable-search-params.xml
@@ -16,8 +16,8 @@
         <description value="What resource is being referenced"/>
         <code value="composed-of"/>
         <type value="reference"/>
-        <expression value="EvidenceVariable.relatedArtifact.where(type=&#39;composed-of&#39;).resource"/>
-        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value=&#39;composed-of&#39;]/f:resource"/>
+        <expression value="EvidenceVariable.relatedArtifact.where(type='composed-of').resource"/>
+        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value='composed-of']/f:resource"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -164,8 +164,8 @@
         <description value="What resource is being referenced"/>
         <code value="depends-on"/>
         <type value="reference"/>
-        <expression value="EvidenceVariable.relatedArtifact.where(type=&#39;depends-on&#39;).resource"/>
-        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value=&#39;depends-on&#39;]/f:resource"/>
+        <expression value="EvidenceVariable.relatedArtifact.where(type='depends-on').resource"/>
+        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value='depends-on']/f:resource"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -184,8 +184,8 @@
         <description value="What resource is being referenced"/>
         <code value="derived-from"/>
         <type value="reference"/>
-        <expression value="EvidenceVariable.relatedArtifact.where(type=&#39;derived-from&#39;).resource"/>
-        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value=&#39;derived-from&#39;]/f:resource"/>
+        <expression value="EvidenceVariable.relatedArtifact.where(type='derived-from').resource"/>
+        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value='derived-from']/f:resource"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -264,8 +264,8 @@
         <description value="What resource is being referenced"/>
         <code value="predecessor"/>
         <type value="reference"/>
-        <expression value="EvidenceVariable.relatedArtifact.where(type=&#39;predecessor&#39;).resource"/>
-        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value=&#39;predecessor&#39;]/f:resource"/>
+        <expression value="EvidenceVariable.relatedArtifact.where(type='predecessor').resource"/>
+        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value='predecessor']/f:resource"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>
@@ -324,8 +324,8 @@
         <description value="What resource is being referenced"/>
         <code value="successor"/>
         <type value="reference"/>
-        <expression value="EvidenceVariable.relatedArtifact.where(type=&#39;successor&#39;).resource"/>
-        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value=&#39;successor&#39;]/f:resource"/>
+        <expression value="EvidenceVariable.relatedArtifact.where(type='successor').resource"/>
+        <xpath value="f:EvidenceVariable/f:relatedArtifact[f:type/@value='successor']/f:resource"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/evidencevariable/evidencevariable-introduction.xml
+++ b/source/evidencevariable/evidencevariable-introduction.xml
@@ -16,6 +16,7 @@
 <p>PICO (and its variants like PECO or PICOT) is a universal acronym used in evidence-based medicine communities to clearly express research questions and evidence findings.</p>
 
 <p>The EvidenceVariable Resource allows expression of the components of a PICO question in codeable and reusable formats.  As an exception, the Population specification will NOT use the EvidenceVariable Resource. The Population specification will use the <a href="group.html">Group</a> Resource to facilitate interoperability in matching <a href="evidence.html">Evidence</a> Resources to actual groups.</p>
+<p><strong>Ballot question:</strong> The EvidenceVariable Resource has been modified to support expressions of complex eligibility criteria for implementer communities seeking alternatives to Group Resource for eligibility criteria for clinical trials. With these changes, the current EvidenceVariable Resource has greater flexibility than the Group Resource for Population specification. Please submit a ballot comment to note if you support a proposed change to the EvidenceVariable Scope and Usage to delete "As an exception, the Population specification will NOT use the EvidenceVariable Resource" and "The Population specification will use the Group Resource to facilitate interoperability in matching Evidence Resources to actual groups."</p>
 
 </div>
 

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -87,8 +87,8 @@
         <key value="cnl-0"/>
         <severity value="warning"/>
         <human value="Name should be usable as an identifier for the module by machine processing applications such as code generation"/>
-        <expression value="name.exists() implies name.matches(&#39;[A-Z]([A-Za-z0-9_]){0,254}&#39;)"/>
-        <xpath value="not(exists(f:name/@value)) or matches(f:name/@value, &#39;[A-Z]([A-Za-z0-9_]){0,254}&#39;)"/>
+        <expression value="name.exists() implies name.matches('[A-Z]([A-Za-z0-9_]){0,254}')"/>
+        <xpath value="not(exists(f:name/@value)) or matches(f:name/@value, '[A-Z]([A-Za-z0-9_]){0,254}')"/>
         <source value="http://hl7.org/fhir/StructureDefinition/EvidenceVariable"/>
       </constraint>
       <mapping>
@@ -322,8 +322,8 @@
     <element id="EvidenceVariable.description">
       <path value="EvidenceVariable.description"/>
       <short value="Natural language description of the evidence variable"/>
-      <definition value="A free text natural language description of the evidence variable from a consumer&#39;s perspective."/>
-      <comment value="This description can be used to capture details such as why the evidence variable was built, comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the evidence variable as conveyed in the &#39;text&#39; field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the evidence variable is presumed to be the predominant language in the place the evidence variable was created)."/>
+      <definition value="A free text natural language description of the evidence variable from a consumer's perspective."/>
+      <comment value="This description can be used to capture details such as why the evidence variable was built, comments about misuse, instructions for clinical use and interpretation, literature references, examples from the paper world, etc. It is not a rendering of the evidence variable as conveyed in the 'text' field of the resource itself. This item SHOULD be populated unless the information is available from context (e.g. the language of the evidence variable is presumed to be the predominant language in the place the evidence variable was created)."/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
Corrected two definitions (and short definitions) for EvidenceVariable.characteristic.exclude and EvidenceVariable.characteristic.definitionByTypeAndValue.value[x]

Also added Ballot question to the EvidenceVariable introduction Scope and Usage