### PR TITLE
J# 43057 completed, and J# 43056 work in progress, and added back Examples for EvidenceVariable and one Group example

### DIFF
--- a/source/evidence/codesystem-variable-role.xml
+++ b/source/evidence/codesystem-variable-role.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="variable-role"/>
+  <meta>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/variable-role"/>
+  <version value="6.0.0"/>
+  <name value="Variable Role"/>
+  <title value="VariableRole"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <date value="2023-11-08T16:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="The role that the variable plays."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/variable-role"/>
+  <content value="complete"/>
+  <concept>
+    <code value="population"/>
+    <display value="Population"/>
+    <definition value="The group from which the observations were obtained."/>
+  </concept>
+  <concept>
+    <code value="exposure"/>
+    <display value="Exposure"/>
+    <definition value="An independant variable of primary interest."/>
+  </concept>
+  <concept>
+    <code value="outcome"/>
+    <display value="Outcome"/>
+    <definition value="A dependent variable."/>
+  </concept>
+  <concept>
+    <code value="covariate"/>
+    <display value="Covariate"/>
+    <definition value="A variable that influences the exposure or outcome."/>
+  </concept>
+</CodeSystem>

--- a/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
@@ -7,7 +7,7 @@
     <div xmlns="http://www.w3.org/1999/xhtml">
       
       <p>
-        &quot;Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12&quot; is a univariate risk estimate.
+        &quot;Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12&quot; is a univariate risk estimate (non-comparative evidence).
       </p>
 	
     </div>
@@ -31,33 +31,21 @@
   </relatedArtifact>
   <description value="5.3% risk of mRS 3-6 at 90 days"/>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
+    <variableRole value="population"/>
     <observed>
-      <reference value="Group/ASTRAL-Cooray-validation-cohort"/>
+      <reference value="Group/ASTRAL-Cooray-validation-cohort-and-received-alteplase"/>
       <type value="Group"/>
-      <display value="ASTRAL validation cohort"/>
+      <display value="ASTRAL validation cohort and received alteplase"/>
     </observed>
     <intended>
-      <reference value="Group/ASTRAL-12"/>
+      <reference value="Group/ASTRAL-12-and-received-alteplase"/>
       <type value="Group"/>
-      <display value="patients 0-4.5 hours after acute ischemic stroke onset with ASTRAL score = 12"/>
+      <display value="patients 0-4.5 hours after acute ischemic stroke onset with ASTRAL score = 12 and received alteplase"/>
     </intended>
   </variableDefinition>
   <variableDefinition>
     <description value="functionally dependent or dead at 3 months"/>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="measuredVariable"/>
-        <display value="measured variable"/>
-      </coding>
-    </variableRole>
+    <variableRole value="outcome"/>
     <observed>
       <reference value="EvidenceVariable/example-mRS3-6-at-90days"/>
       <type value="EvidenceVariable"/>
@@ -73,32 +61,6 @@
         <system value="http://terminology.hl7.org/CodeSystem/directness"/>
         <code value="high"/>
         <display value="High quality match between observed and intended variable"/>
-      </coding>
-    </directnessMatch>
-  </variableDefinition>
-  <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="exposure"/>
-        <display value="exposure"/>
-      </coding>
-    </variableRole>
-    <observed>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-      <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
-    </observed>
-    <intended>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-      <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
-    </intended>
-    <directnessMatch>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/directness"/>
-        <code value="exact"/>
-        <display value="Exact match between observed and intended variable"/>
       </coding>
     </directnessMatch>
   </variableDefinition>

--- a/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
@@ -31,13 +31,7 @@
   </relatedArtifact>
   <description value="mRS 3-6 at 90 days Odds Ratio 0.65 for Alteplase vs. No Alteplase in patients with acute ischemic stroke 0-3 hours prior"/>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
+    <variableRole value="population"/>
     <observed>
       <reference value="EvidenceVariable/Wardlaw2014Analysis1.16.3EvidenceSet"/>
       <type value="EvidenceVariable"/>
@@ -50,13 +44,7 @@
     </intended>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="measuredVariable"/>
-        <display value="measured variable"/>
-      </coding>
-    </variableRole>
+    <variableRole value="outcome"/>
     <observed>
       <reference value="EvidenceVariable/example-mRS3-6-at-90days"/>
       <type value="EvidenceVariable"/>
@@ -69,42 +57,13 @@
     </intended>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="exposure"/>
-        <display value="exposure"/>
-      </coding>
-    </variableRole>
+    <variableRole value="exposure"/>
+    <comparatorCategory value="No Alteplase"/>
     <observed>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
