### PR TITLE
Jira 40580: Correct misspelled reference: HealthCareService-->HealthcareService

### DIFF
--- a/source/healthcareservice/structuredefinition-HealthcareService.xml
+++ b/source/healthcareservice/structuredefinition-HealthcareService.xml
@@ -519,7 +519,7 @@
           <valueString value="ReferralMethod"/>
         </extension>
         <strength value="example"/>
-        <description value="The methods of referral can be used when referring to a specific HealthCareService resource."/>
+        <description value="The methods of referral can be used when referring to a specific HealthcareService resource."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/service-referral-method"/>
       </binding>
       <mapping>

--- a/source/healthcareservice/valueset-service-referral-method.xml
+++ b/source/healthcareservice/valueset-service-referral-method.xml
@@ -46,7 +46,7 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="The methods of referral can be used when referring to a specific HealthCareService resource."/>
+  <description value="The methods of referral can be used when referring to a specific HealthcareService resource."/>
   <immutable value="true"/>
   <compose>
     <include>

--- a/source/request/request-spreadsheet.xml
+++ b/source/request/request-spreadsheet.xml
@@ -1503,7 +1503,7 @@
     <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s91"><Data ss:Type="String">0..*</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s92"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s91"><Data ss:Type="String">Reference(Patient|RelatedPerson|Practitioner|PractitionerRole|Organization|Location|HealthCareService|CareTeam|Device|Endpoint)</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s91"><Data ss:Type="String">Reference(Patient|RelatedPerson|Practitioner|PractitionerRole|Organization|Location|HealthcareService|CareTeam|Device|Endpoint)</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s91"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s91"><Data ss:Type="String">Y</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>


### PR DESCRIPTION
## HL7 FHIR Pull Request

Jira: https://jira.hl7.org/browse/FHIR-40580?filter=-2

## Description

Correct misspelling of resource name in some references: "HealthCareService" should be "HealthcareService".  The resource definition spells it as "HealthcareService" (lower case "c"), but three places refer to it incorrectly as ""HealthCareService" (upper case "c").

