### PR TITLE
FHIR-39432 DeviceMetric category, calibration.type binding

### DIFF
--- a/source/devicemetric/structuredefinition-DeviceMetric.xml
+++ b/source/devicemetric/structuredefinition-DeviceMetric.xml
@@ -246,7 +246,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="code"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="false" />
       <binding>

--- a/source/devicemetric/structuredefinition-DeviceMetric.xml
+++ b/source/devicemetric/structuredefinition-DeviceMetric.xml
@@ -193,7 +193,7 @@
     </element>
     <element id="DeviceMetric.category">
       <path value="DeviceMetric.category"/>
-      <short value="The category of the metric"/>
+      <short value="The kind of metric represented"/>
       <definition value="Indicates the category of the observation generation process. A DeviceMetric can be, for example, a setting, measurement, or calculation."/>
       <min value="1"/>
       <max value="1"/>
@@ -241,7 +241,7 @@
     </element>
     <element id="DeviceMetric.calibration.type">
       <path value="DeviceMetric.calibration.type"/>
-      <short value="The type of calibration"/>
+      <short value="The method of calibration"/>
       <definition value="Describes the type of the calibration method."/>
       <min value="0"/>
       <max value="1"/>

--- a/source/devicemetric/structuredefinition-DeviceMetric.xml
+++ b/source/devicemetric/structuredefinition-DeviceMetric.xml
@@ -193,19 +193,19 @@
     </element>
     <element id="DeviceMetric.category">
       <path value="DeviceMetric.category"/>
-      <short value="measurement | setting | calculation | unspecified"/>
-      <definition value="Indicates the category of the observation generation process. A DeviceMetric can be for example a setting, measurement, or calculation."/>
+      <short value="The category of the metric"/>
+      <definition value="Indicates the category of the observation generation process. A DeviceMetric can be, for example, a setting, measurement, or calculation."/>
       <min value="1"/>
       <max value="1"/>
       <type>
-        <code value="code"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="DeviceMetricCategory"/>
         </extension>
-        <strength value="required"/>
+        <strength value="extensible"/>
         <description value="Describes the category of the metric."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/metric-category"/>
       </binding>
@@ -241,7 +241,7 @@
     </element>
     <element id="DeviceMetric.calibration.type">
       <path value="DeviceMetric.calibration.type"/>
-      <short value="unspecified | offset | gain | two-point"/>
+      <short value="The type of calibration"/>
       <definition value="Describes the type of the calibration method."/>
       <min value="0"/>
       <max value="1"/>
@@ -253,7 +253,7 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="DeviceMetricCalibrationType"/>
         </extension>
-        <strength value="required"/>
+        <strength value="extensible"/>
         <description value="Describes the type of a metric calibration."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/metric-calibration-type"/>
       </binding>


### PR DESCRIPTION
## HL7 FHIR Pull Request

FHIR-39462

## Description

Change DeviceMetric.category and DeviceMetric.calibration.type from `code` to `CodeableConcept` and relax binding from required to extensible.