### PR TITLE
Br cds changes 2023 02 15

### DIFF
--- a/source/activitydefinition/structuredefinition-profile-shareableactivitydefinition.xml
+++ b/source/activitydefinition/structuredefinition-profile-shareableactivitydefinition.xml
@@ -71,17 +71,6 @@
 			</type>
 			<mustSupport value="true"/>
 		</element>
-		<element id="ActivityDefinition.extension:knowledgeCapability">
-			<path value="ActivityDefinition.extension"/>
-			<sliceName value="knowledgeCapability"/>
-			<min value="0"/>
-			<max value="*"/>
-			<type>
-				<code value="Extension"/>
-				<profile value="http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability"/>
-			</type>
-			<mustSupport value="true"/>
-		</element>
 		<element id="ActivityDefinition.extension:knowledgeRepresentationLevel">
 			<path value="ActivityDefinition.extension"/>
 			<sliceName value="knowledgeRepresentationLevel"/>

--- a/source/activitydefinition/structuredefinition-profile-shareableactivitydefinition.xml
+++ b/source/activitydefinition/structuredefinition-profile-shareableactivitydefinition.xml
@@ -71,6 +71,17 @@
 			</type>
 			<mustSupport value="true"/>
 		</element>
+		<element id="ActivityDefinition.extension:knowledgeCapability">
+			<path value="ActivityDefinition.extension"/>
+			<sliceName value="knowledgeCapability"/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability"/>
+			</type>
+			<mustSupport value="true"/>
+		</element>
 		<element id="ActivityDefinition.extension:knowledgeRepresentationLevel">
 			<path value="ActivityDefinition.extension"/>
 			<sliceName value="knowledgeRepresentationLevel"/>

--- a/source/detectedissue/structuredefinition-DetectedIssue.xml
+++ b/source/detectedissue/structuredefinition-DetectedIssue.xml
@@ -500,7 +500,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <mapping>
         <identity value="workflow"/>

--- a/source/eventdefinition/structuredefinition-EventDefinition.xml
+++ b/source/eventdefinition/structuredefinition-EventDefinition.xml
@@ -487,7 +487,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
     </element>
     <element id="EventDefinition.copyright">

--- a/source/plandefinition/structuredefinition-PlanDefinition.xml
+++ b/source/plandefinition/structuredefinition-PlanDefinition.xml
@@ -1357,7 +1357,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <mapping>
         <identity value="workflow"/>
@@ -1378,7 +1378,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <mapping>
         <identity value="workflow"/>

--- a/source/plandefinition/structuredefinition-PlanDefinition.xml
+++ b/source/plandefinition/structuredefinition-PlanDefinition.xml
@@ -628,7 +628,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <mapping>
         <identity value="rim"/>

--- a/source/plandefinition/structuredefinition-profile-shareableplandefinition.xml
+++ b/source/plandefinition/structuredefinition-profile-shareableplandefinition.xml
@@ -60,6 +60,39 @@
       <min value="1"/>
       <max value="1"/>
     </element>
+		<element id="PlanDefinition.extension:knowledgeCapability">
+			<path value="PlanDefinition.extension"/>
+			<sliceName value="knowledgeCapability"/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="http://hl7.org/fhir/StructureDefinition/cqf-knowledgeCapability"/>
+			</type>
+			<mustSupport value="true"/>
+		</element>
+		<element id="PlanDefinition.extension:knowledgeRepresentationLevel">
+			<path value="PlanDefinition.extension"/>
+			<sliceName value="knowledgeRepresentationLevel"/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="http://hl7.org/fhir/StructureDefinition/cqf-knowledgeRepresentationLevel"/>
+			</type>
+			<mustSupport value="true"/>
+		</element>
+		<element id="PlanDefinition.extension:artifactComment">
+			<path value="PlanDefinition.extension"/>
+			<sliceName value="artifactComment"/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="http://hl7.org/fhir/StructureDefinition/cqf-artifactComment"/>
+			</type>
+			<mustSupport value="true"/>
+		</element>
     <element id="PlanDefinition.url">
       <path value="PlanDefinition.url"/>
       <min value="1"/>

--- a/source/requestorchestration/structuredefinition-RequestOrchestration.xml
+++ b/source/requestorchestration/structuredefinition-RequestOrchestration.xml
@@ -521,7 +521,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <isSummary value="true"/>
     </element>
@@ -532,7 +532,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="markdown"/>
       </type>
       <isSummary value="true"/>
     </element>


### PR DESCRIPTION
J#39588: Updated action.description and textEquivalent to markdown
J#39587: Updated PlanDefinition.action.description and textEquivalent to markdown
J#39571: Updated EventDefinition.usage and PlanDefinition.usage to markdown
J#39568: Updated DetectedIssue.detail to markdown
J#32638: Added knowledge extensions to ShareablePlanDefinition
J#32637: Added knowledge extensions to ShareableActivityDefinition