### PR TITLE
FHIR-42722 Add TestScript assert.requirement.key

### DIFF
--- a/source/testscript/structuredefinition-TestScript.xml
+++ b/source/testscript/structuredefinition-TestScript.xml
@@ -1680,18 +1680,25 @@
 				<code value="BackboneElement"/>
 			</type>
 		</element>
-		<element id="TestScript.setup.action.assert.requirement.link[x]">
-			<path value="TestScript.setup.action.assert.requirement.link[x]"/>
-			<short value="Link or reference to the testing requirement"/>
-			<definition value="Link or reference providing traceability to the testing requirement for this test."/>
-			<min value="0"/>
+		<element id="TestScript.setup.action.assert.requirement.reference">
+			<path value="TestScript.setup.action.assert.requirement.reference"/>
+			<short value="Canonical reference to the Requirements instance"/>
+			<definition value="Canonical reference providing traceability to the testing requirement for this assert."/>
+			<min value="1"/>
 			<max value="1"/>
-			<type>
-				<code value="uri"/>
-			</type>
 			<type>
 				<code value="canonical"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Requirements"/>
+			</type>
+		</element>
+		<element id="TestScript.setup.action.assert.requirement.key">
+			<path value="TestScript.setup.action.assert.requirement.key"/>
+			<short value="Requirements statement key identifier"/>
+			<definition value="Requirements.statement.key that identifies the statement that this assert satisfies."/>
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="id"/>
 			</type>
 		</element>
 		<element id="TestScript.test">


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with

## Description

[FHIR-42722](https://jira.hl7.org/browse/FHIR-42722)
- TestScript assert.requirement.reference defined as a canonical type
- TestScript assert.requirement.key add for link back to specific Requirements.statement.key
