### PR TITLE
Fix build notification formatting

### DIFF
--- a/master-branch-pipeline.yml
+++ b/master-branch-pipeline.yml
@@ -77,10 +77,9 @@ jobs:
             -d "type=stream" \
             -d "to=$(ZULIP_STREAM_ID_COMMITTERS)" \
             -d "subject=FHIR Build Status" \
-            -d $"content=PR Build success for master branch:thumbs_up:! [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results) 
-            Published webpage can be viewed [here](https://build.fhir.org/)
+            -d $"content=PR Build success for master branch:thumbs_up:!
+            [build logs](https://dev.azure.com/fhir-pipelines/fhir-publisher/_build/results?buildId=$(Build.BuildId)&view=results) | [published webpage](https://build.fhir.org/)
             "
-
   - task: Bash@3
     condition: failed()
     inputs:


### PR DESCRIPTION
Build notifications have a markdown bug, apparently from a missing closing paren though it appears present in this yaml file. May be a trailing whitespace issue:

![image](https://github.com/HL7/fhir/assets/313089/5c846679-1df1-4e14-b4a8-1e47854ac7ca)
