### PR TITLE
J# 43561 new backbone element ResearchSubject.subjectState

### DIFF
--- a/source/researchsubject/bundle-ResearchSubject-search-params.xml
+++ b/source/researchsubject/bundle-ResearchSubject-search-params.xml
@@ -87,13 +87,13 @@
           <valueCode value="trial-use"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="ResearchSubject.progress.subjectProgress"/>
+          <valueString value="ResearchSubject.subjectState.code"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ResearchSubject-state"/>
-        <description value="candidate | eligible | follow-up | ineligible | not-registered | off-study | on-study | on-study-intervention | on-study-observation | pending-on-study | potential-candidate | screening | withdrawn"/>
+        <description value="candidate | in-prescreening | in-screening | eligible | ineligible | on-study | on-study-intervention | in-follow-up | off-study"/>
         <code value="subject_state"/>
         <type value="token"/>
-        <expression value="ResearchSubject.progress.subjectState"/>
+        <expression value="ResearchSubject.subjectState.code"/>
         <processingMode value="normal"/>
       </SearchParameter>
     </resource>

--- a/source/researchsubject/codesystem-research-subject-status.xml
+++ b/source/researchsubject/codesystem-research-subject-status.xml
@@ -49,66 +49,46 @@
   <concept>
     <code value="candidate"/>
     <display value="Candidate"/>
-    <definition value="An identified person that can be considered for inclusion in a study."/>
+    <definition value="A subject (ResearchSubject) potentially eligible for participation in a study (ResearchStudy) who has not completed an evaluation to determine whether they are eligible or ineligible for consideration."/>
+  </concept>
+  <concept>
+    <code value="in-prescreening"/>
+    <display value="In Prescreening"/>
+    <definition value="A subject (ResearchSubject) undergoing an initial evaluation to determine if they are eligible or ineligible for consideration for inclusion in a study (ResearchStudy).A subject (ResearchSubject) potentially eligible for participation in a study (ResearchStudy) who has not completed an evaluation to determine whether they are eligible or ineligible for consideration."/>
+  </concept>
+  <concept>
+    <code value="in-screening"/>
+    <display value="In Screening"/>
+    <definition value="A subject (ResearchSubject) undergoing a full evaluation to determine if they are eligible or ineligible for inclusion in a study (ResearchStudy)."/>
   </concept>
   <concept>
     <code value="eligible"/>
     <display value="Eligible"/>
-    <definition value="A person that has met the eligibility criteria for inclusion in a study."/>
-  </concept>
-  <concept>
-    <code value="follow-up"/>
-    <display value="Follow-up"/>
-    <definition value="A person is no longer receiving study intervention and/or being evaluated with tests and procedures according to the protocol, but they are being monitored on a protocol-prescribed schedule."/>
+    <definition value="A subject (ResearchSubject) who has passed a full evaluation against the protocol specified eligibility criteria to determine if they are eligible or ineligible for inclusion in a study (ResearchStudy)."/>
   </concept>
   <concept>
     <code value="ineligible"/>
     <display value="Ineligible"/>
-    <definition value="A person who did not meet one or more criteria required for participation in a study is considered to have failed screening or&#xA;is ineligible for the study."/>
-  </concept>
-  <concept>
-    <code value="not-registered"/>
-    <display value="Not Registered"/>
-    <definition value="A person for whom registration was not completed."/>
-  </concept>
-  <concept>
-    <code value="off-study"/>
-    <display value="Off-study"/>
-    <definition value="A person that has ended their participation on a study either because their treatment/observation is complete or through not&#xA;responding, withdrawal, non-compliance and/or adverse event."/>
+    <definition value="A subject (ResearchSubject) who has failed an  evaluation against the protocol specified eligibility criteria to determine if they are eligible or ineligible for inclusion in a study (ResearchStudy)."/>
   </concept>
   <concept>
     <code value="on-study"/>
     <display value="On-study"/>
-    <definition value="A person that is enrolled or registered on a study."/>
+    <definition value="A subject (ResearchSubject) who is enrolled in a study (ResearchStudy)."/>
   </concept>
   <concept>
     <code value="on-study-intervention"/>
     <display value="On-study-intervention"/>
-    <definition value="The person is receiving the treatment or participating in an activity (e.g. yoga, diet, etc.) that the study is evaluating."/>
+    <definition value="A subject (ResearchSubject) who is in an intervention phase of a study (ResearchStudy)."/>
   </concept>
   <concept>
