### PR TITLE
J#46095 ResearchStudy.result allows Composition

### DIFF
--- a/source/researchstudy/structuredefinition-ResearchStudy.xml
+++ b/source/researchstudy/structuredefinition-ResearchStudy.xml
@@ -1123,8 +1123,8 @@
       <max value="*"/>
       <type>
         <code value="Reference"/>
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/EvidenceReport"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Citation"/>
+		<targetProfile value="http://hl7.org/fhir/StructureDefinition/Composition"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport"/>
       </type>
       <isSummary value="true"/>

--- a/source/spelling/add.txt
+++ b/source/spelling/add.txt
@@ -1,15 +1,11 @@
 _language
 _query
-excluded_structure
 _in
 _security
 _type
 _lastupdated
 _filter
 _list
-lifecycle
-subject_state
-included_structure
 _profile
 _tag
 _has
@@ -17,4 +13,3 @@ _source
 _id
 _content
 _text
-hrf


### PR DESCRIPTION
- ResearchStudy.result allows Composition as reference type, and removal of EvidenceReport as an option