### PR TITLE
Br cqi changes 2023 03

### DIFF
--- a/source/clinicalreasoning-knowledge-artifact-representation.html
+++ b/source/clinicalreasoning-knowledge-artifact-representation.html
@@ -348,7 +348,7 @@
   &lt;/topic&gt;
   &lt;relatedArtifact&gt;
     &lt;type value=&quot;depends-on&quot;/&gt;
-    &lt;resource value=&quot;Library/library-quick-model-definition&quot;/&gt;
+    &lt;resource value=&quot;http://example.org/Library/library-quick-model-definition&quot;/&gt;
   &lt;/relatedArtifact&gt;
   &lt;dataRequirement&gt;
     &lt;type value=&quot;Condition&quot;/&gt;
@@ -389,7 +389,7 @@
   &lt;topic&gt;
     &lt;text value=&quot;Chlamydia Screening&quot;/&gt;
   &lt;/topic&gt;
-  &lt;library value=&quot;Library/example&quot;/&gt;
+  &lt;library value=&quot;http://example.org/Library/example&quot;/&gt;
   &lt;action&gt;
     &lt;title value=&quot;Patient has not had chlamydia screening within the recommended timeframe...&quot;/&gt;
     &lt;condition&gt;
@@ -650,7 +650,7 @@
       &lt;code value=&quot;57024-2&quot;/&gt;
     &lt;/coding&gt;
   &lt;/topic&gt;
-  &lt;library value=&quot;Library/cbp-logic&quot;/&gt;
+  &lt;library value=&quot;http://example.org/Library/cbp-logic&quot;/&gt;
   &lt;group&gt;
     &lt;population&gt;
       &lt;code value=&quot;initial-population&quot;/&gt;

--- a/source/clinicalreasoning-quality-reporting.html
+++ b/source/clinicalreasoning-quality-reporting.html
@@ -80,11 +80,11 @@
 <a name="specifying-population-criteria"> </a>
 <h6>Specifying Population Criteria</h6>
 
-<p>A measure can specify various types of populations, depending on the type of measure scoring being used. The following table shows which population criteria types are required (R), optional (O), or not permitted (NP) for proportion, ratio, and continuous variable measures. This table is adapted from Table 1 from the <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=97">HQMF Release 1 Normative</a> specification, and Table 2.1 from the <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=346">QDM-based HQMF IG</a>.</p>
+<p>A measure can specify various types of populations, depending on the measure scoring being used. The following table shows which population criteria types are required (R), optional (O), or not permitted (NP) for proportion, ratio, and continuous variable measures. This table is adapted from Table 1 from the <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=97">HQMF Release 1 Normative</a> specification, and Table 2.1 from the <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=346">QDM-based HQMF IG</a>.</p>
 
 <table class="grid">
 	<thead>
-		<tr><th>MeasureType</th><th>Initial Population</th><th>Denominator</th><th>Denominator Exclusion</th><th>Denominator Exception</th><th>Numerator</th><th>Numerator Exclusion</th><th>Measure Population</th><th>Measure Population Exclusion</th></tr>
+		<tr><th>Measure Scoring</th><th>Initial Population</th><th>Denominator</th><th>Denominator Exclusion</th><th>Denominator Exception</th><th>Numerator</th><th>Numerator Exclusion</th><th>Measure Population</th><th>Measure Population Exclusion</th></tr>
 	</thead>
 	<tbody>
 		<tr><td>Proportion</td><td>R</td><td>R</td><td>O</td><td>O</td><td>R</td><td>O</td><td>NP</td><td>NP</td></tr>
@@ -135,7 +135,7 @@
 <a name="multiple-populations"> </a>
 <h6>Measures with Multiple Populations</h6>
 
