### PR TITLE
fix quotes in DocumentReference intro

### DIFF
--- a/source/documentreference/structuredefinition-DocumentReference.xml
+++ b/source/documentreference/structuredefinition-DocumentReference.xml
@@ -46,7 +46,7 @@
       <value value="http://www.hl7.org/Special/committees/orders/index.cfm"/>
     </telecom>
   </contact>
-  <description value="A reference to a document of any kind for any purpose. While the term “document” implies a more narrow focus, for this resource this &quot;document&quot; encompasses *any* serialized object with a mime-type, it includes formal patient-centric documents (CDA), clinical notes, scanned paper, non-patient specific documents like policy text, as well as a photo, video, or audio recording acquired or used in healthcare.  The DocumentReference resource provides metadata about the document so that the document can be discovered and managed.  The actual content may be inline base64 encoded data or provided by direct reference."/>
+  <description value="A reference to a document of any kind for any purpose. While the term “document” implies a more narrow focus, for this resource this “document” encompasses *any* serialized object with a mime-type, it includes formal patient-centric documents (CDA), clinical notes, scanned paper, non-patient specific documents like policy text, as well as a photo, video, or audio recording acquired or used in healthcare.  The DocumentReference resource provides metadata about the document so that the document can be discovered and managed.  The actual content may be inline base64 encoded data or provided by direct reference."/>
   <fhirVersion value="5.0.0"/>
   <mapping>
     <identity value="workflow"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request

- no

## Description

quotes coming from DocumentReference structureDocument were xml escaped in one case which didn't render right in the build. Changed to the other quotes that did render rigth.