### PR TITLE
Fixes to DocumentReference

### DIFF
--- a/source/documentreference/documentreference-event-mapping-exceptions.xml
+++ b/source/documentreference/documentreference-event-mapping-exceptions.xml
@@ -111,7 +111,7 @@
             <_pattern value="When document reference was first captured in the subject's record"/>
             <resource value="When this document reference was created"/>
         </shortUnmatched>
-        <definitionUnmatched reason="may not be known">
+        <definitionUnmatched reason="might not be known">
             <_pattern value="The date the occurrence of the document reference was first captured in the record - potentially significantly after the occurrence of the event."/>
             <resource value="When the document reference was created."/>
         </definitionUnmatched>

--- a/source/documentreference/documentreference-event-mapping-exceptions.xml
+++ b/source/documentreference/documentreference-event-mapping-exceptions.xml
@@ -2,152 +2,138 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../tools/schema/mappingExceptions.xsd">
     <!--For information on the contents of this file and how to properly update it, see https://confluence.hl7.org/display/FHIR/Mapping+to+Patterns.-->
     <divergentElement patternPath="Event.identifier" resourcePath="DocumentReference.identifier">
-        <shortUnmatched reason="Unknown">
+        <shortUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="Business identifier for document reference"/>
             <resource value="Business identifiers for the document"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="Business identifiers assigned to this document reference by the performer and/or other systems.  These identifiers remain constant as the resource is updated and propagates from server to server."/>
-            <resource value="Other business identifiers associated with the document, including version independent identifiers."/>
-        </definitionUnmatched>
-        <commentsUnmatched reason="Unknown">
+        <commentsUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="Note: This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number."/>
             <resource value="The structure and format of this identifier would be consistent with the specification corresponding to the format of the document. (e.g. for a DICOM standard document, a 64-character numeric UID; for an HL7 CDA format, the CDA Document Id root and extension)."/>
         </commentsUnmatched>
-        <requirementsUnmatched reason="Unknown">
+        <requirementsUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="Allows identification of the document reference as it is known by various participating systems and in a way that remains consistent across servers."/>
             <resource value="Document identifiers usually assigned by the source of the document, or other business identifiers such as XDS DocumentEntry.uniqueId and DocumentEntry.entryUUID. These identifiers are specific to this instance of the document."/>
         </requirementsUnmatched>
     </divergentElement>
+    <divergentElement patternPath="Event.basedOn" resourcePath="DocumentReference.basedOn">
+        <missingTypes _pattern="Reference(Request)" reason="More specific to the use-case for this resource"/>
+        <extraTypes
+            _resource="Reference(Appointment,AppointmentResponse,CarePlan,Claim,CommunicationRequest,Contract,CoverageEligibilityRequest,DeviceRequest,EnrollmentRequest,ImmunizationRecommendation,MedicationRequest,NutritionOrder,RequestOrchestration,ServiceRequest,SupplyRequest,VisionPrescription)" reason="More specific to the use-case for this resource"/>
+        <summary _pattern="true" _resource="false" reason="More specific to the use-case for this resource"/>
+        <shortUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="Fulfills plan, proposal or order"/>
+            <resource value="Procedure that caused this media to be created"/>
+        </shortUnmatched>
+        <definitionUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="A plan, proposal or order that is fulfilled in whole or in part by this document reference."/>
+            <resource value="A procedure that is fulfilled in whole or in part by the creation of this media."/>
+        </definitionUnmatched>
+        <requirementsUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="Allows tracing of authorization for the document reference and tracking whether proposals/recommendations were acted upon."/>
+            <resource value="Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon."/>
+        </requirementsUnmatched>
+    </divergentElement>
     <divergentElement patternPath="Event.status" resourcePath="DocumentReference.status">
-        <shortUnmatched reason="Unknown">
+        <shortUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="preparation | in-progress | not-done | suspended | aborted | completed | entered-in-error | unknown"/>
             <resource value="current | superseded | entered-in-error"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="The current state of the document reference."/>
