### PR TITLE
FHIR-40638 - Fix the SpecimenDefinition breadcrumb so it correctly displays the Administration module

### DIFF
--- a/source/hierarchy.xml
+++ b/source/hierarchy.xml
@@ -341,7 +341,6 @@ signatures.html
       <page type="resource" resource="ImagingSelection"/>
       <page type="resource" resource="MolecularSequence"/>
       <page type="resource" resource="Specimen"/>
-      <page type="resource" resource="SpecimenDefinition"/>
       <page type="resource" resource="BodyStructure"/>
       <page title="Genomics Implementer Guidance" filename="genomics.html"/>
     </page>


### PR DESCRIPTION

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

FHIR-40638 - Fix the SpecimenDefinition breadcrumb so it correctly displays the Administration module.