+      <reference value="EvidenceVariable/example-group-assignment-alteplase-for-stroke-vs-no-alteplase"/>
       <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
+      <display value="Group Assignment: Alteplase for Stroke vs No Alteplase"/>
     </observed>
-    <intended>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-      <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
-    </intended>
-  </variableDefinition>
-  <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="referenceExposure"/>
-        <display value="reference exposure"/>
-      </coding>
-    </variableRole>
-    <observed>
-      <reference value="EvidenceVariable/example-no-alteplase"/>
-      <type value="EvidenceVariable"/>
-      <display value="no alteplase"/>
-    </observed>
-    <intended>
-      <reference value="EvidenceVariable/example-no-alteplase"/>
-      <type value="EvidenceVariable"/>
-      <display value="no alteplase"/>
-    </intended>
   </variableDefinition>
   <synthesisType>
     <coding>

--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -31,13 +31,7 @@
   </relatedArtifact>
   <description value="mRS 0-2 at 90 days Odds Ratio 1.2 for Alteplase vs. No Alteplase in patients with acute ischemic stroke 3-4.5 hours prior"/>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
+    <variableRole value="population"/>
     <observed>
       <reference value="EvidenceVariable/Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
       <type value="EvidenceVariable"/>
@@ -57,13 +51,7 @@
     </directnessMatch>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="measuredVariable"/>
-        <display value="measured variable"/>
-      </coding>
-    </variableRole>
+    <variableRole value="outcome"/>
     <observed>
       <reference value="EvidenceVariable/example-mRS0-2-at-90days"/>
       <type value="EvidenceVariable"/>
@@ -76,42 +64,13 @@
     </intended>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="exposure"/>
-        <display value="exposure"/>
-      </coding>
-    </variableRole>
+    <variableRole value="exposure"/>
+    <comparatorCategory value="No Alteplase"/>
     <observed>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
+      <reference value="EvidenceVariable/example-group-assignment-alteplase-for-stroke-vs-no-alteplase"/>
       <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
+      <display value="Group Assignment: Alteplase for Stroke vs No Alteplase"/>
     </observed>
-    <intended>
-      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
-      <type value="EvidenceVariable"/>
-      <display value="Alteplase for Stroke"/>
-    </intended>
-  </variableDefinition>
-  <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="referenceExposure"/>
-        <display value="reference exposure"/>
-      </coding>
-    </variableRole>
-    <observed>
-      <reference value="EvidenceVariable/example-no-alteplase"/>
-      <type value="EvidenceVariable"/>
-      <display value="no alteplase"/>
-    </observed>
-    <intended>
-      <reference value="EvidenceVariable/example-no-alteplase"/>
-      <type value="EvidenceVariable"/>
-      <display value="no alteplase"/>
-    </intended>
   </variableDefinition>
   <synthesisType>
     <coding>

--- a/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
@@ -31,32 +31,7 @@
   </relatedArtifact>
   <description value="2.7% incidence of fatal intracranial hemorrhage within 7 days with alteplase in patients with acute ischemic stroke"/>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
-    <observed>
-      <reference value="Group/AcuteIschemicStroke"/>
-      <type value="Group"/>
-      <display value="adults with acute ischemic stroke"/>
-    </observed>
-    <intended>
-      <reference value="Group/AcuteIschemicStroke"/>
-      <type value="Group"/>
-      <display value="adults with acute ischemic stroke"/>
-    </intended>
-  </variableDefinition>
-  <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
+    <variableRole value="population"/>
     <observed>
       <reference value="Group/Emberson-2014-IPD-MA-Alteplase-Cohort"/>
       <type value="Group"/>
@@ -69,13 +44,7 @@
     </intended>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="measuredVariable"/>
-        <display value="measured variable"/>
-      </coding>
-    </variableRole>
+    <variableRole value="outcome"/>
     <observed>
       <reference value="EvidenceVariable/example-fatal-ICH-in-7-days"/>
       <type value="EvidenceVariable"/>

--- a/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
@@ -31,32 +31,7 @@
   </relatedArtifact>
   <description value="0.4% incidence of fatal intracranial hemorrhage within 7 days without alteplase in patients with acute ischemic stroke"/>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
-    <observed>
-      <reference value="Group/AcuteIschemicStroke"/>
-      <type value="Group"/>
-      <display value="adults with acute ischemic stroke"/>
-    </observed>
-    <intended>
-      <reference value="Group/AcuteIschemicStroke"/>
-      <type value="Group"/>
-      <display value="adults with acute ischemic stroke"/>
-    </intended>
-  </variableDefinition>
-  <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="population"/>
-        <display value="population"/>
-      </coding>
-    </variableRole>
+    <variableRole value="population"/>
     <observed>
       <reference value="Group/Emberson-2014-IPD-MA-No-Alteplase-Cohort"/>
       <type value="Group"/>