-<p>Quality measures often specify multiple rates, with different population crtiteria for each rate. This is different than stratifying the scores for the same population. For quality measures that contain multiple rates, the Measure will contain multiple group elements, where the criteria are specified once for each group. The <code>id</code> attribute of the <code>group</code> element is used to uniquely identify the group within the measure, as well as within the quality reporting results.</p>
+<p>Quality measures often specify multiple rates, with different population crtiteria for each rate. This is different than stratifying the scores for the same population. For quality measures that contain multiple rates, the Measure will contain multiple group elements, where the criteria are specified once for each group. The <code>linkId</code> attribute of the <code>group</code> element is used to uniquely identify the group within the measure, as well as within the quality reporting results.</p>
 
 <a name="continuous-variable-measures"> </a>
 <h6>Continuous Variable Measures</h6>
@@ -147,9 +147,9 @@
 
 <p>Stratifiers and supplemental data are specified using the <code>stratifier</code> and <code>supplementalData</code> elements of the <a href="measure.html">Measure</a> resource. Stratification criteria are specified either as a reference to a CQL named expression within a Library (e.g. <code>CMS146.AgesUpToNine</code>), or as FHIR resource paths (e.g. <code>Patient.gender</code>). When the stratification criteria is an expression, the stratification will yield as many result groups as the expression returns. For example, if the expression returns a boolean, then there would be two stratification groups: true and false. When the stratification criteria is a FHIR resource path, there will be as many stratification groups as possible values for the resource path. For example, specifying Patient.gender will yield four stratification groups since FHIR has four gender codes: male, female, other, and unknown.</p>
 
-<p>Supplemental data elements can also specified using FHIR resource paths, in which case the supplementalData element is the result of evaluating that path against the subject.</p>
+<p>Supplemental data elements can also be specified using FHIR resource paths, in which case the supplementalData element is the result of evaluating that path against the subject.</p>
 <p>For individual-level reports, if the result of evaluating the supplemental data expression for the subject of the report is not a resource, it is reported as a contained Observation resource and included by reference in the supplementalData element of the MeasureReport.</p>
-<p>For summary-level reports, supplementalData is reported using contained Observation resources that indicate the number of times each value was encountered as the supplementalData for members of the population. In this case, the `code` element of the Observation corresponds to the `code` of the supplementalData, and the `component.code` element of the observation specifies the supplementalData values encountered, and the `component.value[x]` element is specified as an integer that represents the number of times that value was encountered in the members of the population.</p>
+<p>For summary-level reports, supplementalData is reported using contained Observation resources that indicate the number of times each value was encountered as the supplementalData for members of the population. In this case, the <code>code</code> element of the Observation corresponds to the <code>code</code> of the supplementalData, and the <code>component.code</code> element of the observation specifies the supplementalData values encountered, and the <code>component.value[x]</code> element is specified as an integer that represents the number of times that value was encountered in the members of the population.</p>
 
 <p>The CMS146 example measure illustrates the stratification and supplemental data described above:</p>
 
@@ -166,9 +166,9 @@
 <p>Specifying the data criteria in this way enables the following use cases:</p>
 
 <ul>
-	<li>Determining the set of data used by a particular eCQM.</li>
+	<li>Determining the set of data used by a particular Measure.</li>
 	<li>Limited "scoop-and-filter" for creation of population reports.</li>
-	<li>Limited backwards compatibility with existing implementations of previous eCQM IGs.</li>
+	<li>Limited backwards compatibility with existing implementations of previous Measure IGs.</li>
 </ul>
 
 <p>Data criteria can be specified statically, or they can be <i>inferred</i> from the expressions referenced by the measure. The <code>$data-requirements</code> operation can be invoked to retrieve the aggregate data requirements for the measure. This approach has two advantages:</p>
@@ -226,7 +226,7 @@ The next example demonstrates how to obtain the results of evaluating the eMeasu
 <a name="measure-report"> </a>
 <h4>Measure Report</h4>
 