-            <resource value="The status of this document reference."/>
-        </definitionUnmatched>
-        <commentsUnmatched reason="Unknown">
+        <commentsUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="A nominal state-transition diagram can be found in the (Event pattern documentation&#xa;&#xa;Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
             <resource value="This is the status of the DocumentReference object, which might be independent from the docStatus element.&#xa;&#xa;This element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid."/>
         </commentsUnmatched>
     </divergentElement>
+    <divergentElement patternPath="Event.category" resourcePath="DocumentReference.category">
+        <bindingExistence _pattern="false" _resource="true" reason="More specific to the broad use-case for this resource"/>
+        <shortUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="High level categorization of document reference"/>
+            <resource value="Categorization of document"/>
+        </shortUnmatched>
+        <definitionUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="Partitions the document reference into one or more categories that can be used to filter searching, to govern access control and/or to guide system behavior."/>
+            <resource value="A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type."/>
+        </definitionUnmatched>
+        <commentsUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="Categorization might be done automatically (inferred by code) or manually by user assertion.  The absence of a category may limit the ability to determine when the element should be handled, so strong consideration should be given to how systems will be able to determine category values for legacy data and how data that cannot be categorized will be handled.  As well, some categories might not be mutually exclusive, so systems should prepare for multiple declared categories - even within a single category 'axis'.&#xa;In general, there should not be a 'strong' binding ('required' or 'extensible') on the category element overall.  Instead, the element can be sliced and bindings can be asserted that apply to particular repetitions."/>
+            <resource value="Key metadata element describing the the category or classification of the document. This is a broader perspective that groups similar documents based on how they would be used. This is a primary key used in searching."/>
+        </commentsUnmatched>
+    </divergentElement>
     <divergentElement patternPath="Event.code" resourcePath="DocumentReference.type">
-        <shortUnmatched reason="Unknown">
+        <shortUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="What service was done"/>
             <resource value="Kind of document (LOINC if possible)"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
+        <definitionUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="A code that identifies the specific service or action that was or is being performed."/>
             <resource value="Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced."/>
         </definitionUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.subject" resourcePath="DocumentReference.subject">
-        <lowerCardinality _pattern="1" _resource="0" reason="Unknown"/>
-        <missingTypes _pattern="Reference(Patient,Group)" reason="Unknown"/>
-        <extraTypes _resource="Reference(Resource)" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
+        <lowerCardinality _pattern="1" _resource="0" reason="More specific to the use-case for this resource"/>
+        <missingTypes _pattern="Reference(Patient,Group)" reason="More specific to the use-case for this resource"/>
+        <extraTypes _resource="Reference(Resource)" reason="More specific to the use-case for this resource"/>
+        <shortUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="Individual service was done for/to"/>
             <resource value="Who/what is the subject of the document"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
+        <definitionUnmatched reason="More specific to the use-case for this resource">
             <_pattern value="The individual or set of individuals the action is being or was performed on."/>
             <resource value="Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure)."/>
         </definitionUnmatched>
-        <requirementsUnmatched reason="Unknown">
+        <requirementsUnmatched reason="Too specific for this resource">
             <_pattern value="Links the document reference to the Patient context.  May also affect access control."/>
             <resource value=""/>
         </requirementsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.encounter" resourcePath="DocumentReference.context">
-        <upperCardinality _pattern="1" _resource="*" reason="Unknown"/>
-        <extraTypes _resource="Reference(Appointment,EpisodeOfCare)" reason="Unknown"/>
-        <summary _pattern="true" _resource="false" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
-            <_pattern value="Encounter the document reference is part of"/>
-            <resource value="Context of the document content"/>
+        <upperCardinality _pattern="1" _resource="*" reason="More flexible"/>
+        <extraTypes _resource="Reference(Appointment,EpisodeOfCare)" reason="More broad"/>
+    </divergentElement>
+    <divergentElement patternPath="Event.occurrence[x]" resourcePath="DocumentReference.period">
+        <missingTypes _pattern="dateTime, Timing" reason="recorded elsewhere"/>
+        <shortUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="When document reference occurred/is occurring"/>
+            <resource value="Time of service that is being documented"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="The Encounter during which this document reference was created or to which the creation of this record is tightly associated."/>
-            <resource value="Describes the clinical encounter or type of care that the document content is associated with."/>
+        <definitionUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="The date, period or timing when the document reference did occur or is occurring."/>
+            <resource value="The time period over which the service that is described by the document was provided."/>
         </definitionUnmatched>