@@ -69,13 +44,7 @@
     </intended>
   </variableDefinition>
   <variableDefinition>
-    <variableRole>
-      <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
-        <code value="measuredVariable"/>
-        <display value="measured variable"/>
-      </coding>
-    </variableRole>
+    <variableRole value="outcome"/>
     <observed>
       <reference value="EvidenceVariable/example-fatal-ICH-in-7-days"/>
       <type value="EvidenceVariable"/>

--- a/source/evidence/list-Evidence-examples.xml
+++ b/source/evidence/list-Evidence-examples.xml
@@ -30,6 +30,18 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidence-example-ASTRAL-12-alteplase-mRS3-6"/>
+    </extension>
+    <item>
+      <reference value="Evidence/example-ASTRAL-12-alteplase-mRS3-6"/>
+      <display value="Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
       <valueString value="Effect of Alteplase vs No alteplase on mRS 3-6 at 90 days in Stroke 0-3 hours prior"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
@@ -50,18 +62,6 @@
     <item>
       <reference value="Evidence/example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2"/>
       <display value="Effect of Alteplase vs No alteplase on mRS 0-2 at 90 days in Stroke 3-4.5 hours prior"/>
-    </item>
-  </entry>
-  <entry>
-    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
-      <valueString value="Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12"/>
-    </extension>
-    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
-      <valueString value="evidence-example-ASTRAL-12-alteplase-mRS3-6"/>
-    </extension>
-    <item>
-      <reference value="Evidence/example-ASTRAL-12-alteplase-mRS3-6"/>
-      <display value="Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12"/>
     </item>
   </entry>
 </List>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -533,9 +533,28 @@
 		</element>
 		<element id="Evidence.variableDefinition.variableRole">
 			<path value="Evidence.variableDefinition.variableRole"/>
-			<short value="population | subpopulation | exposure | referenceExposure | measuredVariable | confounder"/>
-			<definition value="population | subpopulation | exposure | referenceExposure | measuredVariable | confounder."/>
+			<short value="population | exposure | outcome | covariate"/>
+			<definition value="Classification of the role of the variable."/>
 			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="code"/>
+			</type>
+			<isSummary value="true"/>
+			<binding>
+				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+					<valueString value="EvidenceVariableRole"/>
+				</extension>
+				<strength value="required"/>
+				<description value="The role that the variable plays."/>
+				<valueSet value="http://hl7.org/fhir/ValueSet/variable-role"/>
+			</binding>
+		</element>
+		<element id="Evidence.variableDefinition.roleSubtype">
+			<path value="Evidence.variableDefinition.roleSubtype"/>
+			<short value="subgroup | variable-A | variable-B | variable-AB | confounder | collider | mediator | effect-modifier"/>
+			<definition value="Sub-classification of the role of the variable."/>
+			<min value="0"/>
 			<max value="1"/>
 			<type>
 				<code value="CodeableConcept"/>
@@ -543,11 +562,11 @@
 			<isSummary value="true"/>
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-					<valueString value="EvidenceVariableRole"/>
+					<valueString value="EvidenceVariableRoleSubtype"/>
 				</extension>
 				<strength value="extensible"/>
-				<description value="The role that the assertion variable plays."/>
-				<valueSet value="http://hl7.org/fhir/ValueSet/variable-role"/>
+				<description value="The sub-role that the variable plays."/>
+				<valueSet value="http://hl7.org/fhir/ValueSet/variable-role-subtype"/>
 			</binding>
 		</element>
 		<element id="Evidence.variableDefinition.comparatorCategory">

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -550,6 +550,17 @@
 				<valueSet value="http://hl7.org/fhir/ValueSet/variable-role"/>
 			</binding>
 		</element>
+		<element id="Evidence.variableDefinition.comparatorCategory">
+			<path value="Evidence.variableDefinition.comparatorCategory"/>
+			<short value="The reference value used for comparison"/>
+			<definition value="The reference value used for comparison."/>
+			<comment value="Value should match EvidenceVariable.category.name in the EvidenceVariable referenced in the observed or intended element."/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+		</element>
 		<element id="Evidence.variableDefinition.observed">
 			<path value="Evidence.variableDefinition.observed"/>
 			<short value="Definition of the actual variable related to the statistic(s)"/>