-<p>When eCQMs are represented with the Health Quality Measure Format (HQMF), a single HQMF document represents both the measure itself and the request. Meanwhile, the responses are represented as Quality Reporting Document Architecture (QRDA) documents. QRDA documents come in two flavors: <a href="https://confluence.hl7.org/display/CQIWC/Quality+Reporting+Document+Architecture+Category+1">Category I</a> for individual patient reports and <a href="https://confluence.hl7.org/display/CQIWC/Quality+Reporting+Document+Architecture+Category+3">Category III</a> for population reports.</p>
+<p>When electronic Clinical Quality Measures (eCQMs) are represented with the Health Quality Measure Format (HQMF), a single HQMF document represents both the measure itself and the request. Meanwhile, the responses are represented as Quality Reporting Document Architecture (QRDA) documents. QRDA documents come in two flavors: <a href="https://confluence.hl7.org/display/CQIWC/Quality+Reporting+Document+Architecture+Category+1">Category I</a> for individual patient reports and <a href="https://confluence.hl7.org/display/CQIWC/Quality+Reporting+Document+Architecture+Category+3">Category III</a> for population reports.</p>
 
 <p>When eCQMs are represented with FHIR resources, the measure is represented as a <a href="measure.html">Measure</a> resource, and the request is an <code>HTTP GET</code> conforming to the <a href="operationdefinition.html">OperationDefinition</a> described above. Meanwhile, the responses are represented as <a href="measurereport.html">MeasureReport</a> resources. Like QRDA, the MeasureReport allows for Category I (individual), Category II (subject-list), and Category III (population) reports.</p>
 

--- a/source/clinicalreasoning-quality-reporting.html
+++ b/source/clinicalreasoning-quality-reporting.html
@@ -233,11 +233,11 @@ The next example demonstrates how to obtain the results of evaluating the eMeasu
 <a name="reporting-population-data"> </a>
 <h5>Reporting Population Data</h5>
 
-<p>A <a href="measurereport.html">MeasureReport</a> will contain one group of data for each group specified in the corresponding <a href="measure.html">Measure</a>, consisting of a set of population elements, one for each criteria defined in each group.</p>
+<p>A <a href="measurereport.html">MeasureReport</a> will contain one group of data for each group specified in the corresponding <a href="measure.html">Measure</a>, consisting of a set of population elements, one for each criteria defined in each group. The <code>Measure.group.linkId</code> and <code>Measure.group.population.linkId</code> elements define a linking id that is used to correlate the group and population elements in the MeasureReport back to the corresponding elements in the Measure.</p>
 
 <img alt="Population Measure Report" src="clinicalreasoning-measure-report-population.png"/>
 
-<p>In addition, each group will contain stratifiers with a value stratum for each value defined by the stratifier criteria, for each criteria defined in the measure.</p>
+<p>In addition, each group will contain stratifiers with a value stratum for each value defined by the stratifier criteria, for each criteria defined in the measure. The <code>Measure.group.stratifier.linkId</code> element defines a linking id that is used to correlate the stratifier elements in the MeasureReport back to the corresponding elements in the Measure.</p>
 
 <a name="reporting-individual-data"> </a>
 <h5>Reporting Individual Data</h5>
@@ -247,6 +247,8 @@ The next example demonstrates how to obtain the results of evaluating the eMeasu
 <img alt="Individual Measure Report" src="clinicalreasoning-measure-report-individual.png"/>
 
 <p>See the MeasureReport <a href="measurereport-examples.html">examples</a> for a detailed illustration of how the data elements involved in the calculation of the measure are communicated through the <code>evaluatedResources</code> element.</p>
+
+<p>As with population-level reports, the <code>group</code>, <code>population</code>, <code>stratifier</code>, and <code>supplementalData</code> elements have a <code>linkId</code> element that defines a linking id that is used to correlate these elements in the MeasureReport back to the corresponding elements in the Measure.</p>
 
 <a name="reporting-subject-list-data"> </a>
 <h5>Subject-List Reports</h5>

--- a/source/clinicalreasoning-topics-using-expressions.html
+++ b/source/clinicalreasoning-topics-using-expressions.html
@@ -103,12 +103,12 @@
 
 <p>The example specifies that the <code>reasonCode</code> element should be set to the result of evaluating the <code>RiskAssessmentScore</code> expression. This expression is expected to be present in a Library referenced by the containing resource:</p>
 
