### PR TITLE
FHIR-16526: Updating links to IG registries and nav

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -57,8 +57,8 @@ undergone ANSI approval processes.</b>
  <p><b>Implementation Guides</b></p>
  <p>Specifications based on the FHIR standard</p>
   <ul>
-    <li><a href="http://www.fhir.org/guides/registry">Published by HL7, Affiliates &amp; FHIR Foundation</a></li>
-    <li><a href="https://confluence.hl7.org/display/FHIR/IGs+from+other+Organizations">Other IGs (FHIR Confluence)</a></li>
+    <li><a href="http://www.fhir.org/guides/registry">Curated list of Implementation Guides</a></li>
+    <li><a href="https://registry.fhir.org/">All publicly available FHIR specifications</a></li>
  </ul>
  </td><td>
   <p><b><a href="http://fhir.org">FHIR Foundation</a></b></p>

--- a/tools/templates/newnavbar.html
+++ b/tools/templates/newnavbar.html
@@ -45,10 +45,11 @@
                   <li><a href="<%level%>./patterns.html">Patterns</a></li>
                   <li><a href="<%level%>./profilelist.html">Profiles</a></li>
                   <li><a href="<%level%>./searchparameter-registry.html">Search Parameters</a></li>
-                  <li><a href="http://registry.fhir.org">Artifact Registry</a></li>
+				  <li class="divider"></li>
+                  <li><a href="http://registry.fhir.org" target="_blank">Artifact Registry</a></li>
                 </ul>    
               </li>
-              <li><a href="http://fhir.org/guides/registry">Implementation Guides</a></li>
+              <li><a href="http://fhir.org/guides/registry" target="_blank">Implementation Guides</a></li>
 						</ul>
 					</div><!-- /.nav-collapse -->
 				</div><!-- /.container -->


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: https://jira.hl7.org/browse/FHIR-16526

## Description

* Homepage links used to point to Confluence for non-HL7 IGs. This page has been deprecated and migrated, so updated the links to IG registry and Package registry instead.
* Updated nav to include divider and open registries in new tab
