### PR TITLE
MessageHeader.response.identifier is the received Bundle.identifier

### DIFF
--- a/source/messageheader/structuredefinition-MessageHeader.xml
+++ b/source/messageheader/structuredefinition-MessageHeader.xml
@@ -558,8 +558,8 @@
     </element>
     <element id="MessageHeader.response.identifier">
       <path value="MessageHeader.response.identifier"/>
-      <short value="Id of original message"/>
-      <definition value="The MessageHeader.id of the message to which this message is a response."/>
+      <short value="Bundle.identifier of original message"/>
+      <definition value="The Bundle.identifier of the message to which this message is a response."/>
       <requirements value="Allows receiver to know what message is being responded to."/>
       <min value="1"/>
       <max value="1"/>


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-29690

Change the description and short of MessageHeader.response.identifier to say it is the Bundle.identifier of the original message. 
