### PR TITLE
Fix TODO warnings to show up in Disclaimers section

### DIFF
--- a/source/license.html
+++ b/source/license.html
@@ -16,27 +16,27 @@
 <a name="disclaimer"></a>
 <h3>Disclaimer and Warning of Use</h3>
 <p>
-FHIR Resource definitions developed by HL7 are derived from the considerable collective 
-experience of the HL7 membership and wide community feedback from the development and 
-application of a spectrum of health care interoperability solutions.  However, Resource 
-definitions are generalized to support multiple contexts of use. It is the responsibility 
-of the persons or organizations using these Resources to ensure their use is fit for the 
+FHIR Resource definitions developed by HL7 are derived from the considerable collective
+experience of the HL7 membership and wide community feedback from the development and
+application of a spectrum of health care interoperability solutions.  However, Resource
+definitions are generalized to support multiple contexts of use. It is the responsibility
+of the persons or organizations using these Resources to ensure their use is fit for the
 particular purpose in which they are used, including validation for clinical and operational use.
-</p>
-
-<a name="promotinginterop"></a>
-<h3>Promoting Interoperability</h3>
-<p>
-HL7's mission since 1987 has been improving health care interoperability, and HL7 FHIR is the 
-latest in a long line of interoperability standards. We dedicate the FHIR specification to the 
-public domain using CC0 1.0 in order to encourage adoption of FHIR as a foundation for better 
-healthcare around the world; to increase patient empowerment; and to promote the availability 
-of interoperable health data for everyone who needs it.
 </p>
 
 <a name="ballotstatus"></a>
 <p>
 See also the specific warnings associated with <a href="todo.html">use of the STU</a>.
+</p>
+
+<a name="promotinginterop"></a>
+<h3>Promoting Interoperability</h3>
+<p>
+HL7's mission since 1987 has been improving health care interoperability, and HL7 FHIR is the
+latest in a long line of interoperability standards. We dedicate the FHIR specification to the
+public domain using CC0 1.0 in order to encourage adoption of FHIR as a foundation for better
+healthcare around the world; to increase patient empowerment; and to promote the availability
+of interoperable health data for everyone who needs it.
 </p>
 
 <a name="license"></a>
@@ -47,8 +47,8 @@ Copyright &copy; 2011+ HL7.
 </p>
 
 <p>
-This specification (specifically the set of materials included in the fhir-spec.zip file available from the 
-<a href="downloads.html">downloads page</a> of this specification) is produced by HL7 under the terms of HL7® 
+This specification (specifically the set of materials included in the fhir-spec.zip file available from the
+<a href="downloads.html">downloads page</a> of this specification) is produced by HL7 under the terms of HL7®
 <a href="http://www.hl7.org/documentcenter/public_temp_4108B35F-1C23-BA17-0C38BD44A97683FB/membership/HL7_Governance_and_Operations_Manual.pdf">Governance and Operations Manual</a>
 relating to Intellectual Property (Section 09, at the time this specification was published), specifically its copyright, trademark and patent provisions.
 </p>
@@ -82,19 +82,19 @@ trademark carefully. This means that:
  <li>When using the <a href="icon-pack.zip"><img  style="float: none; margin: 0px; padding: 0px; vertical-align: bottom" src="icon-fhir-16.png"/> logo</a>, always include the ® symbol</li>
  <li>All non-trademark uses of the foregoing marks should include the ® symbol and indicate in text that:<br/>
     "HL7, FHIR and the FHIR [FLAME DESIGN] are the registered trademarks of Health Level Seven International and their use does not constitute endorsement by HL7."</li>
- <li>Use of Health Level Seven International trademarks in URL domains or to brand your product or service without the express written consent of Health Level Seven International is strictly prohibited. 
+ <li>Use of Health Level Seven International trademarks in URL domains or to brand your product or service without the express written consent of Health Level Seven International is strictly prohibited.
    See application forms for consent to use the trademark "FHIR" in an <a href="http://www.fhir.org/community-license">event name</a> or a <a href="http://www.fhir.org/product-license">product name</a> (including domain names)</li>
 </ul>
 
 <p>
 Trademark FAQs are posted on the <a href="http://www.hl7.org/legal/trademarks.cfm">HL7 International website</a>. Questions? Please contact <a href="mailto:HL7trademarks@HL7.org">HL7trademarks@HL7.org</a> for more information.
-</p> 
+</p>
 
 <h3>Third-party artifacts and terminologies</h3>
 <p>
-The HL7 FHIR specification contains and references intellectual property owned by third parties ("Third Party IP"). 
-Acceptance of these License Terms does not grant any rights with respect to Third Party IP. 
-The licensee alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize 
+The HL7 FHIR specification contains and references intellectual property owned by third parties ("Third Party IP").
+Acceptance of these License Terms does not grant any rights with respect to Third Party IP.
+The licensee alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize
 Third Party IP in connection with the specification or otherwise.
 </p>
 <p>
@@ -106,15 +106,15 @@ Following is a non-exhaustive list of third-party artifacts and terminologies th
  <tr><td><b>Artifact/Terminology</b></td><td><b>Statement/Owner/Contact</b></td></tr>
  <tr><td>SNOMED CT</td><td>International Healthcare Terminology Standards Developing Organization (<a href="http://snomed.org">IHTSDO</a>).<br/>This specification includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO) and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement</td></tr>
  <tr><td>DICOM</td><td>National Electrical Manufacturers Association (<a href="http://dicom.nema.org/">NEMA</a>).<br/>This specification includes content from DICOM, which is copyright NEMA, and distributed by agreement between NEMA/DICOM and HL7. Implementer use of DICOM is not covered by this agreement</td></tr>
- <tr><td>Logical Observation Identifiers Names &amp; Codes (LOINC)</td><td>This material contains content from LOINC (<a href="http://loinc.org">http://loinc.org</a>). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. 
-   and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license 
+ <tr><td>Logical Observation Identifiers Names &amp; Codes (LOINC)</td><td>This material contains content from LOINC (<a href="http://loinc.org">http://loinc.org</a>). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc.
+   and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license
    at <a href="http://loinc.org/license">http://loinc.org/license</a>. LOINC® is a registered United States trademark of Regenstrief Institute, Inc.</td></tr>
  <tr><td>International Classification of Diseases (ICD) codes</td><td>Consult the World Health Organization (<a href="http://who.int">WHO</a>)</td></tr>
  <tr><td>Current Procedures Terminology (CPT) code set</td><td>American Medical Association (<a href="http://www.ama-assn.org/">AMA</a>)<br/>CPT copyright 2014 American Medical Association. All rights reserved.</td></tr>
 </table>
 
 [%file newfooter%]
-    
-    
+
+
 </body>
 </html>


### PR DESCRIPTION
Something I missed out in https://github.com/HL7/fhir/pull/2417 - the TODO warnings [got separated](http://build.fhir.org/license.html) from the Disclaimer section. This puts it back.

![image](https://user-images.githubusercontent.com/110988/191828507-5ad717fd-8eb4-4cd3-9696-a15df8dd84f2.png)

@jmandel @michaeldonnelly 
