### PR TITLE
J# 41379 Evidence.statistic.modelCharacteristic changes

### DIFF
--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -876,6 +876,21 @@
 				<code value="BackboneElement"/>
 			</type>
 		</element>
+		<element id="Evidence.modelCharacteristic.condition[x]">
+			<extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
+				<valueCode value="490,150"/>
+			</extension>
+			<path value="Evidence.modelCharacteristic.condition[x]"/>
+			<short value="When this characteristic is used"/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="CodeableConcept"/>
+			</type>
+			<type>
+				<code value="Expression"/>
+			</type>
+		</element>
 		<element id="Evidence.statistic.modelCharacteristic.code">
 			<path value="Evidence.statistic.modelCharacteristic.code"/>
 			<short value="Model specification"/>
@@ -893,15 +908,39 @@
 				<valueSet value="http://hl7.org/fhir/ValueSet/statistic-model-code"/>
 			</binding>
 		</element>
-		<element id="Evidence.statistic.modelCharacteristic.value">
-			<path value="Evidence.statistic.modelCharacteristic.value"/>
-			<short value="Numerical value to complete model specification"/>
-			<definition value="Further specification of the quantified value of the component of the method to generate the statistic."/>
+		<element id="Evidence.statistic.modelCharacteristic.value[x]">
+			<path value="Evidence.statistic.modelCharacteristic.value[x]"/>
+			<short value="The specific value (when paired with code)"/>
+			<definition value="Further specification of the value of the component of the method to generate the statistic."/>
 			<min value="0"/>
 			<max value="1"/>
 			<type>
 				<code value="Quantity"/>
 				<profile value="http://hl7.org/fhir/StructureDefinition/SimpleQuantity"/>
+			</type>
+			<type>
+				<code value="Range"/>
+			</type>
+			<type>
+				<code value="CodeableConcept"/>
+			</type>
+		</element>
+		<element id="Evidence.statistic.modelCharacteristic.intended">
+			<path value="Evidence.statistic.modelCharacteristic.intended"/>
+			<short value="The plan for analysis"/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="boolean"/>
+			</type>
+		</element>
+		<element id="Evidence.statistic.modelCharacteristic.applied">
+			<path value="Evidence.statistic.modelCharacteristic.applied"/>
+			<short value="The analysis that was applied"/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="boolean"/>
 			</type>
 		</element>
 		<element id="Evidence.statistic.modelCharacteristic.variable">
@@ -974,6 +1013,17 @@
 			<min value="0"/>
 			<max value="*"/>
 			<contentReference value="#Evidence.statistic.attributeEstimate"/>
+		</element>
+		<element id="Evidence.statistic.modelCharacteristic.modelCharacteristic">
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
+				<valueString value="AttributeEstimateAttributeEstimate"/>
+			</extension>
+			<path value="Evidence.statistic.modelCharacteristic.modelCharacteristic"/>
+			<short value="Model component"/>
+			<comment value="A nested model characteristic"/>
+			<min value="0"/>
+			<max value="*"/>
+			<contentReference value="#Evidence.statistic.modelCharacteristic"/>
 		</element>
 		<element id="Evidence.certainty">
 			<extension url="http://hl7.org/fhir/build/StructureDefinition/svg">


### PR DESCRIPTION
The EBMonFHIR project, through multiple meetings with statisticians and informaticists developed models and examples for expressing an endpoint analysis plan (a statistical model commonly expressed in clinical study protocols) in a FHIR Resource.  The approach with the smallest number of changes to the FHIR specification involves 5 changes to the Evidence.statistic.modelCharacteristic element, namely:

    1. Add condition[x] 0..1 CodeableConcept | Expression short="When this characteristic is used"
    2. Change value element to value[x] 0..1 Quantity | Range | CodeableConcept  short="The specific value (when paired with code)"
    3. Add intended 0..1 boolean  short="The plan for analysis"
    4. Add applied 0..1 boolean   short="The analysis that was applied"
    5. Add modelCharacteristic 0..* see modelCharacteristic  short="model component"