-        <commentsUnmatched reason="Unknown">
-            <_pattern value="This will typically be the encounter the document reference was created during, but some document references may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission lab tests)."/>
+        <commentsUnmatched reason="More specific to the use-case for this resource">
+            <_pattern value="This indicates when the activity actually occurred or is occurring, not when it was asked/requested/ordered to occur.  For the latter, look at the occurence element of the  Request this {{event}} is &quot;basedOn&quot;.  The status code allows differentiation of whether the timing reflects a historic event or an ongoing event.  Ongoing events should not include an upper bound in the Period or Timing.bounds.&#xa;."/>
             <resource value=""/>
         </commentsUnmatched>
-        <requirementsUnmatched reason="Unknown">
-            <_pattern value="Links the document reference to the Encounter context.  May also affect access control."/>
-            <resource value=""/>
-        </requirementsUnmatched>
     </divergentElement>
-    <divergentElement patternPath="Event.occurrence[x]" resourcePath="DocumentReference.date">
-        <missingTypes _pattern="dateTime, Period, Timing" reason="Unknown"/>
-        <extraTypes _resource="instant" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
-            <_pattern value="When document reference occurred/is occurring"/>
+    <divergentElement patternPath="Event.recorded" resourcePath="DocumentReference.date">
+        <missingTypes _pattern="dateTime" reason="recorded elswhere"/>
+        <extraTypes _resource="instant" reason="recorded elsewhere"/>
+        <shortUnmatched reason="More specific to this resource">
+            <_pattern value="When document reference was first captured in the subject's record"/>
             <resource value="When this document reference was created"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="The date, period or timing when the document reference did occur or is occurring."/>
+        <definitionUnmatched reason="may not be known">
+            <_pattern value="The date the occurrence of the document reference was first captured in the record - potentially significantly after the occurrence of the event."/>
             <resource value="When the document reference was created."/>
         </definitionUnmatched>
-        <commentsUnmatched reason="Unknown">
-            <_pattern value="This indicates when the activity actually occurred or is occurring, not when it was asked/requested/ordered to occur.  For the latter, look at the occurence element of the  Request this {{event}} is &quot;basedOn&quot;.  The status code allows differentiation of whether the timing reflects a historic event or an ongoing event.  Ongoing events should not include an upper bound in the Period or Timing.bounds.&#xa;."/>
-            <resource value="Referencing/indexing time is used for tracking, organizing versions and searching."/>
-        </commentsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.performer.actor" resourcePath="DocumentReference.author">
-        <lowerCardinality _pattern="1" _resource="0" reason="Unknown"/>
-        <upperCardinality _pattern="1" _resource="*" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
+        <lowerCardinality _pattern="1" _resource="0" reason="Not always known"/>
+        <upperCardinality _pattern="1" _resource="*" reason="Need more than one to enable broad use."/>
+        <shortUnmatched reason="Not always a who, sometimes a what.">
             <_pattern value="Who performed document reference"/>
             <resource value="Who and/or what authored the document"/>
         </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
+        <definitionUnmatched reason="Not relevant for this resource">
             <_pattern value="Indicates who or what performed the document reference."/>
             <resource value="Identifies who is responsible for adding the information to the document."/>
         </definitionUnmatched>
     </divergentElement>