--- a/source/evidence/valueset-variable-role-subtype.xml
+++ b/source/evidence/valueset-variable-role-subtype.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="variable-role"/>
+  <id value="variable-role-subtype"/>
   <meta>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
@@ -14,14 +14,10 @@
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="1"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/variable-role"/>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.3.3048"/>
-  </identifier>
+  <url value="http://hl7.org/fhir/ValueSet/variable-role-subtype"/>
   <version value="6.0.0"/>
-  <name value="EvidenceVariableRole"/>
-  <title value="Evidence Variable Role"/>
+  <name value="EvidenceVariableRoleSubtype"/>
+  <title value="Evidence Variable Role Subtype"/>
   <status value="draft"/>
   <experimental value="false"/>
   <date value="2020-12-28T16:55:11+11:00"/>
@@ -36,11 +32,11 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="The role that the variable plays."/>
+  <description value="The sub-role that the variable plays."/>
   <immutable value="true"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/variable-role"/>
+      <system value="http://terminology.hl7.org/CodeSystem/variable-role"/>
     </include>
   </compose>
 </ValueSet>

--- a/source/evidencevariable/evidencevariable-example-alteplase-for-stroke.xml
+++ b/source/evidencevariable/evidencevariable-example-alteplase-for-stroke.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<EvidenceVariable xmlns="http://hl7.org/fhir">
+  <id value="example-alteplase-for-stroke"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>
+        &quot;Alteplase for Stroke&quot; is an exposure concept with a detailed dosing instruction that may be used in expressing what an Evidence is about.
+      </p>
+	
+    </div>
+  </text>
+  <contained>
+	<Group>
+		<id value="Definition-Group"/>
+		<title value="VariableDefinition: Alteplase for Stroke"/>
+		<membership value="conceptual"/>
+		<characteristic>
+			<code>
+				<text value="Defined by Reference"/>
+			</code>
+			<valueUri value="http://example.org/fhir/ActivityDefinition/example-alteplase-dosing"/>
+			<exclude value="false"/>
+			<description value="IV alteplase 0.9 mg/kg (maximum 90 mg) as 10% of dose over 1 minute and 90% over 1 hour"/>
+		</characteristic>
+	</Group>
+  </contained>
+  <name value="AlteplaseForStroke"/>
+  <title value="Alteplase for Stroke"/>
+  <status value="draft"/>
+  <description value="Alteplase for Stroke"/>
+  <actual value="false"/>
+  <definition>
+	<reference>
+		<reference value="#Definition-Group"/>
+	</reference>
+  </definition>
+  <handling value="dichotomous"/>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
+++ b/source/evidencevariable/evidencevariable-example-dead-or-dependent-90day.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <EvidenceVariable xmlns="http://hl7.org/fhir">
-  <id value="example-alive-independent-90day"/>
+  <id value="example-dead-or-dependent-90day"/>
   <text>
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       
       <p>
-        &quot;Alive and not functionally dependent at 90 days&quot; is an outcome used in expressing what an Evidence is about.
+        &quot;Dead or functionally dependent at 90 days&quot; is an outcome used in expressing what an Evidence is about.
       </p>
 	
     </div>
@@ -18,7 +18,7 @@
 		<title value="VariableDefinition: Alive and not functionally dependent at 90 days"/>
 		<type value="person"/>
 		<membership value="definitional"/>
-		<combinationMethod value="all-of"/>
+		<combinationMethod value="any-of"/>
 		<characteristic>
 			<code>
 				<coding>
@@ -34,8 +34,8 @@
 					<display value="Dead (finding)"/>
 				</coding>
 			</valueCodeableConcept>
-			<exclude value="true"/>
-			<description value="alive at 90 days (excluding dead at 90 days)"/>
+			<exclude value="false"/>
+			<description value="dead at 90 days"/>
 			<timing>
 				<contextCode>
 					<coding>
@@ -67,8 +67,8 @@
 					<display value="Functionally dependent (finding)"/>
 				</coding>
 			</valueCodeableConcept>
-			<exclude value="true"/>
-			<description value="not functionally dependent at 90 days (excluding functionally dependent at 90 days)"/>
+			<exclude value="false"/>
+			<description value="functionally dependent at 90 days"/>
 			<timing>
 				<contextCode>
 					<coding>
@@ -87,10 +87,10 @@
 		</characteristic>
 	</Group>
   </contained>
-  <name value="AliveAndNotFunctionallyDependentAt90Days"/>
-  <title value="Alive and not functionally dependent at 90 days"/>
+  <name value="DeadOrFunctionallyDependentAt90Days"/>
+  <title value="Dead or functionally dependent at 90 days"/>
   <status value="draft"/>