-    <code value="on-study-observation"/>
-    <display value="On-study-observation"/>
-    <definition value="The subject is being evaluated via tests and assessments according to the study calendar, but is not receiving any intervention. Note that this state is study-dependent and might not exist in all studies.  A synonym for this is &quot;short-term follow-up&quot;."/>
+    <code value="in-follow-up"/>
+    <display value="In follow-up"/>
+    <definition value="A subject (ResearchSubject) who has completed planned study (ResearchStudy) procedures and tests and is being monitored based on a protocol-prescribed schedule. "/>
   </concept>
   <concept>
-    <code value="pending-on-study"/>
-    <display value="Pending on-study"/>
-    <definition value="A person is pre-registered for a study."/>
-  </concept>
-  <concept>
-    <code value="potential-candidate"/>
-    <display value="Potential Candidate"/>
-    <definition value="A person that is potentially eligible for participation in the study."/>
-  </concept>
-  <concept>
-    <code value="screening"/>
-    <display value="Screening"/>
-    <definition value="A person who is being evaluated for eligibility for a study."/>
-  </concept>
-  <concept>
-    <code value="withdrawn"/>
-    <display value="Withdrawn"/>
-    <definition value="The person has withdrawn their participation in the study before registration."/>
+    <code value="off-study"/>
+    <display value="Off-study"/>
+    <definition value="A subject (ResearchSubject) who is no longer participating in a study (ResearchStudy)."/>
   </concept>
 </CodeSystem>

--- a/source/researchsubject/structuredefinition-ResearchSubject.xml
+++ b/source/researchsubject/structuredefinition-ResearchSubject.xml
@@ -155,133 +155,6 @@
         <map value=".status"/>
       </mapping>
     </element>
-    <element id="ResearchSubject.progress">
-      <path value="ResearchSubject.progress"/>
-      <short value="Subject status"/>
-      <definition value="The current state (status) of the subject and resons for status change where appropriate."/>
-      <comment value="This is intended to deal with the confusion routinely created by haing two conflated concepts of being in a particular state and having achieved a particular milestone.  In strict terms a milestone is a point of time event that results in a change from one state to another.  The state before the milestone is achieved is often given the same name as the milestone, and sometimes the state may have the same description.  For instance &quot;Randomised&quot; and &quot;Visit 1&quot; may be different milestones but the state remains at &quot;on study&quot; after each of them. &#xA;&#xA;It is likely that more than one &quot;state&quot; pattern will be recorded for a subject and a type has been introduced to allow this simultaneous recording."/>
-      <min value="0"/>
-      <max value="*"/>
-      <type>
-        <code value="BackboneElement"/>
-      </type>
-    </element>
-    <element id="ResearchSubject.progress.type">
-      <path value="ResearchSubject.progress.type"/>
-      <short value="state | milestone"/>
-      <definition value="Identifies the aspect of the subject's journey that the state refers to."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchSubjectStateType"/>
-        </extension>
-        <strength value="example"/>
-        <description value="Identifies the kind of state being refered to."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/research-subject-state-type"/>
-      </binding>
-    </element>
-    <element id="ResearchSubject.progress.subjectState">
-      <path value="ResearchSubject.progress.subjectState"/>
-      <short value="candidate | eligible | follow-up | ineligible | not-registered | off-study | on-study | on-study-intervention | on-study-observation | pending-on-study | potential-candidate | screening | withdrawn"/>
-      <definition value="The current state of the subject."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchSubjectProgresss"/>
-        </extension>
-        <strength value="required"/>
-        <description value="Indicates the progression of a study subject through a study."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/research-subject-state"/>
-      </binding>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.status"/>
-      </mapping>
-      <mapping>
-        <identity value="BRIDG5.1"/>
-        <map value="StudySubject.statusCode"/>
-      </mapping>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".status"/>
-      </mapping>
-    </element>
-    <element id="ResearchSubject.progress.milestone">
-      <path value="ResearchSubject.progress.milestone"/>
-      <short value="SignedUp | Screened | Randomized"/>
-      <definition value="The milestones the subject has passed through."/>
-      <comment value="There can be multiple entries but it is also valid to just have the most recent.  This should npt be rlied upon as the full path the subject has taken."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchSubjectMilestone"/>
-        </extension>
-        <strength value="example"/>
-        <description value="Indicates the progression of a study subject through the study milestones."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/research-subject-milestone"/>
-      </binding>
-      <mapping>
-        <identity value="w5"/>
-        <map value="FiveWs.status"/>
-      </mapping>
-      <mapping>
-        <identity value="BRIDG5.1"/>
-        <map value="StudySubject.statusCode"/>
-      </mapping>
-    </element>
-    <element id="ResearchSubject.progress.reason">
-      <path value="ResearchSubject.progress.reason"/>
-      <short value="State change reason"/>
-      <definition value="The reason for the state change.  If coded it should follow the formal subject state model."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="StateChangeReason"/>
-        </extension>
-        <strength value="example"/>
-        <description value="Indicates why the state of the subject changed."/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/state-change-reason"/>
-      </binding>
-    </element>
-    <element id="ResearchSubject.progress.startDate">
-      <path value="ResearchSubject.progress.startDate"/>
-      <short value="State change date"/>
-      <definition value="The date when the new status started."/>
-      <comment value="This is NOT the date the change in state was recorded."/>
-      <requirements value="This was originally defined as the date when the change in status occurred.  This assumed all                      states were recorded which is not true.  Hence the need to track the end of the state."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="dateTime"/>
-      </type>
-    </element>
-    <element id="ResearchSubject.progress.endDate">
-      <path value="ResearchSubject.progress.endDate"/>
-      <short value="State change date"/>
-      <definition value="The date when the state ended."/>
-      <requirements value="See the requirement on the start date."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="dateTime"/>
-      </type>
-    </element>
     <element id="ResearchSubject.period">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/todo">
         <valueString value=".effectiveTime."/>