-    <divergentElement patternPath="Event.performer.actor" resourcePath="DocumentReference.attester">
-        <lowerCardinality _pattern="1" _resource="0" reason="Unknown"/>
-        <upperCardinality _pattern="1" _resource="*" reason="Unknown"/>
-        <missingTypes
-            _pattern="Reference(Practitioner,PractitionerRole,Organization,CareTeam,Patient,Device,RelatedPerson)" reason="Unknown"/>
-        <extraTypes _resource="BackboneElement" reason="Unknown"/>
-        <summary _pattern="true" _resource="false" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
-            <_pattern value="Who performed document reference"/>
-            <resource value="Attests to accuracy of the document"/>
-        </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="Indicates who or what performed the document reference."/>
-            <resource value="A participant who has authenticated the accuracy of the document."/>
-        </definitionUnmatched>
-    </divergentElement>
-    <divergentElement patternPath="Event.performer.actor" resourcePath="DocumentReference.custodian">
-        <lowerCardinality _pattern="1" _resource="0" reason="Unknown"/>
-        <missingTypes
-            _pattern="Reference(Practitioner,PractitionerRole,CareTeam,Patient,Device,RelatedPerson)" reason="Unknown"/>
-        <summary _pattern="true" _resource="false" reason="Unknown"/>
-        <shortUnmatched reason="Unknown">
-            <_pattern value="Who performed document reference"/>
-            <resource value="Organization which maintains the document"/>
-        </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="Indicates who or what performed the document reference."/>
-            <resource value="Identifies the organization or group who is responsible for ongoing maintenance of and access to the document."/>
-        </definitionUnmatched>
-    </divergentElement>
-    <unmappedElement patternPath="Event.partOf" reason="Unknown"/>
-    <unmappedElement patternPath="Event.reported" reason="Unknown"/>
-    <unmappedElement patternPath="Event.reason" reason="Unknown"/>
-    <unmappedElement patternPath="Event.relevantHistory" reason="Unknown"/>
-    <unmappedElement patternPath="Event.performer.function" reason="Unknown"/>
-    <unmappedElement patternPath="Event.note" reason="Unknown"/>
-    <unmappedElement patternPath="Event.category" reason="Unknown"/>
-    <unmappedElement patternPath="Event.recorded" reason="Unknown"/>
-    <unmappedElement patternPath="Event.product" reason="Unknown"/>
-    <unmappedElement patternPath="Event.performer" reason="Unknown"/>
-    <unmappedElement patternPath="Event.basedOn" reason="Unknown"/>
+    <unmappedElement patternPath="Event.partOf" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.reported" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.reason" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.relevantHistory" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.performer.function" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.note" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.product" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="Event.performer" reason="Not relevant for this resource"/>
 </mappingExceptions>

--- a/source/documentreference/documentreference-fivews-mapping-exceptions.xml
+++ b/source/documentreference/documentreference-fivews-mapping-exceptions.xml
@@ -1,24 +1,19 @@
 <mappingExceptions pattern="FiveWs" resource="DocumentReference"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../tools/schema/mappingExceptions.xsd">
     <!--For information on the contents of this file and how to properly update it, see https://confluence.hl7.org/display/FHIR/Mapping+to+Patterns.-->
-    <divergentElement patternPath="FiveWs.status" resourcePath="DocumentReference.docStatus">
-        <modifier _pattern="true" _resource="false" reason="Unknown"/>
-    </divergentElement>
     <divergentElement patternPath="FiveWs.what[x]" resourcePath="DocumentReference.category">
-        <upperCardinality _pattern="1" _resource="*" reason="Unknown"/>
+        <upperCardinality _pattern="1" _resource="*" reason="Need more than one to enable broad use"/>
     </divergentElement>
     <divergentElement patternPath="FiveWs.context" resourcePath="DocumentReference.context">
-        <upperCardinality _pattern="1" _resource="*" reason="Unknown"/>
+        <upperCardinality _pattern="1" _resource="*" reason="Need more than one to enable broad use"/>
     </divergentElement>
-    <unmappedElement patternPath="FiveWs.author" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.actor" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.cause" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.where" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.init" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.why" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.source" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.who" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.grade" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.planned" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.done" reason="Unknown"/>
+    <unmappedElement patternPath="FiveWs.actor" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.cause" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.where" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.init" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.why" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.source" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.who" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.grade" reason="Not relevant for this resource"/>
+    <unmappedElement patternPath="FiveWs.planned" reason="Not relevant for this resource"/>
 </mappingExceptions>

--- a/source/documentreference/documentreference-introduction.xml
+++ b/source/documentreference/documentreference-introduction.xml
@@ -4,13 +4,13 @@
 <a name="scope"></a>
 <h2>Scope and Usage</h2>
 <p>