-<pre><code>&lt;library value=&quot;Library/mmi-suiciderisk-orderset-logic&quot;/&gt;</code></pre>
+<pre><code>&lt;library value=&quot;http://hl7.org/fhir/Library/mmi-suiciderisk-orderset-logic&quot;/&gt;</code></pre>
 
 <p>If the containing resource has a <code>library</code> element (such as ActivityDefinition and PlanDefinition), and only specifies a single library, the expression is evaluated as though it is in scope in that library. However, if the resource references multiple libraries, the referenced expression must be qualified with the name of the library in order to ensure unambiguous resolution. For example, the following fragment illustrates multiple libraries being referenced by the containing resource:</p>
 
-<pre><code>&lt;library value=&quot;Library/mmi-suiciderisk-orderset-logic&quot;/&gt;
-&lt;library value=&quot;Library/another-orderset-logic&quot;/&gt;
+<pre><code>&lt;library value=&quot;http://hl7.org/fhir/Library/mmi-suiciderisk-orderset-logic&quot;/&gt;
+&lt;library value=&quot;http://hl7.org/fhir/Library/another-orderset-logic&quot;/&gt;
 </code></pre>
 
 <p>The following fragment illustrates how an expression reference (reasonCode) would be qualified in the case of multiple library references:</p>