@@ -338,6 +211,84 @@
         <identity value="BRIDG5.1"/>
         <map value="StudySubject"/>
       </mapping>
+    </element>
+    <element id="ResearchSubject.subjectState">
+      <path value="ResearchSubject.subjectState"/>
+      <short value="A duration in the lifecycle of the ResearchSubject within a ResearchStudy"/>
+      <definition value="A duration in the lifecycle of the ResearchSubject within a ResearchStudy."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="ResearchSubject.subjectState.code">
+      <path value="ResearchSubject.subjectState.code"/>
+      <short value="candidate | in-prescreening | in-screening | eligible | ineligible | on-study | on-study-intervention | in-follow-up | off-study"/>
+      <definition value="Identifies the aspect of the subject's journey that the state refers to."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="ResearchSubjectState"/>
+        </extension>
+        <strength value="required"/>
+        <description value="Indicates the progression of a study subject through a study."/>
+		<valueSet value="http://hl7.org/fhir/ValueSet/research-subject-state"/>
+      </binding>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.status"/>
+      </mapping>
+      <mapping>
+        <identity value="BRIDG5.1"/>
+        <map value="StudySubject.statusCode"/>
+      </mapping>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".status"/>
+      </mapping>
+    </element>
+    <element id="ResearchSubject.subjectState.startDate">
+      <path value="ResearchSubject.subjectState.startDate"/>
+      <short value="The date a research subject entered the given state"/>
+      <definition value="The date a research subject entered the given state."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="dateTime"/>
+      </type>
+    </element>
+    <element id="ResearchSubject.subjectState.endDate">
+      <path value="ResearchSubject.subjectState.endDate"/>
+      <short value="The date a research subject exited or left the given state"/>
+      <definition value="The date a research subject exited or left the given state."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="dateTime"/>
+      </type>
+    </element>
+    <element id="ResearchSubject.subjectState.reason">
+      <path value="ResearchSubject.subjectState.reason"/>
+      <short value="State change reason"/>
+      <definition value="The reason for the state change. If coded it should follow the formal subject state model."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="StateChangeReason"/>
+        </extension>
+        <strength value="example"/>
+        <description value="Indicates why the state of the subject changed."/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/state-change-reason"/>
+      </binding>
     </element>
     <element id="ResearchSubject.assignedComparisonGroup">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/todo">


### PR DESCRIPTION
The binding on ResearchSubject.subjectState.reason, StateChangeReason, changes needs to be done in the terminology repo.

---

Create a NEW backbone element to ResearchSubject Resource. Details are below. Additional details regarding terminology is documented here https://confluence.hl7.org/display/BRR/ResearchSubject+Resource

Name of backbone element:
subjectState
Definition of the backbone element: A duration in the lifecycle of the ResearchSubject within a ResearchStudy.

Element details:
code: CodeableConcept; 1..1; ResearchSubjectState (NEW); (see below for terminology)
startDate: dateTime: 1..1; The date a research subject entered the given state.
endDate: dateTime; 0..1; The date a research subject exited or left the given state.
reason: CodeableConcept; 0..1; The rationale for transitioning into the given state. (see below for terminology)