### PR TITLE
Add commit message and user name to zulip notifications

### DIFF
--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -90,11 +90,11 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"'content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
+            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
-            '"
+            "
   - task: Bash@3
     condition: failed()
     inputs:
@@ -106,7 +106,7 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"'content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
+            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
-            '"
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
+            "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -84,12 +84,13 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        COMMIT_INFO=$(git log -1 --pretty='format:%B (%an)')
         curl -X POST https://chat.fhir.org/api/v1/messages \
             -u $(ZULIP_BOT_EMAIL):$(ZULIP_BOT_API_KEY) \
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:! \n$COMMIT_INFO \n[build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -97,10 +98,11 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        COMMIT_INFO=$(git log -1 --pretty='format:%B (%an)')
         curl -X POST https://chat.fhir.org/api/v1/messages \
             -u $(ZULIP_BOT_EMAIL):$(ZULIP_BOT_API_KEY) \
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:! \n$COMMIT_INFO \n[build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -92,7 +92,7 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -108,5 +108,5 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -92,8 +92,7 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
-            Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)) | [published webpage](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
     condition: failed()

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -92,7 +92,7 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -108,5 +108,5 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -92,7 +92,7 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -108,5 +108,5 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -90,11 +90,11 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
+            -d $"'content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
-            "
+            '"
   - task: Bash@3
     condition: failed()
     inputs:
@@ -106,7 +106,7 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
+            -d $"'content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
-            "
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            '"

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -92,7 +92,7 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -108,5 +108,5 @@ jobs:
             -d "subject=FHIR Build Status" \
             -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
             $COMMIT_INFO
-            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)'&'view=results)
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId))
             "

--- a/pull-request-pipeline.yml
+++ b/pull-request-pipeline.yml
@@ -84,13 +84,15 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        COMMIT_INFO=$(git log -1 --pretty='format:%B (%an)')
+        COMMIT_INFO=$(git log -n 1 --skip 1 --pretty='format:%B (%an)')
         curl -X POST https://chat.fhir.org/api/v1/messages \
             -u $(ZULIP_BOT_EMAIL):$(ZULIP_BOT_API_KEY) \
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:! \n$COMMIT_INFO \n[build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            -d $"content=PR Build success for branch $(CI_BRANCH_DIRECTORY) :thumbs_up:!
+            $COMMIT_INFO
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             Published webpage can be viewed [here](https://build.fhir.org/branches/$(CI_BRANCH_DIRECTORY))
             "
   - task: Bash@3
@@ -98,11 +100,13 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        COMMIT_INFO=$(git log -1 --pretty='format:%B (%an)')
+        COMMIT_INFO=$(git log -n 1 --skip 1 --pretty='format:%B (%an)')
         curl -X POST https://chat.fhir.org/api/v1/messages \
             -u $(ZULIP_BOT_EMAIL):$(ZULIP_BOT_API_KEY) \
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:! \n$COMMIT_INFO \n[build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
+            -d $"content=Build failed for branch $(CI_BRANCH_DIRECTORY) :thumbs_down:!
+            $COMMIT_INFO
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results)
             "


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

This adds text to the Zulip notification message containing the last commit summary and the username, so that Zulip users can be watch threads for notifications when their PRs complete:

https://chat.fhir.org/#narrow/stream/179297-committers.2Fnotification/topic/FHIR.20Build.20Status/near/297495656 