-  <description value="Alive and not functionally dependent at 90 days"/>
+  <description value="Dead or functionally dependent at 90 days"/>
   <actual value="false"/>
   <definition>
 	<reference>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <EvidenceVariable xmlns="http://hl7.org/fhir">
-  <id value="example-alive-independent-90day"/>
+  <id value="example-fatal-ICH-in-7-days"/>
   <text>
     <status value="generated"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       
       <p>
-        &quot;Alive and not functionally dependent at 90 days&quot; is an outcome used in expressing what an Evidence is about.
+        &quot;Fatal Intracranial Hemorrhage Within Seven Days&quot; is an outcome used in expressing what an Evidence is about.
       </p>
 	
     </div>
@@ -15,10 +15,10 @@
   <contained>
 	<Group>
 		<id value="Definition-Group"/>
-		<title value="VariableDefinition: Alive and not functionally dependent at 90 days"/>
+		<title value="VariableDefinition: Fatal Intracranial Hemorrhage Within Seven Days"/>
 		<type value="person"/>
 		<membership value="definitional"/>
-		<combinationMethod value="all-of"/>
+		<combinationMethod value="any-of"/>
 		<characteristic>
 			<code>
 				<coding>
@@ -30,12 +30,12 @@
 			<valueCodeableConcept>
 				<coding>
 					<system value="http://snomed.info/sct"/>
-					<code value="419099009"/>
-					<display value="Dead (finding)"/>
+					<code value="1386000"/>
+					<display value="Intracranial hemorrhage (disorder)"/>
 				</coding>
 			</valueCodeableConcept>
-			<exclude value="true"/>
-			<description value="alive at 90 days (excluding dead at 90 days)"/>
+			<exclude value="false"/>
+			<description value="intracranial hemorrhage within 7 days"/>
 			<timing>
 				<contextCode>
 					<coding>
@@ -45,7 +45,7 @@
 					</coding>
 				</contextCode>
 				<offsetDuration>
-					<value value="90"/>
+					<value value="7"/>
 					<unit value="days"/>
 					<system value="http://unitsofmeasure.org"/>
 					<code value="d"/>
@@ -63,12 +63,12 @@
 			<valueCodeableConcept>
 				<coding>
 					<system value="http://snomed.info/sct"/>
-					<code value="718705001"/>
-					<display value="Functionally dependent (finding)"/>
+					 <code value="419620001"/>
+					<display value="Death (event)"/>
 				</coding>
 			</valueCodeableConcept>
 			<exclude value="true"/>
-			<description value="not functionally dependent at 90 days (excluding functionally dependent at 90 days)"/>
+			<description value="death within 7 days"/>
 			<timing>
 				<contextCode>
 					<coding>
@@ -78,7 +78,7 @@
 					</coding>
 				</contextCode>
 				<offsetDuration>
-					<value value="90"/>
+					<value value="7"/>
 					<unit value="days"/>
 					<system value="http://unitsofmeasure.org"/>
 					<code value="d"/>
@@ -87,11 +87,14 @@
 		</characteristic>
 	</Group>
   </contained>
-  <name value="AliveAndNotFunctionallyDependentAt90Days"/>
-  <title value="Alive and not functionally dependent at 90 days"/>
+  <name value="FatalIntracranialHemorrhageWithinSevenDays"/>
+  <title value="Fatal Intracranial Hemorrhage Within Seven Days"/>
   <status value="draft"/>
-  <description value="Alive and not functionally dependent at 90 days"/>
-  <actual value="false"/>
+  <description value="Fatal Intracranial Hemorrhage Within Seven Days"/>
+  <note>
+    <text value="Death must be due to intracranial hemorrhage"/>
+  </note>
+  <actual value="true"/>
   <definition>
 	<reference>
 		<reference value="#Definition-Group"/>

--- a/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
+++ b/source/evidencevariable/evidencevariable-example-fatal-ICH-in-7-days.xml
@@ -14,11 +14,10 @@
   </text>
   <contained>
 	<Group>
-		<id value="Definition-Group"/>
-		<title value="VariableDefinition: Fatal Intracranial Hemorrhage Within Seven Days"/>
-		<type value="person"/>
-		<membership value="definitional"/>
-		<combinationMethod value="any-of"/>
+		<id value="Cohort-Definition"/>
+		<title value="CohortDefinition: Fatal Intracranial Hemorrhage"/>
+		<membership value="conceptual"/>
+		<combinationMethod value="all-of"/>
 		<characteristic>
 			<code>
 				<coding>