-A DocumentReference resource is used to index a document, clinical note, and other binary objects such as a photo, video, or audio recording, including those resulting from diagnostic or care provision procedures, to make them available to a healthcare system. A document is some sequence of bytes that is identifiable, establishes its own context (e.g., what subject, author, etc. can be presented to the user), and has defined update management. The DocumentReference resource can be used with any document format that has a recognized mime type and that conforms to this definition.
+A <code>DocumentReference</code> resource is used to index a document, clinical note, and other binary objects such as a photo, video, or audio recording, including those resulting from diagnostic or care provision procedures, to make them available to a healthcare system. A document is some sequence of bytes that is identifiable, establishes its own context (e.g., what subject, author, etc. can be presented to the user), and has defined update management. The <code>DocumentReference</code> resource can be used with any document format that has a recognized mime type and that conforms to this definition.
 </p>
 <p>
-Typically, DocumentReference resources are used in document indexing systems, such as <a href="https://profiles.ihe.net/ITI/TF/Volume1/ch-10.html">IHE XDS</a> and as profiled in <a href="https://profiles.ihe.net/ITI/MHD/">IHE Mobile Access to Health Documents</a>.
+Typically, <code>DocumentReference</code> resources are used in document indexing systems, such as <a href="https://profiles.ihe.net/ITI/TF/Volume1/ch-10.html">IHE XDS</a> and as profiled in <a href="https://profiles.ihe.net/ITI/MHD/">IHE Mobile Access to Health Documents</a>.
 </p>
 <p>
-DocumentReference contains metadata, inline content or direct references to documents such as:</p>
+    <code>DocumentReference</code> contains metadata, inline content or direct references to documents such as:</p>
 <ul>
  <li><a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=7">CDA</a> documents in FHIR systems</li>
  <li><a href="documents.html">FHIR documents</a> stored elsewhere (i.e. registry/repository following the XDS model)</li>
@@ -30,34 +30,34 @@ DocumentReference contains metadata, inline content or direct references to docu
 <p>
 This resource captures data that might not be in FHIR format. The document can be any object (e.g. file), 
 and is not limited to the formal HL7 definitions of <a href="documents.html">Document</a>. This resource may be a report with 
-unstructured text or a report that is not expressed in a DiagnosticReport. The DiagnosticReport is appropriate to reflect a 
+unstructured text or a report that is not expressed in a <a href="diagnosticreport.html">DiagnosticReport</a>. The <a href="diagnosticreport.html">DiagnosticReport</a> is appropriate to reflect a 
 set of discrete results (Observations) and associated contextual details for a specific report, and within those results any 
-further structure within the Observation instances. The DocumentReference resource may be an 
+further structure within the Observation instances. The <code>DocumentReference</code> resource may be an 
 <a href="observation.html">Observation</a> whose value is audio, video or image data. This resource is the preferred 
 representation of such forms of information as it exposes the metadata relevant for interpreting the information.
-There is some overlap potential such as a scan of a CBC report that can either be referenced by way of a DocumentReference, 
-or included in a DiagnosticReport as a presentedForm together with the structured, discrete data.
+There is some overlap potential such as a scan of a CBC report that can either be referenced by way of a <code>DocumentReference</code>, 
+or included in a <a href="diagnosticreport.html">DiagnosticReport</a> as a presentedForm together with the structured, discrete data.
 In some cases, a single in-system entity may be represented as both resources if they provide relevant metadata or workflow-specific attributes. Specific implementation guides would further clarify which approach is more appropriate.
 </p>
 <p>
 This resource is able to contain medical images in a DICOM format. These images may also be made 
-accessible through an <a href="imagingstudy.html">ImagingStudy</a> resource, which provides a direct reference to the image to a 
+accessible through an <a href="imagingstudy.html">ImagingStudy</a> or <a href="imagingselection.html">ImagingSelection</a> resource, which provides a direct reference to the image to a 
 <a href="ftp://medical.nema.org/medical/dicom/final/sup161_ft.pdf">WADO-RS</a> server. For such images, the WADO-RS framework is a preferred method for representing the 
 images - the WADO-RS service may include rendering the image with annotations and display parameters 
-from an associated DICOM presentation state, for instance. On the other hand, the DocumentReference 
+from an associated DICOM presentation state, for instance. On the other hand, the <code>DocumentReference</code> 
 resource allows for a robust transfer of an image across boundaries where the WADO-RS service is 
