### PR TITLE
J#43328 and J#41632 Evidence.statistis.modelCharacteristic change and Citation Code System added a code

### DIFF
--- a/source/citation/codesystem-cited-artifact-part-type.xml
+++ b/source/citation/codesystem-cited-artifact-part-type.xml
@@ -41,6 +41,11 @@
   <valueSet value="http://hl7.org/fhir/ValueSet/cited-artifact-part-type"/>
   <content value="complete"/>
   <concept>
+    <code value="chapters"/>
+    <display value="chapters"/>
+    <definition value="Denotes specific chapter or chapters of an article or artifact."/>
+  </concept>
+  <concept>
     <code value="pages"/>
     <display value="pages"/>
     <definition value="Denotes specific page or pages of an article or artifact."/>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -1022,23 +1022,12 @@
 				<code value="Range"/>
 			</type>
 		</element>
-		<element id="Evidence.statistic.modelCharacteristic.attributeEstimate">
-			<path value="Evidence.statistic.modelCharacteristic.attributeEstimate"/>
+		<element id="Evidence.statistic.modelCharacteristic.attribute">
+			<path value="Evidence.statistic.modelCharacteristic.attribute"/>
 			<short value="An attribute of the statistic used as a model characteristic"/>
 			<min value="0"/>
 			<max value="*"/>
 			<contentReference value="#Evidence.statistic.attributeEstimate"/>
-		</element>
-		<element id="Evidence.statistic.modelCharacteristic.modelCharacteristic">
-			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name">
-				<valueString value="AttributeEstimateAttributeEstimate"/>
-			</extension>
-			<path value="Evidence.statistic.modelCharacteristic.modelCharacteristic"/>
-			<short value="Model component"/>
-			<comment value="A nested model characteristic"/>
-			<min value="0"/>
-			<max value="*"/>
-			<contentReference value="#Evidence.statistic.modelCharacteristic"/>
 		</element>
 		<element id="Evidence.certainty">
 			<extension url="http://hl7.org/fhir/build/StructureDefinition/svg">


### PR DESCRIPTION
J#43328 simplification of Evidence.statistis.modelCharacteristic

- Rename Evidence.statistis.modelCharacteristic.attributeEstimate to attribute 0..* see attributeEstimate
- Remove Evidence.statistis.modelCharacteristic.modelCharacteristic

J#41632 Add "chapters" code to the Cited Artifact Part Type CodeSystem