@@ -35,30 +34,11 @@
 				</coding>
 			</valueCodeableConcept>
 			<exclude value="false"/>
-			<description value="intracranial hemorrhage within 7 days"/>
-			<timing>
-				<contextCode>
-					<coding>
-						<system value="http://hl7.org/fhir/evidence-variable-event"/>
-						<code value="study-start"/>
-						<display value="Study Start"/>
-					</coding>
-				</contextCode>
-				<offsetDuration>
-					<value value="7"/>
-					<unit value="days"/>
-					<system value="http://unitsofmeasure.org"/>
-					<code value="d"/>
-				</offsetDuration>
-			</timing>
+			<description value="intracranial hemorrhage"/>
 		</characteristic>
 		<characteristic>
 			<code>
-				<coding>
-					<system value="http://snomed.info/sct"/>
-					<code value="260905004"/>
-					<display value="Condition"/>
-				</coding>
+				<text value="resulting in"/>
 			</code>
 			<valueCodeableConcept>
 				<coding>
@@ -67,8 +47,30 @@
 					<display value="Death (event)"/>
 				</coding>
 			</valueCodeableConcept>
-			<exclude value="true"/>
-			<description value="death within 7 days"/>
+			<exclude value="false"/>
+			<description value="resulting in death"/>
+		</characteristic>
+	</Group>
+  </contained>
+  <contained>
+	<Group>
+		<id value="Definition-Group"/>
+		<title value="VariableDefinition: Fatal Intracranial Hemorrhage Within Seven Days"/>
+		<type value="person"/>
+		<membership value="definitional"/>
+		<characteristic>
+			<code>
+				<coding>
+					<system value="http://snomed.info/sct"/>
+					<code value="260905004"/>
+					<display value="Condition"/>
+				</coding>
+			</code>
+			<valueReference>
+				<reference value="#Cohort-Definition"/>
+			</valueReference>
+			<exclude value="false"/>
+			<description value="fatal intracranial hemorrhage within 7 days"/>
 			<timing>
 				<contextCode>
 					<coding>
@@ -91,9 +93,6 @@
   <title value="Fatal Intracranial Hemorrhage Within Seven Days"/>
   <status value="draft"/>
   <description value="Fatal Intracranial Hemorrhage Within Seven Days"/>
-  <note>
-    <text value="Death must be due to intracranial hemorrhage"/>
-  </note>
   <actual value="true"/>
   <definition>
 	<reference>

