### PR TITLE
J# 37641, J# 31652, J# 38050 ResearchStudy resource changes

### DIFF
--- a/source/researchstudy/bundle-ResearchStudy-search-params.xml
+++ b/source/researchstudy/bundle-ResearchStudy-search-params.xml
@@ -107,19 +107,19 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="ResearchStudy-location"/>
+        <id value="ResearchStudy-region"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ResearchStudy.location"/>
+          <valueString value="ResearchStudy.region"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ResearchStudy-location"/>
-        <description value="Geographic region(s) for study"/>
-        <code value="location"/>
+        <description value="Geographic area for the study"/>
+        <code value="region"/>
         <type value="token"/>
-        <expression value="ResearchStudy.location"/>
-        <xpath value="f:ResearchStudy/f:location"/>
+        <expression value="ResearchStudy.region"/>
+        <xpath value="f:ResearchStudy/f:region"/>
         <xpathUsage value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/researchstudy/codesystem-research-study-classifiers.xml
+++ b/source/researchstudy/codesystem-research-study-classifiers.xml
@@ -169,6 +169,22 @@
 			<code value="fda"/>
 			<display value="FDA"/>
 		</concept>
+		<concept>
+			<code value="government"/>
+			<display value="Government"/>
+		</concept>
+		<concept>
+			<code value="nonprofit"/>
+			<display value="Nonprofit"/>
+		</concept>
+		<concept>
+			<code value="academic"/>
+			<display value="Academic"/>
+		</concept>
+		<concept>
+			<code value="industry"/>
+			<display value="Industry"/>
+		</concept>
 	</concept>
 	<concept>
 		<code value="research-study-party-role"/>

--- a/source/researchstudy/codesystem-research-study-classifiers.xml
+++ b/source/researchstudy/codesystem-research-study-classifiers.xml
@@ -131,31 +131,51 @@
 		</concept>
 	</concept>
 	<concept>
+		<code value="research-study-focus-type"/>
+		<display value="Research Study Focus Type"/>
+		<concept>
+			<code value="medication"/>
+			<display value="Medication"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="device"/>
+			<display value="Device"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="intervention"/>
+			<display value="Intervention"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="factor"/>
+			<display value="Factor"/>
+			<definition value=""/>
+		</concept>
+	</concept>
+	<concept>
 		<code value="research-study-classifier"/>
 		<display value="Research Study Classifier"/>
 		<concept>
-			<code value="research-study-focus-type"/>
-			<display value="Research Study Focus Type"/>
-			<concept>
-				<code value="medication"/>
-				<display value="Medication"/>
-				<definition value=""/>
-			</concept>
-			<concept>
-				<code value="device"/>
-				<display value="Device"/>
-				<definition value=""/>
-			</concept>
-			<concept>
-				<code value="intervention"/>
-				<display value="Intervention"/>
-				<definition value=""/>
-			</concept>
-			<concept>
-				<code value="factor"/>
-				<display value="Factor"/>
-				<definition value=""/>
-			</concept>
+			<code value="fda-regulated-drug"/>
+			<display value="FDA regulated drug"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="fda-regulated-device"/>
+			<display value="FDA regulated device"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="mpg-paragraph-23b"/>
+			<display value="MPG Paragraph 23b (German legal requirement)"/>
+			<definition value=""/>
+		</concept>
+		<concept>
+			<code value="irb-exempt"/>
+			<display value="IRB-exempt"/>
+			<definition value=""/>
 		</concept>
 	</concept>
 	<concept>

--- a/source/researchstudy/codesystem-research-study-classifiers.xml
+++ b/source/researchstudy/codesystem-research-study-classifiers.xml
@@ -160,22 +160,22 @@
 		<concept>
 			<code value="fda-regulated-drug"/>
 			<display value="FDA regulated drug"/>
-			<definition value=""/>
+			<definition value="A medication regulated by the U.S. Food and Drug Administration."/>
 		</concept>
 		<concept>
 			<code value="fda-regulated-device"/>
 			<display value="FDA regulated device"/>
-			<definition value=""/>
+			<definition value="A medical device regulated by the U.S. Food and Drug Administration."/>
 		</concept>
 		<concept>
 			<code value="mpg-paragraph-23b"/>
-			<display value="MPG Paragraph 23b (German legal requirement)"/>
-			<definition value=""/>
+			<display value="MPG Paragraph 23b"/>
+			<definition value="Research regulated by a specific German legal requirement (Medizinproduktegesetz MPG Paragraph 23b)."/>
 		</concept>
 		<concept>
 			<code value="irb-exempt"/>
 			<display value="IRB-exempt"/>
-			<definition value=""/>
+			<definition value="Human subjects research that is excempt from oversight and monitoring by an institutional review board (IRB)."/>
 		</concept>
 	</concept>
 	<concept>

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -541,10 +541,10 @@
         <map value="DocumentVersion.keywordCode; DocumentVersion.keywordText"/>
       </mapping>
     </element>
-    <element id="ResearchStudy.location">
-      <path value="ResearchStudy.location"/>
-      <short value="Geographic region(s) for study"/>
-      <definition value="Indicates a country, state or other region where the study is taking place."/>
+    <element id="ResearchStudy.region">
+      <path value="ResearchStudy.region"/>
+      <short value="Geographic area for the study"/>
+      <definition value="A country, state or other area where the study is taking place rather than its precise geographic location or address."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -743,8 +743,8 @@
     </element>
     <element id="ResearchStudy.associatedParty.classifier">
       <path value="ResearchStudy.associatedParty.classifier"/>
-      <short value="nih | fda"/>
-      <definition value="Organisational type of association."/>
+      <short value="nih | fda | government | nonprofit | academic | industry"/>
+      <definition value="A categorization other than role for the associated party."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -670,7 +670,7 @@
     <element id="ResearchStudy.classifier">
       <path value="ResearchStudy.classifier"/>
       <short value="Classification for the study"/>
-      <definition value="Additional grouping mechanism or categorization of a research study. Example: type of blinding, type of randomization, etc. Implementation Note: do not use the classifier element to support existing semantics that are already supported thru explicit elements in the resource."/>
+      <definition value="Additional grouping mechanism or categorization of a research study. Example: FDA regulated device, FDA regulated drug, MPG Paragraph 23b (a German legal requirement), IRB-exempt, etc. Implementation Note: do not use the classifier element to support existing semantics that are already supported thru explicit elements in the resource."/>
       <min value="0"/>
       <max value="*"/>
       <type>


### PR DESCRIPTION

A. Change element name from ResearchStudy.location to region, and definition change.

B. Change definition for ResearchStudy.associatedParty.classifier and added codes.

C. 
1. Remove the type of blinding and type of randomization examples from definition
2. Add FDA regulated device, FDA regulated drug, MPG Paragraph 23b (German legal requirement), IRB-exempt, as examples
3. Delete the values from ResearchStudy Classifiers Code system ( https://build.fhir.org/valueset-research-study-classifiers.html) and ADD the four values from [#2](https://github.com/HL7/fhir/issues/2) above
4. Added definitions for those four new codes.