### PR TITLE
correct JAdES B-LT reference

### DIFF
--- a/source/datatypes.html
+++ b/source/datatypes.html
@@ -1783,7 +1783,7 @@ When the signature is an JSON Digital Signature (contentType = application/jose)
  <li>When FHIR Resources are signed, the signature is across the <a href="json.html#canonical">Canonical JSON form</a> of the resource(s)</li>
  <li>The Signature SHOULD use the hashing algorithm SHA-256. Signature validation policy will apply to the signature and determine acceptability</li>
  <li>The Signature SHALL include a "srCms signer commitments" element for the Purpose(s) of Signature. The Purpose can be the action being attested to, or the role associated with the signature. The value shall come from ASTM E1762-95(2013). The Signature.type shall contain the same values as the srCms element.</li>
- <li>The Signature SHOULD conform to JAdES-XL for support of long term signatures. The JAdES-X-L specification adds the timestamp of the signing, inclusion of the signing certificate, and statement of revocation</li>
+ <li>The Signature SHOULD conform to JAdES-B-LT for support of long term signatures. The JAdES-B-LT specification adds the timestamp of the signing, inclusion of the signing certificate, and statement of revocation</li>
 </ul>
 <p>
 There are three levels of signature verification:


### PR DESCRIPTION

## HL7 FHIR Pull Request

- FHIR-44839

## Description

correct JAdES reference to Long-Term signature profile which should be B-LT.
