### PR TITLE
J#42885 Remove Evidence.statistic.modelCharacteristic.condition[x] element

### DIFF
--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -906,21 +906,6 @@
 				<code value="BackboneElement"/>
 			</type>
 		</element>
-		<element id="Evidence.statistic.modelCharacteristic.condition[x]">
-			<extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
-				<valueCode value="490,150"/>
-			</extension>
-			<path value="Evidence.statistic.modelCharacteristic.condition[x]"/>
-			<short value="When this characteristic is used"/>
-			<min value="0"/>
-			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
-			<type>
-				<code value="Expression"/>
-			</type>
-		</element>
 		<element id="Evidence.statistic.modelCharacteristic.code">
 			<path value="Evidence.statistic.modelCharacteristic.code"/>
 			<short value="Model specification"/>


### PR DESCRIPTION
And there is a fhir-extensions pull request for the extension change required by this tracker item.