--- a/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS0-2-at-90days.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<EvidenceVariable xmlns="http://hl7.org/fhir">
+  <id value="example-mRS0-2-at-90days"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>
+        &quot;mRS 0-2 at 90 days&quot; is an outcome, defined by a CQL expression, used in expressing what an Evidence is about.
+      </p>
+	
+    </div>
+  </text>
+  <contained>
+	<Group>
+		<id value="Definition-Group"/>
+		<title value="VariableDefinition: mRS 0-2 at 90 days"/>
+		<type value="person"/>
+		<membership value="definitional"/>
+		<characteristic>
+   		  <code>
+   		    <coding>
+   		      <system value="http://snomed.info/sct"/>
+   		      <code value="260905004"/>
+   		      <display value="Condition"/>
+   		    </coding>
+   		  </code>
+   		  <valueExpression>
+   		    <description value="mRS 0-2"/>
+  		    <language value="text/cql"/>
+   		    <expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 0 and 2"/>
+  		  </valueExpression>
+  		  <exclude value="false"/>
+   		  <description value="mRS 0-2 at 90 days"/>
+   		  <timing>
+   		    <contextCode>
+   		      <coding>
+   		        <system value="http://hl7.org/fhir/evidence-variable-event"/>
+   		        <code value="study-start"/>
+   		        <display value="Study Start"/>
+   		      </coding>
+   		    </contextCode>
+   		    <offsetDuration>
+   		      <value value="90"/>
+   		      <unit value="days"/>
+   		      <system value="http://unitsofmeasure.org"/>
+   		      <code value="d"/>
+   		    </offsetDuration>
+   		  </timing>
+		</characteristic>
+	</Group>
+  </contained>
+  <name value="ModifiedRankinScaleScore02At90DaysAfterTreatment"/>
+  <title value="Modified Rankin Scale score 0-2 at 90 days after treatment"/>
+  <status value="draft"/>
+  <description value="Modified Rankin Scale score 0-2 at 90 days after treatment"/>
+  <actual value="true"/>
+    <definition>
+	<reference>
+		<reference value="#Definition-Group"/>
+	</reference>
+  </definition>
+  <handling value="dichotomous"/>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<EvidenceVariable xmlns="http://hl7.org/fhir">
+  <id value="example-mRS3-6-at-90days"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>
+        &quot;mRS 3-6 at 90 days&quot; is an outcome, defined by a CQL expression, used in expressing what an Evidence is about.
+      </p>
+	
+    </div>
+  </text>
+  <contained>
+	<Group>
+		<id value="Definition-Group"/>
+		<title value="VariableDefinition: mRS 3-6 at 90 days"/>
+		<type value="person"/>
+		<membership value="definitional"/>
+		<characteristic>
+   		  <code>
+   		    <coding>
+   		      <system value="http://snomed.info/sct"/>
+   		      <code value="260905004"/>
+   		      <display value="Condition"/>
+   		    </coding>
+   		  </code>
+   		  <valueExpression>
+   		    <description value="mRS 3-6"/>
+  		    <language value="text/cql"/>
+   		    <expression value="[&quot;Observation&quot;: code in &quot;75859-9|LOINC&quot;] mRS where mRS.value between 3 and 6"/>
+  		  </valueExpression>
+  		  <exclude value="false"/>
+   		  <description value="mRS 3-6 at 90 days"/>
+   		  <timing>
+   		    <contextCode>
+   		      <coding>
+   		        <system value="http://hl7.org/fhir/evidence-variable-event"/>
+   		        <code value="study-start"/>
+   		        <display value="Study Start"/>
+   		      </coding>
+   		    </contextCode>
+   		    <offsetDuration>
+   		      <value value="90"/>
+   		      <unit value="days"/>
+   		      <system value="http://unitsofmeasure.org"/>
+   		      <code value="d"/>
+   		    </offsetDuration>
+   		  </timing>
+		</characteristic>
+	</Group>
+  </contained>
+  <name value="ModifiedRankinScaleScore36At90DaysAfterTreatment"/>
+  <title value="Modified Rankin Scale score 3-6 at 90 days after treatment"/>
+  <status value="draft"/>
+  <description value="Modified Rankin Scale score 3-6 at 90 days after treatment"/>
+  <actual value="true"/>
+    <definition>
+	<reference>
+		<reference value="#Definition-Group"/>
+	</reference>
+  </definition>
+  <handling value="dichotomous"/>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
+++ b/source/evidencevariable/evidencevariable-example-mRS3-6-at-90days.xml
@@ -57,9 +57,9 @@
   <description value="Modified Rankin Scale score 3-6 at 90 days after treatment"/>
   <actual value="true"/>
     <definition>
-	<reference>
+	  <reference>
 		<reference value="#Definition-Group"/>
-	</reference>
-  </definition>
+	  </reference>
+    </definition>
   <handling value="dichotomous"/>
 </EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-no-alteplase.xml
+++ b/source/evidencevariable/evidencevariable-example-no-alteplase.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<EvidenceVariable xmlns="http://hl7.org/fhir">
+  <id value="example-no-alteplase"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      
+      <p>
+        &quot;No alteplase&quot; is an intended exposure concept that may be used in expressing what an Evidence is about.
+      </p>
+	
+    </div>
+  </text>
+  <contained>
+	<Group>
+		<id value="Definition-Group"/>
+		<title value="VariableDefinition: No alteplase"/>
+		<membership value="conceptual"/>
+		<characteristic>
+			<code>
+				<text value="Defined by CodeableConcept"/>
+			</code>
+			<valueCodeableConcept>
+				<coding>
+					<system value="http://www.nlm.nih.gov/research/umls/rxnorm"/>
+					<code value="8410"/>
+					<display value="alteplase"/>
+				</coding>
+			</valueCodeableConcept>
+			<exclude value="true"/>
+			<description value="No alteplase"/>
+		</characteristic>
+	</Group>
+  </contained>
+  <name value="NoAlteplase"/>
+  <title value="No Alteplase"/>
+  <status value="draft"/>
+  <description value="no alteplase"/>
+  <actual value="false"/>
+  <definition>
+	<reference>
+		<reference value="#Definition-Group"/>
+	</reference>
+  </definition>
+  <handling value="dichotomous"/>
+</EvidenceVariable>

