### PR TITLE
Applying FHIR-31735: split tools out from spec

### DIFF
--- a/source/downloads.html
+++ b/source/downloads.html
@@ -77,6 +77,10 @@
     </td>
   </tr>
   <tr>
+    <td colspan="2"><hr/></td>
+  </tr>
+
+  <tr>
     <td>GraphQL</td>
     <td>
       <ul>
@@ -98,13 +102,9 @@
   </tr>
 
   <tr>
-    <td>Validator</td>
-    <td>The <a href="https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar">official FHIR validator</a> - a Java jar file that can be used to validate resources. See <a href="validation.html">Validation Tools</a> for further information, or <a href="https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator">Using the FHIR Validator</a> for parameter documentation</td>
-  </tr>
-
-  <tr>
-    <td>IG Publisher</td>
-    <td>The <a href="https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar">Implementation Guide Publishing Tool</a> (see <a href="https://confluence.hl7.org/display/FHIR/IG+Publisher+Documentation">IG Publishing documentation</a>)</td>
+    <td colspan="2">
+      In addition to the resources listed below, the HL7 Confluence contains an overview of <a href="https://confluence.hl7.org/display/FHIR/FHIR+Tools+Registry">commonly used tools to help with implementing FHIR</a>.
+    </td>
   </tr>
 
   <tr>

--- a/source/implsupport-module.html
+++ b/source/implsupport-module.html
@@ -88,54 +88,26 @@ For more general considerations, see <a href="secpriv-module.html">the Security 
 
 <h4>For Client Developers and Testers: Reference Servers</h4>
 <p>
-	The following reference servers have been created by the FHIR team and
+	The HL7 Confluence has a <a href="https://confluence.hl7.org/display/FHIR/Public+Test+Servers">
+	list of public test servers</a> that have been created by the FHIR community and
 	made available to help implementers test their code. While the reference
 	servers are not considered to be a normative part of the FHIR specification,
 	the maintainers make every effort to ensure that they are fully compliant.
 </p>
-<p>
-	Note that there are a large number of servers available for testing that
-	are not listed here. A full list is available on the HL7 Confluence system
-	<a href="https://confluence.hl7.org/display/FHIR/Public+Test+Servers">here</a>.
-</p>
-<table class="grid">
-	<thead>
-		<tr><th>Server Name</th><th>Maintainer</th><th>Link</th></tr>
-	</thead>
-	<tbody>
-		<tr><td>Healthintersections</td><td>Grahame Grieve</td><td><a href="http://fhir3.healthintersections.com.au/">http://fhir3.healthintersections.com.au/</a></td></tr>
-		<tr><td>Firely Server</td><td>Firely</td><td><a href="https://server.fire.ly/">https://server.fire.ly/</a></td></tr>
-		<tr><td>HAPI</td><td>University Health Network / James Agnew</td><td><a href="http://fhirtest.uhn.ca/">http://fhirtest.uhn.ca/</a></td></tr>
-		<tr><td>sqlonfhir</td><td>Telstra Health / Brian Postlethwaite</td><td><a href="http://sqlonfhir-stu3.azurewebsites.net/fhir">http://sqlonfhir-stu3.azurewebsites.net/fhir</a></td></tr>
-	</tbody>
-</table>
 
 <h4>For Developers: Reference Implementations (Libraries)</h4>
 <p>
-	The following reference implementations are made available under an open-source
-	license. These libraries may be used by developers to quickly add FHIR capabilities
-	to their applications.
+	The HL7 Confluence has a <a href="https://confluence.hl7.org/display/FHIR/Open+Source+Implementations">
+	list of open source FHIR implementations</a>. These libraries may be used
+	by developers to quickly add FHIR capabilities to their applications.
 </p>
-<table class="grid">
-	<thead>
-		<tr><th>Language</th><th>Library</th><th>Link</th><th>License</th></tr>
-	</thead>
-	<tbody>
-		<tr><td>.NET / C#</td><td>Firely .NET SDK</td><td><a href="https://github.com/FirelyTeam/firely-net-sdk">https://github.com/FirelyTeam/firely-net-sdk</a></td><td>BSD-3</td></tr>
-		<tr><td>Java</td><td>HAPI FHIR</td><td><a href="http://hapifhir.io">http://hapifhir.io</a></td><td>Apache 2.0</td></tr>
-		<tr><td>Swift</td><td>Swift FHIR</td><td><a href="https://github.com/smart-on-fhir/Swift-FHIR">https://github.com/smart-on-fhir/Swift-FHIR</a></td><td>Apache 2.0</td></tr>
-		<tr><td>JavaScript</td><td>fhir.js</td><td><a href="https://github.com/smart-on-fhir/fhir.js">https://github.com/smart-on-fhir/fhir.js</a></td><td>MIT</td></tr>
-		<tr><td>Python</td><td>Client Py</td><td><a href="https://github.com/smart-on-fhir/client-py">https://github.com/smart-on-fhir/client-py</a></td><td>Apache 2.0</td></tr>
-		<tr><td>Pascal</td><td>FHIR Pascal</td><td><a href="http://hl7.org/fhir/downloads.html">http://hl7.org/fhir/downloads.html</a></td><td>BSD-3</td></tr>
-	</tbody>
-</table>
 
 <a name="for_profilers"></a>
 <h4>For Profilers</h4>
 <p>
 	A number of tools are available to profilers wishing to create
 	profiles for use in their implementations. A current list of tools can be found
-	<a href="https://confluence.hl7.org/pages/viewpage.action?pageId=35718864#ProfileTooling-Editing&amp;AuthoringProfiles">here</a>
+	<a href="https://confluence.hl7.org/display/FHIR/Profile+Tooling">here</a>
 	on HL7 Confluence.  (See the
 	<a href="./conformance-module.html">conformance module</a> for
 	information on profiling.)