--- a/source/library/cms146_data_requirements.json
+++ b/source/library/cms146_data_requirements.json
@@ -7,7 +7,7 @@
   },
   "relatedArtifact" : [{
     "type" : "depends-on",
-    "resource" : "Library/library-quick-model-definition"
+    "resource" : "http://hl7.org/fhir/Library/library-quick-model-definition"
   }],
   "dataRequirement" : [{
     "type" : "Condition",

--- a/source/library/library-cms146-example-content.cql
+++ b/source/library/library-cms146-example-content.cql
@@ -507,7 +507,7 @@ d6bdadc 5 hours ago
   <description value="Logic for CMS 146: Appropriate Testing for Children with Pharyngitis"/>
   <relatedArtifact>
     <type value="depends-on"/>
-    <resource value="Library/library-quick-model-definition"/>
+    <resource value="http://hl7.org/fhir/Library/library-quick-model-definition"/>
   </relatedArtifact>
 
   <dataRequirement>

--- a/source/measure/cms146_data_requirements.json
+++ b/source/measure/cms146_data_requirements.json
@@ -7,7 +7,7 @@
   },
   "relatedArtifact" : [{
     "type" : "depends-on",
-    "resource" : "Library/library-quick-model-definition"
+    "resource" : "http://hl7.org/fhir/Library/library-quick-model-definition"
   }],
   "dataRequirement" : [{
     "type" : "Condition",

--- a/source/measure/measure-introduction.xml
+++ b/source/measure/measure-introduction.xml
@@ -8,7 +8,7 @@
 
 <p>Note that the Measure itself does not typically contain any logic; rather a <a href="library.html">Library</a> resource is referenced that contains the logic required by the measure, and the various expression elements, such as population criteria, reference named expressions within that library (or libraries). In addition, if the Measure references multiple libraries, then any expression references within the resource must be qualified with the name of the library that contains the referenced expression.</p>
 
-<p>This resource is a definition resource from a FHIR workflow perspective - see <a href="workflow.html">Workflow</a>, specifically <a href="workflow.html#definition">Definition</a>.
+<p>This resource is a definition resource from a FHIR workflow perspective - see <a href="workflow.html">Workflow</a>, specifically <a href="workflow.html#definition">Definition</a>.</p>
 
 <p>For a detailed discussion of how to use the Measure and MeasureReport resources, refer to the <a href="clinicalreasoning-quality-reporting.html">Quality Reporting</a> topic.</p>
 

--- a/source/measure/measure-introduction.xml
+++ b/source/measure/measure-introduction.xml
@@ -8,6 +8,8 @@
 
 <p>Note that the Measure itself does not typically contain any logic; rather a <a href="library.html">Library</a> resource is referenced that contains the logic required by the measure, and the various expression elements, such as population criteria, reference named expressions within that library (or libraries). In addition, if the Measure references multiple libraries, then any expression references within the resource must be qualified with the name of the library that contains the referenced expression.</p>
 
+<p>This resource is a definition resource from a FHIR workflow perspective - see <a href="workflow.html">Workflow</a>, specifically <a href="workflow.html#definition">Definition</a>.
+
 <p>For a detailed discussion of how to use the Measure and MeasureReport resources, refer to the <a href="clinicalreasoning-quality-reporting.html">Quality Reporting</a> topic.</p>
 
 </div>
@@ -16,7 +18,7 @@
 <h2>Boundaries and Relationships</h2>
 <p>The Measure resource describes a specific quality measure, or population analytic, providing the structure of the measure in terms of the calculation elements (the <i>populations</i> involved). The <a href="group.html">Group</a> resource is also capable of describing a population, however, the complexity involved in specifying the criteria in the general case requires the use of a high-level query language such as Clinical Quality Language (CQL). As such, the Measure resource defines only the top-level populations and references expressions for the actual criteria. These expressions are typically provided using a <a href="library.html">Library</a> resource containing CQL or ELM expressions. In addition, the individual members of a population may be cases such as encounters or procedures and in these cases, the Group resource would be unable to represent the population characteristics accurately.</p>
 
-<p>A Measure is also similar to an <a href="observation.html">Observation</a> resource, with the exception that the Measure is purely definitional, it contains no actual measurements, only a description of how to calculate a particular measurement or set of measurements.</p>
+<p>A Measure is also similar to an <a href="observationdefinition.html">ObservationDefinition</a> resource, in that it is purely definitional, it contains no actual measurements, only a description of how to calculate a particular measurement or set of measurements. Measure is different from ObservationDefinition in that Measure is intended to provide a computable specification.</p>
 
 <p>A Measure is also similar to a clinical document, but as with the relationship to Observation, a Document is specific to a particular subject.</p>
 </div>

--- a/source/measure/operationdefinition-Measure-evaluate-measure.xml
+++ b/source/measure/operationdefinition-Measure-evaluate-measure.xml
@@ -120,7 +120,7 @@
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="The type of measure report: subject, subject-list, or population. If not specified, a default value of subject will be used if the subject parameter is supplied, otherwise, population will be used"/>
+    <documentation value="The type of measure report: individual, subject-list, or summary. If not specified, a default value of individual will be used if the subject parameter is supplied, otherwise, summary will be used. NOTE: Implementations should support the use of `subject` for individual and `population` for summary for backwards compatibility with existing implementations."/>
     <type value="code"/>
   </parameter>
   <parameter>

--- a/source/measure/structuredefinition-Measure.xml
+++ b/source/measure/structuredefinition-Measure.xml
@@ -410,7 +410,7 @@
       <short value="Population basis"/>
       <definition value="The population basis specifies the type of elements in the population. For a subject-based measure, this is boolean (because the subject and the population basis are the same, and the population criteria define yes/no values for each individual in the population). For measures that have a population basis that is different than the subject, this element specifies the type of the population basis. For example, an encounter-based measure has a subject of Patient and a population basis of Encounter, and the population criteria all return lists of Encounters."/>
       <comment value="For a subject-based measure, the population basis is simply boolean; all the criteria are expressed as true/false conditions that determine membership of an individual case in the population. For non-subject-based measures, the population basis can be any resource type, and the criteria are queries that return the subject's contribution to the population as a list of that resource type. For example, for a procedure-based measure, the population criteria would return lists of procedures that should be included in each population."/>
-      <requirements value="Allows non-subject-based measures to be specified"/>
+      <requirements value="Allows non-subject-based measures to be specified. Note that because the binding is to all fhir types, it is possible to specify abstract types such as Resource or DomainResource as the basis for a measure. Authoring environments may wish to constrain this further, depending on content needs."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/measure/structuredefinition-Measure.xml
+++ b/source/measure/structuredefinition-Measure.xml
@@ -1803,7 +1803,7 @@
       <path value="Measure.supplementalData"/>
       <short value="What other data should be reported with the measure"/>
       <definition value="The supplemental data criteria for the measure report, specified as either the name of a valid CQL expression within a referenced library, or a valid FHIR Resource Path."/>
-      <comment value="Note that supplemental data are reported as observations for each patient and included in the evaluatedResources bundle. See the MeasureReport resource or the Quality Reporting topic for more information."/>
+      <comment value="Note that supplemental data are reported as resources for each patient and referenced in the supplementalData element of the MeasureReport. If the supplementalData expression results in a value other than a resource, it is reported using an Observation resource, typically contained in the resulting MeasureReport. See the MeasureReport resource and the Quality Reporting topic for more information."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/measurereport/list-MeasureReport-examples.xml
+++ b/source/measurereport/list-MeasureReport-examples.xml
@@ -52,4 +52,16 @@
       <display value="General Example"/>
     </item>
   </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Example subject-list"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="measurereport-788ca455-e11b1a59"/>
+    </extension>
+    <item>
+      <reference value="MeasureReport/788ca455-e11b1a59"/>
+      <display value="Subject List Example"/>
+    </item>
+  </entry>
 </List>

--- a/source/measurereport/measurereport-788ca455-e11b1a59.xml
+++ b/source/measurereport/measurereport-788ca455-e11b1a59.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MeasureReport xmlns="http://hl7.org/fhir">
+   <id value="788ca455-e11b1a59" />
+   <contained>
+      <List>
+         <id value="1" />
+         <status value="current" />
+         <mode value="snapshot" />
+         <entry>
+            <item>
+               <reference value="MeasureReport/788ca455-e11b1a59-838c24b5" />
+            </item>
+         </entry>
+         <entry>
+            <item>
+               <reference value="MeasureReport/788ca455-e11b1a59-2ad816ff" />
+            </item>
+         </entry>
+      </List>
+   </contained>
+   <status value="complete" />
+   <type value="subject-list" />
+   <measure value="http://lantanagroup.com/fhir/nhsn-measures/Measure/NHSNGlycemicControlHypoglycemicInitialPopulation" />
+   <reporter>
+      <reference value="Organization/aa389ad5-e6fe-4030-88ce-010ab96e4ac4" />
+   </reporter>
+   <period>
+      <start value="2022-08-01T00:00:00+00:00" />
+      <end value="2022-08-31T23:59:59+00:00" />
+   </period>
+   <group>
+      <population>
+         <code>
+            <coding>
+               <system value="http://terminology.hl7.org/CodeSystem/measure-population" />
+               <code value="initial-population" />
+               <display value="Initial Population" />
+            </coding>
+         </code>
+         <count value="2" />
+         <subjectResults>
+            <reference value="#1" />
+         </subjectResults>
+      </population>
+   </group>
+</MeasureReport>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -420,7 +420,7 @@
       <path value="MeasureReport.improvementNotation"/>
       <short value="increase | decrease"/>
       <definition value="Whether improvement in the measure is noted by an increase or decrease in the measure score."/>
-      <comment value="This element is typically defined by the measure, but reproduced here to ensure the measure score can be interpreted. The element is labeled as a modifier because it changes the interpretation of the reported measure score."/>
+      <comment value="This element is typically defined by the measure, but reproduced here to ensure the measure score can be interpreted. The element is labeled as a modifier because it changes the interpretation of the reported measure score. Note also that a MeasureReport instance includes the improvementNotation as defined by the Measure being reported. It is duplicated in the MeasureReport because it is a critical aspect of interpreting the measure score but it is not intended to reflect whether the measure report is an increase or decrease. It helps interpret if the measure score is an increase or decrease, I.e., moving in the direction of the desired outcome."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -1048,6 +1048,7 @@
       <path value="MeasureReport.evaluatedResource"/>
       <short value="What data was used to calculate the measure score"/>
       <definition value="A reference to a Resource that was used in the calculation of this measure."/>
+      <comment value="Evaluated resources are only reported for individual reports."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -1047,7 +1047,7 @@
       </extension>
       <path value="MeasureReport.evaluatedResource"/>
       <short value="What data was used to calculate the measure score"/>
-      <definition value="A reference to a Resource that was used in the calculation of this measure."/>
+      <definition value="Evaluated resources are used to capture what data was involved in the calculation of a measure. This usage is only allowed for individual reports to ensure that the size of the MeasureReport resource is bounded."/>
       <comment value="Evaluated resources are only reported for individual reports."/>
       <min value="0"/>
       <max value="*"/>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -58,11 +58,6 @@
     <uri value="http://hl7.org/fhir/fivews"/>
     <name value="FiveWs Pattern Mapping"/>
   </mapping>
-  <mapping>
-    <identity value="qrda"/>
-    <uri value="http://hl7.org/qrda"/>
-    <name value="QRDA Mapping"/>
-  </mapping>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="MeasureReport"/>
@@ -123,10 +118,6 @@
       <mapping>
         <identity value="rim"/>
         <map value="id"/>
-      </mapping>
-      <mapping>
-        <identity value="qrda"/>
-        <map value="ClinicalDocument.id"/>
       </mapping>
     </element>
     <element id="MeasureReport.status">
@@ -293,10 +284,6 @@
         <identity value="rim"/>
         <map value="participation[typeCode=AUT].time"/>
       </mapping>
-      <mapping>
-        <identity value="qrda"/>
-        <map value="ClinicalDocument.effectiveTime"/>
-      </mapping>
     </element>
     <element id="MeasureReport.reporter">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
@@ -322,10 +309,6 @@
       <mapping>
         <identity value="rim"/>
         <map value="participation[typeCode=PRF]"/>
-      </mapping>
-      <mapping>
-        <identity value="qrda"/>
-        <map value="ClinicalDocument.documentationOf"/>
       </mapping>
     </element>
     <element id="MeasureReport.reportingVendor">

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -58,6 +58,11 @@
     <uri value="http://hl7.org/fhir/fivews"/>
     <name value="FiveWs Pattern Mapping"/>
   </mapping>
+  <mapping>
+    <identity value="qrda"/>
+    <uri value="http://hl7.org/qrda"/>
+    <name value="QRDA Mapping"/>
+  </mapping>
   <kind value="resource"/>
   <abstract value="false"/>
   <type value="MeasureReport"/>
@@ -118,6 +123,10 @@
       <mapping>
         <identity value="rim"/>
         <map value="id"/>
+      </mapping>
+      <mapping>
+        <identity value="qrda"/>
+        <map value="ClinicalDocument.id"/>
       </mapping>
     </element>
     <element id="MeasureReport.status">
@@ -284,6 +293,10 @@
         <identity value="rim"/>
         <map value="participation[typeCode=AUT].time"/>
       </mapping>
+      <mapping>
+        <identity value="qrda"/>
+        <map value="ClinicalDocument.effectiveTime"/>
+      </mapping>
     </element>
     <element id="MeasureReport.reporter">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
@@ -309,6 +322,10 @@
       <mapping>
         <identity value="rim"/>
         <map value="participation[typeCode=PRF]"/>
+      </mapping>
+      <mapping>
+        <identity value="qrda"/>
+        <map value="ClinicalDocument.documentationOf"/>
       </mapping>
     </element>
     <element id="MeasureReport.reportingVendor">

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -277,8 +277,8 @@
     </element>
     <element id="MeasureReport.date">
       <path value="MeasureReport.date"/>
-      <short value="When the report was generated"/>
-      <definition value="The date this measure report was generated."/>
+      <short value="When the measure was calculated"/>
+      <definition value="The date this measure was calculated."/>
       <min value="0"/>
       <max value="1"/>
       <type>


### PR DESCRIPTION
J#20506 - Added mappings for QRDA I and III to MeasureReport
J#20804 - Clarified MeasureReport.date
J#25718 - Added guidance on the use of linkId in Measure and MeasureReport
J#25737 - Corrected relative canonical references throughout clinical reasoning examples
J#26695 - Clarified use of type vs scoring in specifying population criteria
J#28359 - Aligned $evaluate-measure reportType parameter values with MeasureReport.type values
J#29807 - Clarified supplementalData usage and reporting
J#29816 - Clarified supplementalData usage and reporting
J#31413 - Clarified improvementNotation interpretation
J#32194 - Clarified basis can result in abstract types
J#34033 - Clarified evaluatedResources are only used in individual reports
J#40257 - Clarified boundaries and relationships of Measure to ObservationDefinition