### PR TITLE
FHIR-38201 - Remove references to VersionNumber extension for composition

### DIFF
--- a/source/composition/implementationguide-composition-clinicaldocument.xml
+++ b/source/composition/implementationguide-composition-clinicaldocument.xml
@@ -22,10 +22,5 @@
         <reference value="StructureDefinition/composition-clinicaldocument-otherConfidentiality"/>
       </reference>
     </resource>
-    <resource>
-      <reference>
-        <reference value="StructureDefinition/composition-clinicaldocument-versionNumber"/>
-      </reference>
-    </resource>
   </definition>
 </ImplementationGuide>

--- a/source/composition/structuredefinition-profile-clinicaldocument.xml
+++ b/source/composition/structuredefinition-profile-clinicaldocument.xml
@@ -71,17 +71,6 @@
       <min value="0"/>
       <max value="*"/>
     </element>
-    <element id="Composition.extension:versionNumber">
-      <path value="Composition.extension"/>
-      <sliceName value="versionNumber"/>
-      <short value="Version-specific identifier for composition"/>
-      <definition value="Version specific identifier for the composition, assigned when each version is created/updated."/>
-      <comment value="While each resource, including the composition itself, has its own version identifier, this is a formal identifier for the logical version of the composition as a whole. It would remain constant if the resources were moved to a new server, and all got new individual resource versions, for example."/>
-      <type>
-        <code value="Extension"/>
-        <profile value="http://hl7.org/fhir/StructureDefinition/composition-clinicaldocument-versionNumber"/>
-      </type>
-    </element>
     <element id="Composition.subject">
       <path value="Composition.subject"/>
       <type>


### PR DESCRIPTION
## HL7 FHIR Pull Request

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: https://jira.hl7.org/browse/FHIR-38201

## Description
Removing references to the composition-versionNumber extension.

**Before**
![image](https://user-images.githubusercontent.com/6674267/225681101-26916267-9607-4c60-9150-8b6a6bb7a94b.png)

**After**
![image](https://user-images.githubusercontent.com/6674267/225681172-469c97ac-51fc-4afb-b64d-e5195f43c747.png)