--- a/source/validation.html
+++ b/source/validation.html
@@ -117,7 +117,7 @@ described in this specification, and which of the aspects above they can validat
   <td></td> <!-- Business Rules -->
  </tr>
  <tr>
-  <td><a href="#jar">Validator</a></td>
+  <td><a href="#validators">Validator</a></td>
   <td><img src="assets/images/tick.png"/></td> <!-- XML -->
   <td><img src="assets/images/tick.png"/></td> <!-- JSON -->
   <td><img src="assets/images/tick.png"/></td> <!-- RDF -->
@@ -152,8 +152,8 @@ Notes:
  <li>Schematron generated for a profile can test cardinality and invariants, but not bindings, and slicing is not really supported well</li>
  <li>JSON schema generated for a profile can test cardinality, and slicing is partially supported</li>
  <li>ShEx can enforce some bindings for well understood terminologies, but this is an ongoing area of development</li>
- <li>It is at the discretion of the server how much validation to perform, but most servers use the validation jar, 
-   or code derived from it, and offer the same services. Some servers also offer <a href="#web">a web interface</a></li>
+ <li>It is at the discretion of the server how much validation to perform, but most servers offer the same services as or even use the common validators.
+   Some servers also offer <a href="#web">a web interface</a></li>
 </ol>
 
 <p>
@@ -169,8 +169,8 @@ In case of disagreement between these conformance methods, note that:
 </p>
 <ul>
  <li>The schema/schematron is the least capable - mainly because it is not connected to a terminology server</li>
- <li>The java validator is only as good as the underlying definitions, and depends on whether the underlying terminology server supports all the relevant terminologies</li>
- <li>In general, the server validation operations use or derive from the java validation code, so have the same caveats</li>
+ <li>The validators are only as good as the underlying definitions, and depend on whether the underlying terminology servers support all the relevant terminologies</li>
+ <li>In general, the server validation operations use or derive from the validation code in the common validators, so have the same caveats</li>
  <li>The final arbiter is human inspection of the content of the resources, and the relevant implementation guides and base specification</li>
 </ul>
 
@@ -250,61 +250,11 @@ Links:
 </ul>
 
 
-<a name="jar"></a>
-<h3>Using the FHIR Validator</h3>
+<a name="validators"></a>
+<h3>Using FHIR validators</h3>
 
 <p>
-The FHIR Validator is a Java jar that is provided as part of the specification, and that is used 
-during the publication process to validate all the published examples. To 
-execute the FHIR validator, follow the following steps:
-</p>
-<ul>
- <li><a href="downloads.html">Download</a> the FHIR Validator</li>
- <li>Execute the validator, specifying the version, and a reference to the resource to validate</li>
-</ul>
-<p>
-Here is an example windows batch file that demonstrates the process (using the common utilities <a href="http://gnuwin32.sourceforge.net/packages/wget.htm">wget</a> and <a href="http://www.7-zip.org/">7z</a>):
-</p>
-<pre>
-@ECHO OFF
-
- ECHO get the validator and unzip it 
- wget https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&amp;g=ca.uhn.hapi.fhir&amp;a=org.hl7.fhir.validation.cli&amp;v=LATEST&amp;e=jar
- rename *.jar validator.jar
-
- ECHO 1. First example shows how to validate against the base spec:
- ECHO   a. get an example to validate
- wget <%baseURLn%>patient-example.xml -O pat-ex.xml
-
- ECHO   b. validate it against FHIR R3 
- java -jar org.hl7.fhir.validator.jar pat-ex.xml -version 3.0
-
- ECHO 2. Second example shows how to validate against a profile in the spec:
- ECHO   a. get an example to validate
- wget <%baseURLn%>observation-example-heart-rate.xml -O obs-ex.xml
-
- ECHO   b. validate it
- java -jar org.hl7.fhir.validator.jar obs-ex.xml -version <%version%> -profile http://hl7.org/fhir/StructureDefinition/heartrate
-
- ECHO 3. Third example shows how to validate against a profile in an implementation guide:
- ECHO   a. get an example to validate
- wget <%baseURLn%>observation-example-heart-rate.xml -O obs-ex.xml
-
- ECHO   b. validate it. note that you have to tell the validator where to get the implementation guide information
- java -jar org.hl7.fhir.validator.jar obs-ex.xml -version 3.0 -ig http://hl7.org/fhir/us/core -profile http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient
-
- ECHO Press Any Key to Close
- pause
-</pre>
-<p>
-Note that it is not necessary to download the resource first; the http address can be supplied directly:
-</p>
-<pre>
- java -jar org.hl7.fhir.validator.jar <%baseURLn%>/patient-example.html -profile http://hl7.org/fhir/StructureDefinition/Patient
-</pre>
-<p>
-The validator requires an underlying terminology server. By default, this is http://fhir3.healthintersections.com.au. 
-For further details of the parameters supported by the validator, see <a href="https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator">Using the FHIR Validator</a>
+  See the HL7 Confluence for an overview of <a href="https://confluence.hl7.org/display/FHIR/FHIR+Tools+Registry">commonly used tools to help with implementing FHIR, including FHIR validators</a>.
 </p>
 
 <a name="op"></a>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: https://jira.hl7.org/browse/FHIR-31735

## Description

* Splitting out specific tool listings from Downloads and Validation page
* Creating corresponding Confluence pages where needed
* Listing on Confluence pages which spec pages refer to them, to prevent people breaking links by updating titles/deleting page