-not available. For this reason, medical images can also be represented in a DocumentReference resource, 
-but the DocumentReference.content.attachment.url should provide a reference to a source WADO-RS service for the image.
+not available. For this reason, medical images can also be represented in a <code>DocumentReference</code> resource, 
+but the <code>DocumentReference.content.attachment.url</code> should provide a reference to a source WADO-RS service for the image.
 </p>
 <p>
 FHIR defines both a <a href="documents.html">document format</a> and this document reference. FHIR documents are for documents
-that are authored and assembled in FHIR. DocumentReference is intended for general references to any type of media file <em>including</em> assembled documents.
+that are authored and assembled in FHIR. <code>DocumentReference</code> is intended for general references to any type of media file <em>including</em> assembled documents.
 </p>
 <p>
 The document that is a target of the reference can be a reference to a FHIR document served by another server, or
 the target can be stored in the special <a href="http.html#binary">FHIR Binary Resource</a>, or the target can be
 stored on some other server system. The document reference is also able to address documents that are retrieved
-by a service call such as an XDS.b RetrieveDocumentSet, or a DICOM exchange, or an <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=185">HL7 V2</a> message query - though
+by a service call such as an <a href="https://profiles.ihe.net/ITI/TF/Volume1/ch-10.html">XDS.b RetrieveDocumentSet</a>, or a DICOM <a href="ftp://medical.nema.org/medical/dicom/final/sup161_ft.pdf">WADO-RS</a> exchange, or an <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=185">HL7 V2</a> message query - though
 the way each of these service calls works must be specified in some external standard or other documentation.
 </p>
 <p>

--- a/source/documentreference/documentreference-notes.xml
+++ b/source/documentreference/documentreference-notes.xml
@@ -5,8 +5,9 @@
 <ul>
  <li>The resources maintain one way relationships that point backwards - e.g., the document that replaces one document points towards the document that it replaced. The reverse relationships can be followed by using 
   indexes built from the resources. Typically, this is done using the search parameters described below. Given that documents may have other documents that replace or append them, clients should always check these relationships when accessing documents</li>
-  <li>The _content search parameter shall search across the DocumentReference.content.attachment.data, and DocumentReference.content.url.</li>
-  <li>If the referenced resource changes, then the corresponding DocumentRefererence may be out of sync temporarily. Coordination will be needed to ensure that the DocumentReference gets updated if the referenced resource changes (and to not allow updates to the DocumentReference that cause it to be misaligned with the referenced resource).</li>
+  <li>The _content search parameter shall search across the <code>DocumentReference.content.attachment.data</code>, and <code>DocumentReference.content.attachment.url</code>.</li>
+  <li>If the referenced resource changes, then the corresponding <code>DocumentReference</code> may be out of sync temporarily. Coordination will be needed to ensure that the <code>DocumentReference</code> gets updated if the referenced resource changes (and to not allow updates to the <code>DocumentReference</code> that cause it to be misaligned with the referenced resource).</li>
+  <li><code>DocumentReference</code> might be appropriate for including a rendered DICOM image in cases where the full image context is not important. When this is done, the <code>DocumentReference.event.reference</code> should point at the <a href="imagingstudy.html">ImagingStudy</a> or <a href="imagingselection.html">ImagingSelection</a>. </li>
 </ul>
 <!--   No longer needed now that we have format code vocabulary
 <h3>Document Formats</h3>

--- a/source/documentreference/operationdefinition-DocumentReference-docref.xml
+++ b/source/documentreference/operationdefinition-DocumentReference-docref.xml
@@ -34,7 +34,7 @@
     </extension>
   </extension>
   <extension url="http://hl7.org/fhir/build/StructureDefinition/footer">
-    <valueMarkdown value="The server either returns a search result containing a single DocumentReference, &#xA;or it returns an error."/>
+    <valueMarkdown value="The server either returns a search result Bundle containing at least one DocumentReference, &#xA;or it returns an error."/>
   </extension>
   <url value="http://hl7.org/fhir/build/OperationDefinition/DocumentReference-docref"/>
   <version value="5.0.1"/>
