### PR TITLE
Added UTF8 encoding to the gradle build JVM arguments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ kindlingVersion=1.0.17-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx12800M
+org.gradle.jvmargs=-Xmx12800M -Dfile.encoding=UTF8
 org.gradle.configureondemand=true


### PR DESCRIPTION
Without this on Windows platforms XML files are not correctly loaded and the build errors. Not sure what changed to cause this to start happening, but adding this property to the build fixes the issue.