### PR TITLE
ResearchStudy resource changes J# 39250 J# 39192 J# 39187 J# 38656

### DIFF
--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -274,8 +274,8 @@
     </element>
     <element id="ResearchStudy.relatedArtifact">
       <path value="ResearchStudy.relatedArtifact"/>
-      <short value="References and dependencies"/>
-      <definition value="Citations, references and other related documents."/>
+      <short value="References, URLs, and attachments"/>
+      <definition value="Citations, references, URLs and other related documents.  When using relatedArtifact to share URLs, the relatedArtifact.type will often be set to one of &quot;documentation&quot; or &quot;supported-with&quot; and the URL value will often be in relatedArtifact.document.url but another possible location is relatedArtifact.resource when it is a canonical URL."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -426,7 +426,7 @@
     <element id="ResearchStudy.focus.productCode">
       <path value="ResearchStudy.focus.productCode"/>
       <short value="Identification of product under study"/>
-      <definition value="Identification of product under study.  This may be any combination of code and/or name."/>
+      <definition value="Identification of product under study. This may be any combination of code and/or name."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -954,7 +954,7 @@
       </extension>
       <path value="ResearchStudy.comparisonGroup"/>
       <short value="Defined path through the study for a subject"/>
-      <definition value="Describes an expected sequence of events for one of the participants of a study.  E.g. Exposure to drug A, wash-out, exposure to drug B, wash-out, follow-up."/>
+      <definition value="Describes an expected event or sequence of events for one of the subjects of a study. E.g. for a living subject: exposure to drug A, wash-out, exposure to drug B, wash-out, follow-up. E.g. for a stability study: {store sample from lot A at 25 degrees for 1 month}, {store sample from lot A at 40 degrees for 1 month}."/>
       <comment value="In many clinical trials this is refered to as the ARM of the study, but such a term is not used in other sorts of trials even when there is a comparison between two or more groups."/>
       <alias value="arm"/>
       <min value="0"/>
@@ -971,15 +971,12 @@
         <map value="Arm"/>
       </mapping>
     </element>
-    <element id="ResearchStudy.comparisonGroup.identifier[x]">
-      <path value="ResearchStudy.comparisonGroup.identifier[x]"/>
+    <element id="ResearchStudy.comparisonGroup.identifier">
+      <path value="ResearchStudy.comparisonGroup.identifier"/>
       <short value="Allows the comparisonGroup for the study and the comparisonGroup for the subject to be linked easily"/>
       <definition value="Allows the comparisonGroup for the study and the comparisonGroup for the subject to be linked easily."/>
       <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="uri"/>
-      </type>
+      <max value="*"/>
       <type>
         <code value="Identifier"/>
       </type>
@@ -1138,8 +1135,9 @@
         <valueCode value="840,310"/>
       </extension>
       <path value="ResearchStudy.outcomeMeasure"/>
-      <short value="An outcome or planned variable to measure during the study"/>
-      <definition value="An outcome or planned variable to measure during the study."/>
+      <short value="A variable measured during the study"/>
+      <definition value="An &quot;outcome measure&quot;, &quot;endpoint&quot;, &quot;effect measure&quot; or &quot;measure of effect&quot; is a specific measurement or observation used to quantify the effect of experimental variables on the participants in a study, or for observational studies, to describe patterns of diseases or traits or associations with exposures, risk factors or treatment."/>
+	  <comment value="A study may have multiple distinct outcome measures that can be used to assess the overall goal for a study. The goal of a study is in the objective whereas the metric by which the goal is assessed is the outcomeMeasure. Examples: Time to Local Recurrence (TLR), Disease-free Survival (DFS), 30 Day Mortality, Systolic BP"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -1208,47 +1206,6 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport"/>
       </type>
       <isSummary value="true"/>
-    </element>
-    <element id="ResearchStudy.webLocation">
-      <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
-        <valueCode value="840,410"/>
-      </extension>
-      <path value="ResearchStudy.webLocation"/>
-      <short value="Archive location for the study"/>
-      <definition value="A general storage or archive location for the study.  This may contain an assortment of content which is not specified in advance."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="BackboneElement"/>
-      </type>
-    </element>
-    <element id="ResearchStudy.webLocation.classifier">
-      <path value="ResearchStudy.webLocation.classifier"/>
-      <short value="registry-page|recruitment-page|contact-page"/>
-      <definition value="Describes the nature of the location being specified."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value=" ArtifactUrlClassifier"/>
-        </extension>
-        <strength value="example"/>
-        <description value="defn."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/artifact-url-classifier"/>
-      </binding>
-    </element>
-    <element id="ResearchStudy.webLocation.url">
-      <path value="ResearchStudy.webLocation.url"/>
-      <short value="The location address"/>
-      <definition value="The location address."/>
-      <min value="1"/>
-      <max value="1"/>
-      <type>
-        <code value="uri"/>
-      </type>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Removed ResearchStudy.webLocation element
ResearchStudy.comparisonGroup.identifier[x] is now ResearchStudy.comparisonGroup.identifier with 0..* cardinality ResearchStudy.outcomeMeasure, ResearchStudy.comparisonGroup,  description changes