### PR TITLE
FHIR-46400 - Update the observation-status value set definition text for 'amended' and 'corrected'

### DIFF
--- a/source/observation/codesystem-observation-status.xml
+++ b/source/observation/codesystem-observation-status.xml
@@ -72,11 +72,11 @@
   <concept>
     <code value="amended"/>
     <display value="Amended"/>
-    <definition value="Subsequent to being Final, the observation has been modified subsequent.  This includes updates/new information and corrections."/>
+    <definition value="Subsequent to being Final, the observation has been modified. This includes updates/new information and corrections."/>
     <concept>
       <code value="corrected"/>
       <display value="Corrected"/>
-      <definition value="Subsequent to being Final, the observation has been modified to correct an error in the test result."/>
+      <definition value="Subsequent to being Final, the observation has been modified to correct an error in the original test result(s)."/>
     </concept>
   </concept>
   <concept>


### PR DESCRIPTION

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-46400`

## Description

The definition text for 'amended' should be adjusted to remove the dangling second use of 'subsequent'. 
Change from: "Subsequent to being Final, the observation has been modified subsequent. This includes updates/new information and corrections."
to: "Subsequent to being Final, the observation has been modified. This includes updates/new information and corrections."

Plus, for better consistency (with the text for the new sibling 'appended' concept), the definition text for 'corrected' should be changed to: "Subsequent to being Final, the observation has been modified to correct an error in the original test result(s)."