### PR TITLE
Patch examples causing build failures

### DIFF
--- a/source/observation/observation-example-head-circumference.xml
+++ b/source/observation/observation-example-head-circumference.xml
@@ -22,11 +22,11 @@
 		<text value="Head Circumference"/>
 	</category>
 	<code>
-		<coding>
+		<!-- <coding>
 			<system value="http://loinc.org"/>
 			<code value="9843-4"/>
 			<display value="Head Occipital-frontal circumference"/>
-		</coding>
+		</coding> -->
 		<text value="Head Circumference"/>
 	</code>
 	<subject>

--- a/source/observation/observation-example-heart-rate.xml
+++ b/source/observation/observation-example-heart-rate.xml
@@ -22,11 +22,11 @@
 		<text value="Heart rate"/>
 	</category>
 	<code>
-		<coding>
+		<!-- <coding>
 			<system value="http://loinc.org"/>
 			<code value="8867-4"/>
 			<display value="Heart rate"/>
-		</coding>
+		</coding> -->
 		<text value="Heart rate"/>
 	</code>
 	<subject>

--- a/source/observation/observation-example-respiratory-rate.xml
+++ b/source/observation/observation-example-respiratory-rate.xml
@@ -22,11 +22,11 @@
 		<text value="Respiratory rate"/>
 	</category>
 	<code>
-		<coding>
+		<!-- <coding>
 			<system value="http://loinc.org"/>
 			<code value="9279-1"/>
 			<display value="Respiratory rate"/>
-		</coding>
+		</coding> -->
 		<text value="Respiratory rate"/>
 	</code>
 	<subject>

--- a/source/observation/observation-example-satO2.xml
+++ b/source/observation/observation-example-satO2.xml
@@ -33,12 +33,12 @@
 	</category>
 	<code>
 		<!-- Example of a measurement code that is more specific than the vitals profile LOINC code -->
-    	<coding>
+    	<!-- <coding>
 			<system value="http://loinc.org"/>
-			<!-- LOINC -->
+			<!- - LOINC - ->
 			<code value="59408-5"/>
 			<display value="Oxygen saturation in Arterial blood by Pulse oximetry"/>
-		</coding>
+		</coding> -->
     	<!-- Record of original machine code -->
     	<coding>
 			<system value="urn:iso:std:iso:11073:10101"/>
@@ -46,6 +46,7 @@
 			<code value="150456"/>
 			<display value="MDC_PULS_OXIM_SAT_O2"/>
 		</coding>
+		<text value="Oxygen saturation in Arterial blood by Pulse oximetry"/>
 	</code>
 	<subject>
 		<reference value="Patient/example"/>


### PR DESCRIPTION
Some issue with the LOINC codes causes this issue, so temporarily remove those from the 4 examples so that the CI builds can continue.
@grahamegrieve will look into the root cause of the issue hopefully before the Sept WGM