### PR TITLE
FHIR-32538 - Merge event.code and event.detail

### DIFF
--- a/source/composition/bundle-Composition-search-params.xml
+++ b/source/composition/bundle-Composition-search-params.xml
@@ -70,18 +70,37 @@
   <entry>
     <resource>
       <SearchParameter>
-        <id value="Composition-context"/>
+        <id value="Composition-event-code"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="Composition.event.code"/>
+          <valueString value="Composition.event.detail.concept"/>
         </extension>
-        <url value="http://hl7.org/fhir/build/SearchParameter/Composition-context"/>
-        <description value="Code(s) that apply to the event being documented"/>
-        <code value="context"/>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Composition-event-code"/>
+        <description value="Main clinical acts documented as codes"/>
+        <code value="event-code"/>
         <type value="token"/>
-        <expression value="Composition.event.code"/>
+        <expression value="Composition.event.detail.concept"/>
+        <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="Composition-event-reference"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="trial-use"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Composition.event.detail.reference"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Composition-event-reference"/>
+        <description value="Main clinical acts documented as references"/>
+        <code value="event-reference"/>
+        <type value="reference"/>
+        <expression value="Composition.event.detail.reference"/>
         <processingMode value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/composition/composition-example.xml
+++ b/source/composition/composition-example.xml
@@ -74,19 +74,21 @@
 		</resourceReference>
 	</relatesTo>
 	<event>
-		<code>
-			<coding>
-				<system value="http://terminology.hl7.org/CodeSystem/v3-ActCode"/>
-				<code value="HEALTHREC"/>
-				<display value="health record"/>
-			</coding>
-		</code>
 		<period>
 			<start value="2010-07-18"/>
 			<end value="2012-11-12"/>
 		</period>
 		<detail>
-			<reference value="Observation/example"/>
+			<concept>
+				<coding>
+					<system value="http://terminology.hl7.org/CodeSystem/v3-ActCode"/>
+					<code value="HEALTHREC"/>
+					<display value="health record"/>
+				</coding>
+			</concept>
+			<reference>
+				<reference value="Observation/example"/>
+			</reference>
 		</detail>
 	</event>
 	<section>

--- a/source/composition/structuredefinition-Composition.xml
+++ b/source/composition/structuredefinition-Composition.xml
@@ -682,38 +682,6 @@
         <map value="DocumentReference.event"/>
       </mapping>
     </element>
-    <element id="Composition.event.code">
-      <path value="Composition.event.code"/>
-      <short value="Code(s) that apply to the event being documented"/>
-      <definition value="This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the typeCode, such as a &quot;History and Physical Report&quot; in which the procedure being documented is necessarily a &quot;History and Physical&quot; act."/>
-      <comment value="An event can further specialize the act inherent in the typeCode, such as where it is simply &quot;Procedure Report&quot; and the procedure was a &quot;colonoscopy&quot;. If one or more eventCodes are included, they SHALL NOT conflict with the values inherent in the classCode, practiceSettingCode or typeCode, as such a conflict would create an ambiguous situation. This short list of codes is provided to be used as key words for certain types of queries."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <isSummary value="true"/>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="DocumentEventType"/>
-        </extension>
-        <strength value="example"/>
-        <description value="This list of codes represents the main clinical acts being documented."/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
-      </binding>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".code"/>
-      </mapping>
-      <mapping>
-        <identity value="cda"/>
-        <map value=".code"/>
-      </mapping>
-      <mapping>
-        <identity value="fhirdocumentreference"/>
-        <map value="DocumentReference.event.code"/>
-      </mapping>
-    </element>
     <element id="Composition.event.period">
       <path value="Composition.event.period"/>
       <short value="The period covered by the documentation"/>
@@ -739,15 +707,24 @@
     </element>
     <element id="Composition.event.detail">
       <path value="Composition.event.detail"/>
-      <short value="The event(s) being documented"/>
-      <definition value="The description and/or reference of the event(s) being documented. For example, this could be used to document such a colonoscopy or an appendectomy."/>
+      <short value="The event(s) being documented, as code(s), reference(s), or both"/>
+      <definition value="Represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the typeCode, such as a &quot;History and Physical Report&quot; in which case the procedure being documented is necessarily a &quot;History and Physical&quot; act. The events may be included as a code or as a reference to an other resource."/>
+      <comment value="An event can further specialize the act inherent in the typeCode, such as where it is simply &quot;Procedure Report&quot; and the procedure was a &quot;colonoscopy&quot;. If one or more events are included, they SHALL NOT conflict with the values inherent in the classCode, practiceSettingCode or typeCode, as such a conflict would create an ambiguous situation. This short list of codes is provided to be used as key words for certain types of queries."/>
       <min value="0"/>
       <max value="*"/>
       <type>
-        <code value="Reference"/>
+        <code value="CodeableReference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
       </type>
       <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="DocumentEventType"/>
+        </extension>
+        <strength value="example"/>
+        <description value="This list of codes represents the main clinical acts being documented."/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-ActCode"/>
+      </binding>
       <mapping>
         <identity value="rim"/>
         <map value=".outboundRelationship[typeCode=&quot;SUBJ&quot;].target"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request
https://jira.hl7.org/browse/FHIR-32538

## Description
Merges Composition's event.code and event.detail into a single CodeableReference.
Replaces the `context` search parameter with 2 parameters similar to DocumentReference.

![image](https://user-images.githubusercontent.com/6674267/226004202-9ddac328-91c2-4e4b-80d9-f1560a640501.png)
