### PR TITLE
Fix pipeline java install step

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -9,7 +9,6 @@ variables:
 - group: SSH_UPLOAD
 
 jobs:
-
 - job: buildAndPublishSpecification
   steps:
   # Download Java, install, and set JAVA_HOME env variables

--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -9,8 +9,11 @@ variables:
 - group: SSH_UPLOAD
 
 jobs:
-- job: setupEnvironment
+
+- job: buildAndPublishSpecification
+  dependsOn: setupEnvironment
   steps:
+  # Download Java, install, and set JAVA_HOME env variables
   - task: Bash@3
     displayName: 'Download java sdk'
     inputs:
@@ -32,10 +35,7 @@ jobs:
         echo which java returns
         which java
 
-- job: buildAndPublishSpecification
-  dependsOn: setupEnvironment
-  steps:
-  # Trigger a publish to test if all changes produce a valid, publishable java implementation of the specification
+    # Trigger a publish to test if all changes produce a valid, publishable java implementation of the specification
   - task: Gradle@2
     inputs:
       gradleWrapperFile: 'gradlew'

--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -23,7 +23,7 @@ jobs:
       jdkArchitectureOption: x64
       jdkSourceOption: LocalDirectory
       jdkFile: "$(Build.ArtifactStagingDirectory)/java11.tar.gz"
-      jdkDestinationDirectory: ""
+      jdkDestinationDirectory: "$(Build.ArtifactStagingDirectory)/jdk"
   - task: Bash@3
     inputs:
       targetType: 'inline'

--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -11,7 +11,6 @@ variables:
 jobs:
 
 - job: buildAndPublishSpecification
-  dependsOn: setupEnvironment
   steps:
   # Download Java, install, and set JAVA_HOME env variables
   - task: Bash@3

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -24,7 +24,7 @@ jobs:
       jdkArchitectureOption: x64
       jdkSourceOption: LocalDirectory
       jdkFile: "$(Build.ArtifactStagingDirectory)/java11.tar.gz"
-      jdkDestinationDirectory: ""
+      jdkDestinationDirectory: "$(Build.ArtifactStagingDirectory)/jdk"
   - task: Bash@3
     inputs:
       targetType: 'inline'

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -11,7 +11,6 @@ variables:
 
 
 - job: buildAndPublishSpecification
-  dependsOn: setupEnvironment
   steps:
   # Download Java, install, and set JAVA_HOME env variables
   - task: Bash@3

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -9,7 +9,7 @@ variables:
 - group: ZULIP_VAR_GROUP
 - group: SSH_UPLOAD
 
-
+jobs:
 - job: buildAndPublishSpecification
   steps:
   # Download Java, install, and set JAVA_HOME env variables

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -9,9 +9,11 @@ variables:
 - group: ZULIP_VAR_GROUP
 - group: SSH_UPLOAD
 
-jobs:
-- job: setupEnvironment
+
+- job: buildAndPublishSpecification
+  dependsOn: setupEnvironment
   steps:
+  # Download Java, install, and set JAVA_HOME env variables
   - task: Bash@3
     displayName: 'Download java sdk'
     inputs:
@@ -33,9 +35,6 @@ jobs:
         echo which java returns
         which java
 
-- job: buildAndPublishSpecification
-  dependsOn: setupEnvironment
-  steps:
   # Trigger a publish to test if all changes produce a valid, publishable java implementation of the specification
   - task: Gradle@2
     inputs:


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

This moves the JVM installation into the buildAndPublishSpecification job.

Previously, the JVM was being installed into the artifacts directory in a separate setupEnvironment job, which means any env variables created would be lost by the time buildAndPublishSpecification occurred. This resulted in buildAndPublishSpecification always using the Java 8 within the agent itself instead of the JVM installed in the setupEnvironment job.

This PR fixes this problem, and also reduces build time by requiring only one pull of the agent workspace (it was previously doing this twice, once in setupEnvironment and once in buildAndPublishSpecification). 

## IMPORTANT

In PR form, this appears to be stalling at one of the established checks: 

```
Pull Request Pipeline (buildAndPublishSpecification) Expected — Waiting for status to be reported
```

I believe this is due to the checks still expecting statuses from all jobs previously configured (see this thread: https://github.com/orgs/community/discussions/26698#discussioncomment-3252954). I believe this will either pass when we merge to master, OR we will have to drop checks and re-instate them for the checks to be updated.
