### PR TITLE
Fix typo in general service API

### DIFF
--- a/source/fhirpath.html
+++ b/source/fhirpath.html
@@ -567,7 +567,7 @@ Parameters:
 <p>
 In order to support interaction with a server in FHIRPath statements, FHIR defines
 a general %server object that FHIRPath implementations should make available.
-Calls to this object are passed through a <a href="terminology-service.html">standard FHIR terminology service</a>.
+Calls to this object are passed through a <a href="http.html">FHIR RESTful framework</a>.
 </p>
 <p>
 Summary:


### PR DESCRIPTION
I'm guessing the section on using http verbs within FHIRpath refers to the RESTful API, not the terminology one.