@@ -54,7 +54,7 @@
       <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="This operation is used to return all the references to documents related to a patient. &#xA;&#xA; The operation requires a patient id and takes the optional input parameters: &#xA;  - start date&#xA;  - end date&#xA;  - document type &#xA;&#xA; and returns a [Bundle](bundle.html) of type &quot;searchset&quot; containing [DocumentReference](documentreference.html) resources for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. &#xA;&#xA; This operation is *different* from a search by patient and type and date range because: &#xA;&#xA; 1. It is used to request a server to *generate* a document based on the specified parameters. &#xA;&#xA; 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD &#xA;&#xA; 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. &#xA;&#xA; This operation is the *same* as a FHIR RESTful search by patient, type and date range because: &#xA;&#xA; 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter."/>
+  <description value="This operation is used to return all the references to documents related to a patient. &#xA;&#xA; The operation requires a patient id and takes the optional input parameters: &#xA;  - start date&#xA;  - end date&#xA;  - document type &#xA;&#xA;  - on demand &#xA;&#xA;  - profile &#xA;&#xA; and returns a [Bundle](bundle.html) of type &quot;searchset&quot; containing [DocumentReference](documentreference.html) resources for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. &#xA;&#xA; This operation is *different* from a search by patient and type and date range because: &#xA;&#xA; 1. It is used to request a server to *generate* a document based on the specified parameters. &#xA;&#xA; 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current summary &#xA;&#xA; 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. &#xA;&#xA; Unless the client indicates they are only interested in 'on-demand' documents using the on-demand parameter, the server SHOULD return DocumentReference instances for existing documents that meet the request parameters. In this regard, this operation is similar to a FHIR RESTful query."/>
   <affectsState value="true"/>
   <code value="docref"/>
   <comment value="- The server is responsible for determining what resources, if any, to return as [included](search.html#revinclude) resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior. &#xA;&#xA; - The document itself can be subsequently retrieved using the link provided  in the `DocumentReference.content.attachment.url element`. The link could be a FHIR endpoint to a [Binary](binary.html) Resource or some other document repository. &#xA;&#xA; - It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification"/>
@@ -90,7 +90,7 @@
     <use value="in"/>
     <min value="0"/>
     <max value="1"/>
-    <documentation value="The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope"/>
+    <documentation value="	The type relates to document type e.g. C-CDA Clinical Summary of Care (CCD) = LOINC 34133-9: Summary of episode note, and International Patient Summary (IPS) = LOINC 60591-5: Patient summary document.  If no type is provided, the summary document, if available, SHALL be in scope, and all other document types MAY be in scope. It is at the server's discretion how to respond if multiple types are provided. The server MAY return documents to any of the specified types. The server's CapabilityStatement should document its behavior and what types it supports"/>
     <type value="CodeableConcept"/>
     <binding>
       <strength value="required"/>
@@ -104,6 +104,14 @@
     <max value="1"/>
     <documentation value="This on-demand parameter allows client to dictate whether they are requesting only 'on-demand' or both 'on-demand' and 'stable' documents (or delayed/deferred assembly) that meet the query parameters"/>
     <type value="boolean"/>
+  </parameter>
+  <parameter>
+    <name value="profile"/>
+    <use value="in"/>
+    <min value="0"/>
+    <max value="*"/>
+    <documentation value="This parameter allows the client to request documents according to a specific profile using the profile's canonical reference. It is at the server's discretion how to respond if multiple profiles are provided. The server MAY return documents to any of the specified profiles. The server's CapabilityStatement should document its behavior and what profiles it supports."/>
+    <type value="canonical"/>
   </parameter>
   <parameter>
     <name value="return"/>

--- a/source/documentreference/structuredefinition-DocumentReference.xml
+++ b/source/documentreference/structuredefinition-DocumentReference.xml
@@ -138,7 +138,7 @@
     <element id="DocumentReference.identifier">
       <path value="DocumentReference.identifier"/>
       <short value="Business identifiers for the document"/>
-      <definition value="Other business identifiers associated with the document, including version independent identifiers."/>
+      <definition value="Business identifiers assigned to this document reference by the performer and/or other systems.  These identifiers remain constant as the resource is updated and propagates from server to server."/>
       <comment value="The structure and format of this identifier would be consistent with the specification corresponding to the format of the document. (e.g. for a DICOM standard document, a 64-character numeric UID; for an HL7 CDA format, the CDA Document Id root and extension)."/>
       <requirements value="Document identifiers usually assigned by the source of the document, or other business identifiers such as XDS DocumentEntry.uniqueId and DocumentEntry.entryUUID. These identifiers are specific to this instance of the document."/>
       <min value="0"/>
