### PR TITLE
J#44837 and J#44838 BR&R ResearchSubject changes, and J#44514 Updated the Patient example for extension change

### DIFF
--- a/source/patient/patient-example-sex-and-gender.xml
+++ b/source/patient/patient-example-sex-and-gender.xml
@@ -71,11 +71,9 @@
 		</extension>
 		<extension url="sourceDocument">
 			<!-- Reference to a scan of the birth certificate -->
-			<valueCodeableReference>
-			  <reference>
-  				<reference value="DocumentReference/1"/>
-			  </reference>
-			</valueCodeableReference>
+			<valueReference>
+  			  <reference value="DocumentReference/1"/>
+			</valueReference>
 		</extension>
 		<extension url="sourceField">
 			<valueString value="SEX"/>
@@ -123,11 +121,9 @@
 		</extension>
 		<extension url="sourceDocument">
 			<!-- Reference to a scan of the insurance card-->
-			<valueCodeableReference>
-			  <reference>
-  				<reference value="DocumentReference/2"/>
-			  </reference>
-			</valueCodeableReference>
+			<valueReference>
+  			  <reference value="DocumentReference/2"/>
+			</valueReference>
 		</extension>
 		<extension url="sourceField">
 			<valueString value="SEX"/>
@@ -175,11 +171,9 @@
 		</extension>
 		<extension url="sourceDocument">
 			<!-- Reference to a scan of the driver's license -->
-			<valueCodeableReference>
-			  <reference>
-  				<reference value="DocumentReference/1"/>
-			  </reference>
-			</valueCodeableReference>
+			<valueReference>
+  			  <reference value="DocumentReference/1"/>
+			</valueReference>
 		</extension>
 		<extension url="jurisdiction">
 			<valueCodeableConcept>

--- a/source/researchsubject/researchsubject-introduction.xml
+++ b/source/researchsubject/researchsubject-introduction.xml
@@ -9,11 +9,12 @@
   <p>Note that in a human drug trial the human is the research subject even though the drug is what is being investigated.</p>
   <p>The scope of ResearchSubject is intended to support the following use cases:</p>
   <ul>
-   <li>Humans and Animals for Clinical and Pre-clinical Trials</li>
-   <li>Drug Products for Stability Studies and other Tests</li>
-   <li>Devices for non-clinical laboratory studies - in-vivo and in-vitro</li>
-   <li>Tissue Sample for bench science studies</li>
+    <li>Humans and Animals for Clinical and Pre-clinical Trials</li>
+    <li>Drug Products for Stability Studies and other Tests</li>
+    <li>Devices for non-clinical laboratory studies - in-vivo and in-vitro</li>
+    <li>Tissue Sample for bench science studies</li>
   </ul>
+  <p>The Subject State is the research subject's (participant’s) movement through the study protocol from the subject's point of view.  The Subject Milestone is how the study activities relate to the subject's movement through the study protocol. The two are separate. State is driven by the subject and the Milestone is driven by the study protocol. The values in each element may be the same if necessary for study reasons.</p>
 </div>
 
 </div>

--- a/source/researchsubject/structuredefinition-ResearchSubject.xml
+++ b/source/researchsubject/structuredefinition-ResearchSubject.xml
@@ -276,6 +276,7 @@
       <path value="ResearchSubject.subjectState.reason"/>
       <short value="State change reason"/>
       <definition value="The reason for the state change. If coded it should follow the formal subject state model."/>
+      <comment value="Example, if the milestone is &quot;Randomized&quot; then the reason could be &quot;sponsor IVRS randomization code allocated&quot;."/>
       <min value="0"/>
       <max value="1"/>
       <type>

--- a/source/researchsubject/structuredefinition-ResearchSubject.xml
+++ b/source/researchsubject/structuredefinition-ResearchSubject.xml
@@ -290,6 +290,53 @@
         <valueSet value="http://terminology.hl7.org/ValueSet/state-change-reason"/>
       </binding>
     </element>
+    <element id="ResearchSubject.subjectMilestone">
+      <path value="ResearchSubject.subjectMilestone"/>
+      <short value="A significant event in the progress of a ResearchSubject"/>
+      <definition value="A significant event in the progress of a ResearchSubject."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="BackboneElement"/>
+      </type>
+    </element>
+    <element id="ResearchSubject.subjectMilestone.milestone">
+      <path value="ResearchSubject.subjectMilestone.milestone"/>
+      <short value="SignedUp | Screened | Randomized"/>
+      <definition value="A specific event in the research subjects journey through a research study."/>
+      <min value="1"/>
+      <max value="*"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="ResearchSubjectMilestone"/>
+        </extension>
+        <strength value="extensible"/>
+        <description value="Indicates the progression of a study subject through a study."/>
+	<valueSet value="http://hl7.org/fhir/ValueSet/research-subject-milestone"/>
+      </binding>
+    </element>
+    <element id="ResearchSubject.subjectMilestone.date">
+      <path value="ResearchSubject.subjectMilestone.date"/>
+      <short value="The date/time when this milestone event was completed"/>
+      <definition value="The date/time when this milestone event was completed."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="dateTime"/>
+      </type>
+    </element>
+    <element id="ResearchSubject.subjectMilestone.reason">
+      <path value="ResearchSubject.subjectMilestone.reason"/>
+      <definition value="A rationale that provides additional clarification for the milestone that was captured or documented."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+    </element>
     <element id="ResearchSubject.assignedComparisonGroup">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/todo">
         <valueString value="This ought to have an identifier as well as a name&#xA;&#xA;OR - allocation is to a Group which is part of a planDefinition which represents an Arm."/>


### PR DESCRIPTION
ResearchSubject.subjectMilestone 0..*   A significant event in the progress of a ResearchSubject.      

milestone: CodeableConcept; 1..*  A specific event in the research subjects journey through a research study. _See the code list below Binding: Research Subject Milestone (Extensible)
date: dateTime; 0..1 The date/time when this milestone event was completed.
reason: CodeableConcept; 0..1 A rationale that provides additional clarification for the milestone that was captured or documented. Example, If the milestone is "Randomized" then the reason could be "sponsor IVRS randomization code  allocated".

Add the following to the Scope and Usage section of the ResearchSubject Resource

(Comment – add it at the end of this section)

The Subject State is the research subject's (participant’s) movement through the study protocol from the subject's point of view.  The Subject Milestone is how the study activities relate to the subject's movement through the study protocol. The two are separate. State is driven by the subject and the Milestone is driven by the study protocol. The values in each element may be the same if necessary for study reasons.


J#44514 Updated the Patient example to be compatible for the recordedSexOrGender extension for sourceDocument. For the recordedSexOrGender Patient extension extension:sourceDocument.valueCodeableReference was split into valueCodeableConcept and valueReference, so I fixed the example that was using it. The FHIR build process was failing even with no changes unless this example was fixed.