--- a/source/evidencevariable/evidencevariable-example-placebo.xml
+++ b/source/evidencevariable/evidencevariable-example-placebo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<EvidenceVariable xmlns="http://hl7.org/fhir">
+  <id value="example-placebo"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+		
+      <p>
+			In a study of response rates if placebo is given, &quot;placcebo given&quot; may be the variable for the exposure of interest.
+      </p>
+	
+    </div>
+  </text>
+  <name value="Placebo"/>
+  <title value="Placebo"/>
+  <status value="draft"/>
+  <description value="Placebo"/>
+  <actual value="true"/>
+  <definition>
+	<concept>
+	  <coding>
+	    <system value="http://snomed.info/sct"/>
+	    <code value="182886004"/>
+	    <display value="Placebo given (situation)"/>
+	  </coding>
+	</concept>
+  </definition>
+  <handling value="dichotomous"/>
+</EvidenceVariable>

--- a/source/evidencevariable/list-EvidenceVariable-examples.xml
+++ b/source/evidencevariable/list-EvidenceVariable-examples.xml
@@ -16,4 +16,88 @@
       <display value="Alive and not functionally dependent 90 days"/>
     </item>
   </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Alteplase for Stroke"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-alteplase-for-stroke"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-alteplase-for-stroke"/>
+      <display value="Alteplase for Stroke"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="No Alteplase"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-no-alteplase"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-no-alteplase"/>
+      <display value="No Alteplase"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Placebo"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-placebo"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-placebo"/>
+      <display value="Placebo"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Fatal Intracranial Hemorrhage Within Seven Days"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-fatal-ICH-in-7-days"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-fatal-ICH-in-7-days"/>
+      <display value="Fatal Intracranial Hemorrhage Within Seven Days"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Dead or functionally dependent at 90 days"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-dead-or-dependent-90day"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-dead-or-dependent-90day"/>
+      <display value="Dead or functionally dependent at 90 days"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Modified Rankin Scale score 0-2 at 90 days after treatment"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-mRS0-2-at-90days"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-mRS0-2-at-90days"/>
+      <display value="Modified Rankin Scale score 0-2 at 90 days after treatment"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Modified Rankin Scale score 3-6 at 90 days after treatment"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="evidencevariable-example-mRS3-6-at-90days"/>
+    </extension>
+    <item>
+      <reference value="EvidenceVariable/example-mRS3-6-at-90days"/>
+      <display value="Modified Rankin Scale score 3-6 at 90 days after treatment"/>
+    </item>
+  </entry>
 </List>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../../schema/fhir-single.xsd">
 	<id value="EvidenceVariable"/>
 	<meta>
-		<lastUpdated value="2021-01-05T10:01:24.148+11:00"/>
+		<lastUpdated value="2023-11-08T10:01:24.148+11:00"/>
 	</meta>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-category">
 		<valueString value="Specialized.Evidence-Based Medicine"/>
@@ -562,6 +562,10 @@
 			</type>
 			<type>
 				<code value="Range"/>
+			</type>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
 			</type>
 		</element>
 	</differential>

--- a/source/group/group-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
+++ b/source/group/group-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Group xmlns="http://hl7.org/fhir">
+  <id value="example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+		  
+      <p>
+			Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis
+	  </p>
+		
+    </div>
+  </text>
+  <name value="StrokeThrombolysisTrialists20142016IPDMACohort"/>
+  <title value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+  <status value="draft"/>
+  <description value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+  <type value="person"/>
+  <membership value="enumerated"/>
+  <member>
+	<entity>
+          <reference value="Group/ECASSIII-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="ECASS III Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/IST3-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="IST3 Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/ECASS-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="ECASS Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/ECASSII-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="ECASSII Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/EPITHET-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="EPITHET Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/ATLANTIS-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="ATLANTIS Trial Cohort"/>
+	</entity>
+  </member>
+  <member>
+	<entity>
+          <reference value="Group/NINDS-Trial-Cohort"/>
+          <type value="Group"/>
+          <display value="NINDS Trial Cohort"/>
+	</entity>
+  </member>
+</Group>

--- a/source/group/list-Group-examples.xml
+++ b/source/group/list-Group-examples.xml
@@ -52,4 +52,16 @@
       <display value="Patient List"/>
     </item>
   </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="group-example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
+    </extension>
+    <item>
+      <reference value="Group/example-Stroke-Thrombolysis-Trialists-2014-2016-IPD-MA-Cohort"/>
+      <display value="Stroke Thrombolysis Trialists’ Collaborators Group collection used for individual patient data meta-analysis"/>
+    </item>
+  </entry>
 </List>


### PR DESCRIPTION
J# 43056 work in progress, added Evidence.variableDefinition elements: variableRole, roleSubtype, comparatorCategory
J# 43057 EvidenceVariable.category.value[x] now has Reference(Group)