@@ -223,6 +223,10 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/VisionPrescription"/>
       </type>
       <mapping>
+        <identity value="workflow"/>
+        <map value="Event.basedOn"/>
+      </mapping>
+      <mapping>
         <identity value="rim"/>
         <map value=".outboundRelationship[typeCode=FLFS].target"/>
       </mapping>
@@ -234,7 +238,7 @@
     <element id="DocumentReference.status">
       <path value="DocumentReference.status"/>
       <short value="current | superseded | entered-in-error"/>
-      <definition value="The status of this document reference."/>
+      <definition value="The current state of the document reference."/>
       <comment value="This is the status of the DocumentReference object, which might be independent from the docStatus element.&#xA;&#xA;This element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid."/>
       <min value="1"/>
       <max value="1"/>
@@ -289,6 +293,8 @@
       <type>
         <code value="code"/>
       </type>
+      <isModifier value="true"/>
+      <isModifierReason value="This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid"/>
       <isSummary value="true"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -411,6 +417,10 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/referenced-item-category"/>
       </binding>
       <mapping>
+        <identity value="workflow"/>
+        <map value="Event.category"/>
+      </mapping>
+      <mapping>
         <identity value="w5"/>
         <map value="FiveWs.what[x]"/>
       </mapping>
@@ -473,8 +483,10 @@
     </element>
     <element id="DocumentReference.context">
       <path value="DocumentReference.context"/>
-      <short value="Context of the document content"/>
-      <definition value="Describes the clinical encounter or type of care that the document content is associated with."/>
+      <short value="Encounter the document reference is part of"/>
+      <definition value="The Encounter during which this document reference was created or to which the creation of this record is tightly associated."/>
+      <comment value="This will typically be the encounter the document reference was created during, but some document references may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission lab tests)."/>
+      <requirements value="Links the document reference to the Encounter context.  May also affect access control."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -485,6 +497,7 @@
       </type>
       <condition value="docRef-1"/>
       <condition value="docRef-2"/>
+      <isSummary value="true"/>
       <mapping>
         <identity value="workflow"/>
         <map value="Event.encounter"/>
@@ -647,6 +660,14 @@
       </type>
       <isSummary value="true"/>
       <mapping>
+        <identity value="workflow"/>
+        <map value="Event.occurrence[x]"/>
+      </mapping>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.done[x]"/>
+      </mapping>
+      <mapping>
         <identity value="fhircomposition"/>
         <map value="Composition.event.period"/>
       </mapping>
@@ -677,7 +698,7 @@
       <isSummary value="true"/>
       <mapping>
         <identity value="workflow"/>
-        <map value="Event.occurrence[x]"/>
+        <map value="Event.recorded"/>
       </mapping>
       <mapping>
         <identity value="w5"/>
@@ -715,6 +736,10 @@
         <map value="Event.performer.actor"/>
       </mapping>
       <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.author"/>
+      </mapping>
+      <mapping>
         <identity value="fhircomposition"/>
         <map value="Composition.author"/>
       </mapping>
@@ -749,10 +774,6 @@
       <type>
         <code value="BackboneElement"/>
       </type>
-      <mapping>
-        <identity value="workflow"/>
-        <map value="Event.performer.actor"/>
-      </mapping>
       <mapping>
         <identity value="fhircomposition"/>
         <map value="Composition.attester"/>
@@ -871,10 +892,6 @@
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
       </type>
-      <mapping>
-        <identity value="workflow"/>
-        <map value="Event.performer.actor"/>
-      </mapping>
       <mapping>
         <identity value="fhircomposition"/>
         <map value="Composition.custodian"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request

- FHIR-41613
- FHIR-42915
- FHIR-42916
- FHIR-42917

## Description

- cleanup $docref to be less US specific and more correct to the current use
- indicators to relationship to imaging resources
- alignment with FiveWs and Workflow **-exceptions**
