### PR TITLE
Moehrke imaging nov24

### DIFF
--- a/source/imagingselection/imagingselection-event-mapping-exceptions.xml
+++ b/source/imagingselection/imagingselection-event-mapping-exceptions.xml
@@ -47,7 +47,7 @@
         </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="A nominal state-transition diagram can be found in the (Event pattern documentation&#xa;&#xa;Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
-            <resource value="Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
+            <resource value="Unknown does not represent &quot;other&quot; - one of the defined statuses SHALL apply.  Unknown is used when the authoring system is not sure what the current status is."/>
         </commentsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.category" resourcePath="ImagingSelection.category">

--- a/source/imagingselection/imagingselection-introduction.xml
+++ b/source/imagingselection/imagingselection-introduction.xml
@@ -33,26 +33,27 @@
   <div>
     <a name="bnr"></a>
     <h2>Boundaries and Relationships</h2>
-
     <p>
-    The <a href="imagingstudy.html">ImagingStudy</a> resource is used to store details of an entire DICOM Study and associated information.
-    </p>
-    <p>
-    The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions.
-    </p>
-    <p>
-    An <a href="observation.html">Observation</a> MAY be related to a set of images in several ways.
-    </p>
-    <ul>
-      <li><a href="observation.html">Observation.partOf</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a></li>
-      <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
-      <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
-      <li><a href="observation.html">Observation.focus</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
-    </ul>
-    <p>While an ImagingSelection is restricted to a single DICOM Series, a single <a href="observation.html">Observation</a> references multiple ImagingSelection resources if it relates to multiple Studies and / or Series – for example, to reference multiple images over different cardiac phases or a PET and a CT image.</p>
-    <p>A <a href="diagnosticreport.html">DiagnosticReport</a> might directly reference an ImagingSelection that includes one or more Observations derived from ImagingSelection resources.</p>
-    <p>In contrast with a <a href="documentreference.html">DocumentReference</a>, an ImagingSelection includes the ability to specify a region within an image, an observation node within a DICOM Structured Reporting (SR) and the ability to specify one or more Endpoint resources for retrieval of the referenced images, frames, waveforms or documents. Additionally, <a href="documentreference.html">DocumentReference</a> has limited ability to reference multiple images or frames and can only specify the Study, Series and SOP Instance UIDs implicitly via the URL.</p>
-    <p><a href="documentreference.html">DocumentReference</a> might be appropriate for including a rendered DICOM image in cases where the full image context is not important.</p>
-  </div>
-
+        The <a href="imagingstudy.html">ImagingStudy</a> resource is used to store details of an entire DICOM Study and associated information, including its relationship to other resources, such as <a href="servicerequest.html">ServiceRequest</a> and <a href="encounter.html">Encounter</a>.
+        </p>
+        <p>
+        The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions. Instances of this resource are created for specific clinical purposes and are unlikely to change once created.
+        </p>
+        <p>
+        An <a href="observation.html">Observation</a> MAY be related to a set of images in the following ways.
+        </p>
+        <ul>
+          <li><a href="observation.html">Observation.partOf</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a></li>
+          <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
+          <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
+          <li><a href="observation.html">Observation.focus</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
+        </ul>
+      
+    
+      <p>The <a href="documentreference.html">DocumentReference</a> resource is used to to store non-DICOM images, video, or audio with relevant metadata.</p>
+      <p>The <a href="binary.html">Binary</a> resource to store arbitrary content.</p>
+    
+    
+    </div>
+    
 </div>

--- a/source/imagingselection/imagingselection-introduction.xml
+++ b/source/imagingselection/imagingselection-introduction.xml
@@ -5,7 +5,7 @@
     <p>This resource is an <a href="workflow.html#event">
       <em>event resource</em>
     </a> from a FHIR workflow perspective - see <a href="workflow.html">Workflow</a>.</p>
-    <p>A selection of data from an ImagingStudy. The selection may be:</p>
+    <p>A selection of data from an ImagingStudy. The selection MAY be:</p>
     <ul>
       <li>All DICOM SOP Instances in a single DICOM Series</li>
       <li>A set of DICOM SOP Instances within a single DICOM Series</li>
@@ -28,7 +28,7 @@
       <li>Identifying images, frames or presentation states selected as part of shared application context in a context-sharing environment</li>
       <li>Identifying a specific set of images, frames or presentation states to be presented</li>
     </ul>
-    <p>All DICOM SOP Instances referenced in a single ImagingSelection resource shall be part of the same DICOM Series (and therefore also the same DICOM Study). In order to reference SOP Instances in multiple Studies or Series it is necessary to create multiple ImagingSelection resources.</p>
+    <p>All DICOM SOP Instances referenced in a single ImagingSelection resource SHALL be part of the same DICOM Series (and therefore also the same DICOM Study). In order to reference SOP Instances in multiple Studies or Series it is necessary to create multiple ImagingSelection resources.</p>
   </div>
   <div>
     <a name="bnr"></a>
@@ -41,13 +41,13 @@
     The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions.
     </p>
     <p>
-    An <a href="observation.html">Observation</a> may be related to a set of images in several ways.
+    An <a href="observation.html">Observation</a> MAY be related to a set of images in several ways.
     </p>
     <ul>
-      <li><a href="observation.html">Observation.partOf</a> may reference an <a href="imagingstudy.html">ImagingStudy</a></li>
-      <li><a href="observation.html">Observation.derivedFrom</a> may reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
-      <li><a href="observation.html">Observation.derivedFrom</a> may reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
-      <li><a href="observation.html">Observation.focus</a> may reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
+      <li><a href="observation.html">Observation.partOf</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a></li>
+      <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
+      <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
+      <li><a href="observation.html">Observation.focus</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
     </ul>
     <p>While an ImagingSelection is restricted to a single DICOM Series, a single <a href="observation.html">Observation</a> references multiple ImagingSelection resources if it relates to multiple Studies and / or Series – for example, to reference multiple images over different cardiac phases or a PET and a CT image.</p>
     <p>A <a href="diagnosticreport.html">DiagnosticReport</a> might directly reference an ImagingSelection that includes one or more Observations derived from ImagingSelection resources.</p>

--- a/source/imagingselection/imagingselection-notes.xml
+++ b/source/imagingselection/imagingselection-notes.xml
@@ -5,7 +5,7 @@
 <h2>Notes</h2>
   <h3>Imaging Selection Subsets</h3>
   <p>Some DICOM SOP Instances contain multiple sub-resources, such as frames, segments, etc.</p>
-  <p>An Imaging Selection resource may specify the subset of these that are included in the selection using the <code>instance.subset</code> element.</p>
+  <p>An Imaging Selection resource MAY specify the subset of these that are included in the selection using the <code>instance.subset</code> element.</p>
   <p>The defined types of subsets are:</p>
   <ul>
     <li>Frames selected from a multiframe SOP Instance</li>

--- a/source/imagingselection/structuredefinition-ImagingSelection.xml
+++ b/source/imagingselection/structuredefinition-ImagingSelection.xml
@@ -427,7 +427,7 @@
     <element id="ImagingSelection.frameOfReferenceUid">
       <path value="ImagingSelection.frameOfReferenceUid"/>
       <short value="The Frame of Reference UID for the selected images"/>
-      <definition value="The Frame of Reference UID identifying the coordinate system that conveys spatial and/or temporal information for the selected images or frames."/>
+      <definition value="Uniquely identifies groups of composite instances that have the same coordinate system that conveys spatial and/or temporal information."/>
       <comment value="See [DICOM PS3.3 C.7.4.1](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.4.html)."/>
       <requirements value="DICOM Frame of Reference UID.&#xA;                            Required if studyInstanceUid and seriesInstanceUid are not present."/>
       <alias value="FrameOfReferenceUID"/>

--- a/source/imagingselection/structuredefinition-ImagingSelection.xml
+++ b/source/imagingselection/structuredefinition-ImagingSelection.xml
@@ -115,14 +115,14 @@
       <path value="ImagingSelection.status"/>
       <short value="available | entered-in-error | inactive | unknown"/>
       <definition value="The current state of the ImagingSelection resource. This is not the status of any ImagingStudy, ServiceRequest, or Task resources associated with the ImagingSelection."/>
-      <comment value="Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
+      <comment value="Unknown does not represent &quot;other&quot; - one of the defined statuses SHALL apply.  Unknown is used when the authoring system is not sure what the current status is."/>
       <min value="1"/>
       <max value="1"/>
       <type>
         <code value="code"/>
       </type>
       <isModifier value="true"/>
-      <isModifierReason value="This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid"/>
+      <isModifierReason value="This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource SHOULD not be treated as valid"/>
       <isSummary value="true"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -479,7 +479,7 @@
       <path value="ImagingSelection.focus"/>
       <short value="Related resources that are the focus for the imaging selection"/>
       <definition value="The actual focus of an imaging selection when it is another imaging selection resource and not the patient of record."/>
-      <comment value="An imaging selection may reference a DICOM resource that itself references other DICOM resources.&#xA;       e.g. a presentation state references a set of source images or frames."/>
+      <comment value="An imaging selection MAY reference a DICOM resource that itself references other DICOM resources.&#xA;       e.g. a presentation state references a set of source images or frames."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -641,9 +641,9 @@
     <element id="ImagingSelection.instance.imageRegion2D.coordinate">
       <path value="ImagingSelection.instance.imageRegion2D.coordinate"/>
       <short value="Specifies the coordinates that define the image region"/>
-      <definition value="The coordinates describing the image region. Encoded as a set of (column, row) pairs that denote positions in the selected image / frames specified with sub-pixel resolution.&#xA;The origin at the TLHC of the TLHC pixel is 0.0\0.0, the BRHC of the TLHC pixel is 1.0\1.0, and the BRHC of the BRHC pixel is the number of columns\rows in the image / frames. The values must be within the range 0\0 to the number of columns\rows in the image / frames."/>
+      <definition value="The coordinates describing the image region. Encoded as a set of (column, row) pairs that denote positions in the selected image / frames specified with sub-pixel resolution.&#xA;The origin at the TLHC of the TLHC pixel is 0.0\0.0, the BRHC of the TLHC pixel is 1.0\1.0, and the BRHC of the BRHC pixel is the number of columns\rows in the image / frames. The values SHALL be within the range 0\0 to the number of columns\rows in the image / frames."/>
       <comment value="For a description of how 2D coordinates are encoded, see [DICOM PS 3.3 C.18.6](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.18.6.html)."/>
-      <requirements value="The number of values must be a multiple of two."/>
+      <requirements value="The number of values SHALL be a multiple of two."/>
       <alias value="GraphicData"/>
       <min value="1"/>
       <max value="*"/>
@@ -700,9 +700,9 @@
     <element id="ImagingSelection.imageRegion3D.coordinate">
       <path value="ImagingSelection.imageRegion3D.coordinate"/>
       <short value="Specifies the coordinates that define the image region"/>
-      <definition value="The coordinates describing the image region. Encoded as an ordered set of (x,y,z) triplets (in mm and may be negative) that define a region of interest in the patient-relative Reference Coordinate System defined by ImagingSelection.frameOfReferenceUid element."/>
+      <definition value="The coordinates describing the image region. Encoded as an ordered set of (x,y,z) triplets (in mm and MAY be negative) that define a region of interest in the patient-relative Reference Coordinate System defined by ImagingSelection.frameOfReferenceUid element."/>
       <comment value="For a description of how 3D coordinates are encoded, see [DICOM PS3.3 C.18.9](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.18.9.html)."/>
-      <requirements value="The number of values must be a multiple of three."/>
+      <requirements value="The number of values SHALL be a multiple of three."/>
       <alias value="GraphicData"/>
       <min value="1"/>
       <max value="*"/>

--- a/source/imagingselection/structuredefinition-ImagingSelection.xml
+++ b/source/imagingselection/structuredefinition-ImagingSelection.xml
@@ -354,7 +354,7 @@
       <short value="The imaging study from which the imaging selection is derived"/>
       <definition value="The imaging study from which the imaging selection is made."/>
       <min value="0"/>
-      <max value="*"/>
+      <max value="1"/>
       <type>
         <code value="Reference"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/ImagingStudy"/>
@@ -367,7 +367,7 @@
       <short value="DICOM Study Instance UID"/>
       <definition value="The Study Instance UID for the DICOM Study from which the images were selected."/>
       <comment value="See [DICOM PS3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
-      <requirements value="DICOM Study Instance UID.&#xA;       Required unless frameOfReferenceUid and imageRegion are present and instance is not present."/>
+      <requirements value="DICOM Study Instance UID.&#xA;Required unless frameOfReferenceUid and imageRegion are present and instance is not present.&#xA;If imagingselection.derivedFrom is present and references an ImagingStudy, the studyUid attribute - if present - must match an identifier of that ImagingStudy."/>
       <alias value="StudyInstanceUID"/>
       <min value="0"/>
       <max value="1"/>

--- a/source/imagingstudy/bundle-ImagingStudy-search-params.xml
+++ b/source/imagingstudy/bundle-ImagingStudy-search-params.xml
@@ -13,7 +13,7 @@
           <valueString value="ImagingStudy.basedOn"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ImagingStudy-based-on"/>
-        <description value="The order for the image, such as Accession Number associated with a ServiceRequest"/>
+        <description value="The order for the image"/>
         <code value="based-on"/>
         <type value="reference"/>
         <expression value="ImagingStudy.basedOn"/>
@@ -129,7 +129,7 @@
           <valueString value="ImagingStudy.identifier"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/ImagingStudy-identifier"/>
-        <description value="Identifiers for the Study, such as DICOM Study Instance UID"/>
+        <description value="Identifiers for the Study, such as DICOM Study Instance UID or Accession Number"/>
         <code value="identifier"/>
         <type value="token"/>
         <expression value="ImagingStudy.identifier"/>

--- a/source/imagingstudy/imagingstudy-event-mapping-exceptions.xml
+++ b/source/imagingstudy/imagingstudy-event-mapping-exceptions.xml
@@ -2,21 +2,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../tools/schema/mappingExceptions.xsd">
     <!--For information on the contents of this file and how to properly update it, see https://confluence.hl7.org/display/FHIR/Mapping+to+Patterns.-->
     <divergentElement patternPath="Event.identifier" resourcePath="ImagingStudy.identifier">
-        <shortUnmatched reason="Unknown">
-            <_pattern value="Business identifier for imaging study"/>
-            <resource value="Identifiers for the whole study"/>
-        </shortUnmatched>
-        <definitionUnmatched reason="Unknown">
-            <_pattern value="Business identifiers assigned to this imaging study by the performer and/or other systems.  These identifiers remain constant as the resource is updated and propagates from server to server."/>
-            <resource value="Identifiers for the ImagingStudy such as DICOM Study Instance UID."/>
-        </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="Note: This is a business identifier, not a resource identifier (see [discussion](resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number."/>
-            <resource value="See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID."/>
+            <resource value="It is best practice for the identifier to only appear on a single resource instance, however business practices MAY occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number. See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID and Accession Number."/>
         </commentsUnmatched>
         <requirementsUnmatched reason="Unknown">
             <_pattern value="Allows identification of the imaging study as it is known by various participating systems and in a way that remains consistent across servers."/>
-            <resource value="If one or more series elements are present in the ImagingStudy, then there shall be one DICOM Study UID identifier (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
+            <resource value="ImagingStudy.identifier SHALL contain exactly one Study Instance UID value if one or more series element values are present (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
         </requirementsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.basedOn" resourcePath="ImagingStudy.basedOn">
@@ -25,16 +17,12 @@
             _resource="Reference(CarePlan,ServiceRequest,Appointment,AppointmentResponse,Task)" reason="Unknown"/>
         <shortUnmatched reason="Unknown">
             <_pattern value="Fulfills plan, proposal or order"/>
-            <resource value="Request fulfilled"/>
+            <resource value="Fulfills plan or order"/>
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="A plan, proposal or order that is fulfilled in whole or in part by this imaging study."/>
-            <resource value="A list of the diagnostic requests that resulted in this imaging study being performed."/>
+            <resource value="A plan or order that is fulfilled in whole or in part by this imaging study."/>
         </definitionUnmatched>
-        <requirementsUnmatched reason="Unknown">
-            <_pattern value="Allows tracing of authorization for the imaging study and tracking whether proposals/recommendations were acted upon."/>
-            <resource value="To support grouped procedures (one imaging study supporting multiple ordered procedures, e.g. chest/abdomen/pelvis CT).&#xa;If the ImagingStudy is associated with an Accession Number, this field should include a reference to that value in the form:&#xa;-  type = ServiceRequest&#xa;-  identifier.value = (Accession Number Value)&#xa;-  identifier.type = ACSN&#xa;A reference value pointing to a ServiceRequest resource is allowed but is not required."/>
-        </requirementsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.partOf" resourcePath="ImagingStudy.partOf">
         <missingTypes _pattern="Reference(Event)" reason="Unknown"/>
@@ -59,7 +47,7 @@
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="A larger event of which this particular imaging study is a component or step."/>
-            <resource value="This field corresponds to the DICOM Procedure Code Sequence (0008,1032). This is different from the FHIR Procedure resource that may include the ImagingStudy."/>
+            <resource value="This field corresponds to the DICOM Procedure Code Sequence (0008,1032). This is different from the FHIR Procedure resource that MAY include the ImagingStudy."/>
         </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="Not to be used to link an imaging study to an Encounter - use 'context' for that."/>
@@ -77,7 +65,7 @@
         </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="A nominal state-transition diagram can be found in the (Event pattern documentation&#xa;&#xa;Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
-            <resource value="Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
+            <resource value="Unknown does not represent &quot;other&quot; - one of the defined statuses SHALL apply.  Unknown is used when the authoring system is not sure what the current status is."/>
         </commentsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.subject" resourcePath="ImagingStudy.subject">
@@ -106,7 +94,7 @@
         </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="This will typically be the encounter the imaging study was created during, but some imaging studys may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission lab tests)."/>
-            <resource value="This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission test)."/>
+            <resource value="This will typically be the encounter the event occurred within, but some events MAY be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission test)."/>
         </commentsUnmatched>
         <requirementsUnmatched reason="Unknown">
             <_pattern value="Links the imaging study to the Encounter context.  May also affect access control."/>
@@ -171,7 +159,7 @@
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="Comments made about the imaging study by the performer, subject or other participants."/>
-            <resource value="Per the recommended DICOM mapping, this element is derived from the Study Description attribute (0008,1030). Observations or findings about the imaging study should be recorded in another resource, e.g. Observation, and not in this element."/>
+            <resource value="Per the recommended DICOM mapping, this element is derived from the Study Description attribute (0008,1030). Observations or findings about the imaging study SHOULD be recorded in another resource, e.g. Observation, and not in this element."/>
         </definitionUnmatched>
     </divergentElement>
     <unmappedElement patternPath="Event.reported" reason="Not relevant for this resource"/>

--- a/source/imagingstudy/imagingstudy-example-xr.xml
+++ b/source/imagingstudy/imagingstudy-example-xr.xml
@@ -56,8 +56,6 @@
 	<endpoint>
 		<reference value="Endpoint/example-wadors"/>
 	</endpoint>
-	<numberOfSeries value="1"/>
-	<numberOfInstances value="2"/>
 	<procedure>
 		<reference>
 			<reference value="Procedure/example"/>
@@ -85,6 +83,8 @@
 	<note>
 		<text value="XR Wrist 3+ Views"/>
 	</note>
+	<numberOfSeries value="1"/>
+	<numberOfInstances value="2"/>
 	<series>
 		<uid value="2.16.124.113543.6003.1154777499.30246.19789.3503430045.1"/>
 		<number value="3"/>

--- a/source/imagingstudy/imagingstudy-example.xml
+++ b/source/imagingstudy/imagingstudy-example.xml
@@ -15,13 +15,13 @@
 		<reference value="Patient/dicom"/>
 	</subject>
 	<started value="2011-01-01T11:01:20+03:00"/>
-	<numberOfSeries value="1"/>
-	<numberOfInstances value="1"/>
 	<reason>
 		<reference>
 			<reference value="Observation/656"/>
 		</reference>
 	</reason>
+	<numberOfSeries value="1"/>
+	<numberOfInstances value="1"/>
 	<series>
 		<uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
 		<number value="3"/>

--- a/source/imagingstudy/imagingstudy-introduction.xml
+++ b/source/imagingstudy/imagingstudy-introduction.xml
@@ -4,7 +4,10 @@
 <a name="scope"></a>
 <h2>Scope and Usage</h2>
 <p>
-ImagingStudy provides information on a DICOM imaging study, and the series and imaging objects in 
+	The ImagingStudy resource provides information on available imaging data.
+</p>
+<p>
+An ImagingStudy provides information on a DICOM imaging study, and the series and imaging objects in 
 that study. It also provides information on how to retrieve that information (in a native DICOM 
 format, or in a rendered format, such as JPEG). ImagingStudy is used to make information 
 about a single DICOM study available. 
@@ -26,21 +29,22 @@ query (e.g., a DICOMweb search transaction) in the simplest cases. The DICOM ins
 resource; use of a DICOM service is needed (e.g., a DICOMweb retrieve transaction).
 </p>
 <p> 
-An ImagingStudy SHALL reference one DICOM Study, and MAY reference a subset of that Study. More than one ImagingStudy MAY reference the same DICOM Study or different subsets of the same DICOM Study.
+An ImagingStudy SHALL reference one DICOM Study.
 </p>
+<p>This resource may change as additional information is added to the related DICOM Study.</p>
 </div>
 
 <div>
 <a name="bnr"></a>
 <h2>Boundaries and Relationships</h2>
 <p>
-    The <a href="imagingstudy.html">ImagingStudy</a> resource is used to store details of an entire DICOM Study and associated information.
+    The <a href="imagingstudy.html">ImagingStudy</a> resource is used to store details of an entire DICOM Study and associated information, including its relationship to other resources, such as <a href="servicerequest.html">ServiceRequest</a> and <a href="encounter.html">Encounter</a>.
     </p>
     <p>
-		The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions.
+		The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions. Instances of this resource are created for specific clinical purposes and are unlikely to change once created.
 		</p>
 		<p>
-		An <a href="observation.html">Observation</a> MAY be related to a set of images in several ways.
+		An <a href="observation.html">Observation</a> MAY be related to a set of images in the following ways.
 		</p>
 		<ul>
 		  <li><a href="observation.html">Observation.partOf</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a></li>
@@ -50,8 +54,8 @@ An ImagingStudy SHALL reference one DICOM Study, and MAY reference a subset of t
 		</ul>
 	
 
-	<p>Use the <a href="documentreference.html">DocumentReference</a> resource to store non-DICOM images, video, or audio with relevant metadata.</p>
-	<p>Use the <a href="binary.html">Binary</a> resource to store arbitrary content.</p>
+	<p>The <a href="documentreference.html">DocumentReference</a> resource is used to to store non-DICOM images, video, or audio with relevant metadata.</p>
+	<p>The <a href="binary.html">Binary</a> resource to store arbitrary content.</p>
 
 
 </div>

--- a/source/imagingstudy/imagingstudy-introduction.xml
+++ b/source/imagingstudy/imagingstudy-introduction.xml
@@ -40,13 +40,13 @@ An ImagingStudy SHALL reference one DICOM Study, and MAY reference a subset of t
 		The <a href="imagingselection.html">ImagingSelection</a> resource is used to reference to a specific set of specific set of images, frames, waveforms or image regions.
 		</p>
 		<p>
-		An <a href="observation.html">Observation</a> may be related to a set of images in several ways.
+		An <a href="observation.html">Observation</a> MAY be related to a set of images in several ways.
 		</p>
 		<ul>
-		  <li><a href="observation.html">Observation.partOf</a> may reference an <a href="imagingstudy.html">ImagingStudy</a></li>
-		  <li><a href="observation.html">Observation.derivedFrom</a> may reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
-		  <li><a href="observation.html">Observation.derivedFrom</a> may reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
-		  <li><a href="observation.html">Observation.focus</a> may reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
+		  <li><a href="observation.html">Observation.partOf</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a></li>
+		  <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingstudy.html">ImagingStudy</a> when it does not relate to a specific set of images, frames, waveforms or image regions</li>
+		  <li><a href="observation.html">Observation.derivedFrom</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it directly relates to a specific set of images, frames, waveforms or image regions</li>
+		  <li><a href="observation.html">Observation.focus</a> MAY reference an <a href="imagingselection.html">ImagingSelection</a> when it is a measurement of the set of images, frames, waveforms or image regions described by the <a href="imagingselection.html">ImagingSelection</a></li>
 		</ul>
 	
 

--- a/source/imagingstudy/imagingstudy-introduction.xml
+++ b/source/imagingstudy/imagingstudy-introduction.xml
@@ -6,8 +6,8 @@
 <p>
 ImagingStudy provides information on a DICOM imaging study, and the series and imaging objects in 
 that study. It also provides information on how to retrieve that information (in a native DICOM 
-format, or in a rendered format, such as JPEG). ImagingStudy is used to make available information 
-about all parts of a single DICOM study. 
+format, or in a rendered format, such as JPEG). ImagingStudy is used to make information 
+about a single DICOM study available. 
 </p>
 <p>
 This resource provides mappings of its elements to DICOM attributes.  DICOM attributes are identified 
@@ -22,8 +22,8 @@ in <a href="http://medical.nema.org/medical/dicom/current/output/html/part04.htm
 </p>
 <p>
 ImagingStudy provides access to significant DICOM information but will only eliminate the need for DICOM 
-query (e.g., QIDO-RS) in the simplest cases. The DICOM instances are not stored in the ImagingStudy 
-resource; use of a DICOM WADO-RS server or other storage mechanism is needed.
+query (e.g., a DICOMweb search transaction) in the simplest cases. The DICOM instances are not stored in the ImagingStudy 
+resource; use of a DICOM service is needed (e.g., a DICOMweb retrieve transaction).
 </p>
 <p> 
 An ImagingStudy SHALL reference one DICOM Study, and MAY reference a subset of that Study. More than one ImagingStudy MAY reference the same DICOM Study or different subsets of the same DICOM Study.

--- a/source/imagingstudy/imagingstudy-notes.xml
+++ b/source/imagingstudy/imagingstudy-notes.xml
@@ -33,26 +33,22 @@ The ImagingStudy's DICOM Study Instance UID is encoded in the <code>ImagingStudy
 <a name="accession-number"></a>
 <h3>Accession Number</h3>
 <p>
-The study accession number is encoded as an <code>Reference.Identifier</code> using the ServiceRequest Reference type and the <code>“ACSN”</code> identifier type, as follows:
+The study accession number is encoded in the <code>ImagingStudy.identifier</code> element using the <code>ACSN</code> identifier type, e.g.:
 <pre class="json">
 
-"basedOn": [
-    {
-        "type": "ServiceRequest",
-        "identifier":{
-            "type" : {
-                "coding" : [
-                    {
-                        "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                        "code" : "ACSN"
-                    }
-                ]
-            },
-            "system":"http://ginormoushospital.org/accession",
-            "value":"GH334103"
-        }
-    }
-]
+
+"identifier":{
+    "type" : {
+        "coding" : [
+            {
+                "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                "code" : "ACSN"
+            }
+        ]
+    },
+    "system":"http://ginormoushospital.org/accession",
+    "value":"GH334103"
+}
 
 </pre>
 </p>

--- a/source/imagingstudy/imagingstudy-notes.xml
+++ b/source/imagingstudy/imagingstudy-notes.xml
@@ -68,16 +68,16 @@ archive servers, per-series endpoints are required. For the identified services 
 a series would be stored together, and thus instance-level endpoints are not defined.
 </p>
 <p>
-Different Endpoint connection types may have different capabilities, protocols or requirements; and the specified 
-<code>Endpoint.address</code> may require manipulation. See below for the details on use of imaging-related Endpoint connection types.
+Different Endpoint connection types MAY have different capabilities, protocols or requirements; and the specified 
+<code>Endpoint.address</code> MAY require manipulation. See below for the details on use of imaging-related Endpoint connection types.
 </p>
 <a name="wado-rs"></a>
 <h3>WADO-RS</h3>
 <p>
 An <code>Endpoint.connectionType</code> of code <code>dicom-wado-rs</code>, system <code>http://terminology.hl7.org/CodeSystem/endpoint-connection-type</code>, 
 identifies a DICOM WADO-RS service. The <code>Endpoint.address</code> identifies the HTTP(S) service base url. 
-That is, only the scheme, authority and path are included. Sub-services, such as <code>study</code>, shall not be specified. 
-The path shall not contain a trailing slash.
+That is, only the scheme, authority and path are included. Sub-services, such as <code>study</code>, SHALL NOT be specified. 
+The path SHALL NOT contain a trailing slash.
 </p>
 <p>
 The DICOM WADO-RS (Web Access to DICOM Objects, RESTful mode) service uses a RESTful approach to instance retrieval.
@@ -109,7 +109,7 @@ https://pacs.hospital.org/wado-rs/studies/1.2.250.1.59.40211.12345678.678910/ser
 Query parameters on the "rendered" sub-resource can control other aspects of the rendering including: the rendered dimensions, the
 quality (compression ratio), the region of interest to render, the brightness/contrast (window center/width)
 adjustments, and whether to “burn” patient or study demographics into the rendered result. Specific frames
-of a multi-frame instance may be retrieved using the frames sub-resource.
+of a multi-frame instance MAY be retrieved using the frames sub-resource.
 </p>
 <p>
 For example, provided the Accept header indicates a preference for image/jpeg, the example above can be
@@ -138,7 +138,7 @@ see <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part18/PS3
 <h3>WADO-URI</h3>
 <p>An <code>Endpoint.connectionType</code> of code <code>dicom-wado-uri</code>, system <code>http://terminology.hl7.org/CodeSystem/endpoint-connection-type</code>, 
 identifies a DICOM WADO-URI service. The <code>Endpoint.address</code> identifies the HTTP(S) service base url. 
-That is, only the scheme, authority and path are included. Neither a question mark (“?”) nor any query parameters shall be included.
+That is, only the scheme, authority and path are included. Neither a question mark (“?”) nor any query parameters SHALL be included.
 </p>
 <p>
 The DICOM WADO-URI (Web Access to DICOM Objects, URI mode) service uses HTTP query parameter syntax. This service allows
@@ -187,11 +187,11 @@ see <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part18/PS3
 <h3>IID</h3>
 <p>An <code>Endpoint.connectionType</code> of code <code>ihe-iid</code>, system <code>http://terminology.hl7.org/CodeSystem/endpoint-connection-type</code>, 
 identifies an IHE <b>Invoke Image Display (IID)</b> service. The <code>Endpoint.address</code> identifies the HTTP(S) service base url. 
-That is, only the scheme, authority and path are included. Neither a question mark (“?”) nor any query parameters shall be included.
+That is, only the scheme, authority and path are included. Neither a question mark (“?”) nor any query parameters SHALL be included.
 </p>
 <p>
 The IHE <b>Invoke Image Display (IID)</b> service provides a standardized mechanism to launch a viewer in a particular study 
-context. (IID also supports invoking a particular patient context, but that is not profiled here.) An IID-type Endpoint should 
+context. (IID also supports invoking a particular patient context, but that is not profiled here.) An IID-type Endpoint SHOULD 
 be used only at the study level. As well as invoking the viewer on a particular study, query parameters can request particular 
 viewer capabilities, image quality, and more.
 </p>
@@ -221,9 +221,9 @@ or the introduction on the <a href="http://wiki.ihe.net/index.php/Invoke_Image_D
 <a name="additional-dicom-attributes"></a>
 <h3>Additional DICOM attributes</h3>
 <p>
-Some imaging uses may require information beyond what is present in an ImagingStudy resource. Many of the DICOM patient and study level attributes are found in the FHIR Patient, Procedure, or other resources which are referenced from an ImagingStudy instance. Other DICOM content may be transformed into other FHIR resources, such as DiagnosticReports or Observations, which are not directly referenced, but may be easily found.
+Some imaging uses MAY require information beyond what is present in an ImagingStudy resource. Many of the DICOM patient and study level attributes are found in the FHIR Patient, Procedure, or other resources which are referenced from an ImagingStudy instance. Other DICOM content MAY be transformed into other FHIR resources, such as DiagnosticReports or Observations, which are not directly referenced, but MAY be easily found.
 </p><p>
-Although many ImagingStudy consumers are expected to need only the DICOM information contained in FHIR resources, some may need additional DICOM attributes. For these cases, which by their nature involve more imaging-aware consumers, the most flexible solution is to leverage the DICOM WADO-RS metadata-only endpoint to retrieve an XML or JSON representation of the DICOM study, series, instance, or frame information.
+Although many ImagingStudy consumers are expected to need only the DICOM information contained in FHIR resources, some MAY need additional DICOM attributes. For these cases, which by their nature involve more imaging-aware consumers, the most flexible solution is to leverage the DICOM WADO-RS metadata-only endpoint to retrieve an XML or JSON representation of the DICOM study, series, instance, or frame information.
 </p><p>
 A benefit of using the metadata endpoint in this way is that the ImagingStudy creator does not need to know each of the attributes that each of the (current or future) ImagingStudy consumers is (or will be) interested in.
 </p>
@@ -377,19 +377,19 @@ capable DICOM viewing software.
 <a name="size"></a>
 <h3>Size Considerations</h3>
 <p>
-Depending on the modality and procedure type, a DICOM study can range from having one or two instances instance (as in many X-ray procedures) to several thousand instances (for some CT exams). The number of series within a study has far less variability, and is usually under twenty, although post-processing, computer-aided detection, and AI applications may cause modest increases. An ImagingStudy resource describing a large DICOM study would itself be of significant size.
+Depending on the modality and procedure type, a DICOM study can range from having one or two instances instance (as in many X-ray procedures) to several thousand instances (for some CT exams). The number of series within a study has far less variability, and is usually under twenty, although post-processing, computer-aided detection, and AI applications MAY cause modest increases. An ImagingStudy resource describing a large DICOM study would itself be of significant size.
 </p><p>
-Issuing narrowly-tailored queries can help a client avoid search results containing many ImagingStudy resources. The _summary=true query parameter will omit several resource elements, including all instance-level elements; this can be used to examine search results before retrieving the full instances. If a server limits the byte size of search bundle, this may impact the number of ImagingStudy resources returned per search result page; a client can use the _count query parameter to influence the number of resources per search result page.
+Issuing narrowly-tailored queries can help a client avoid search results containing many ImagingStudy resources. The _summary=true query parameter will omit several resource elements, including all instance-level elements; this can be used to examine search results before retrieving the full instances. If a server limits the byte size of search bundle, this MAY impact the number of ImagingStudy resources returned per search result page; a client can use the _count query parameter to influence the number of resources per search result page.
 </p><p>
-When populating an ImagingStudy resource, storing an update for each DICOM instance in the study could result in sending previously sent information repeatedly--an issue that grows as the study size increases. It might also result in a server maintaining thousands of versions of the resource. Repeated, rapid updates of an ImagingStudy may lead to resource contention.
+When populating an ImagingStudy resource, storing an update for each DICOM instance in the study could result in sending previously sent information repeatedly--an issue that grows as the study size increases. It might also result in a server maintaining thousands of versions of the resource. Repeated, rapid updates of an ImagingStudy MAY lead to resource contention.
 </p><p>
-Although not reflected in the ImagingStudy resource, the size of an individual referenced instance may be anywhere from a few kilobytes (a compressed 256x256 pixel MR or 640x480 pixel ultrasound image) to a gigabyte or more (for digital breast tomography imaging). When retrieving the referenced content of an ImagingStudy, consider whether all DICOM instances are needed, whether DICOM instances are used concurrently or sequentially, and what rendering or Transfer Syntax is appropriate for the use case.
+Although not reflected in the ImagingStudy resource, the size of an individual referenced instance MAY be anywhere from a few kilobytes (a compressed 256x256 pixel MR or 640x480 pixel ultrasound image) to a gigabyte or more (for digital breast tomography imaging). When retrieving the referenced content of an ImagingStudy, consider whether all DICOM instances are needed, whether DICOM instances are used concurrently or sequentially, and what rendering or Transfer Syntax is appropriate for the use case.
 </p>
 
 <a name="workflow"></a>
 <h3>ImagingStudy Create and Update Workflow</h3>
 <p>
-The ImagingStudy resource can be hosted by an image archive application - such as a PACS or Vendor-Neutral Archive - or a more general healthcare informatics application such as an EMR. In some cases it may be hosted in both locations.
+The ImagingStudy resource can be hosted by an image archive application - such as a PACS or Vendor-Neutral Archive - or a more general healthcare informatics application such as an EMR. In some cases it MAY be hosted in both locations.
 </p><p>
 However, the image archive is typically the source of truth for the content of the ImagingStudy.
 </p><p>
@@ -474,7 +474,7 @@ while the EMR:
 <p>
 Mechanisms for ensuring consistency between two systems holding representations of the same data are still in development.
 </p><p>
-As the image archive is the "source of truth", the above methods may still be applicable. See Provenance resource.
+As the image archive is the "source of truth", the above methods MAY still be applicable. See Provenance resource.
 </p>
 
 <a name="status"></a>
@@ -482,17 +482,17 @@ As the image archive is the "source of truth", the above methods may still be ap
 <p>
 Typically, an ImagingStudy is a FHIR representation of imaging data that is stored in a DICOM device, such as an image archive (e.g. PACS). The value of the status element reflects the status of this representation and does not necessarily reflect the status of either the underlying imaging data or any ServiceRequest or Task resources that resulted in the ImagingStudy being created.
 </p><p>
-In some cases, the ImagingStudy may be created before any images have been acquired. In this case, the <code>.status</code> will have a value of <code>registered</code>. A <code>registered</code>  ImagingStudy should not be used to load images.
+In some cases, the ImagingStudy MAY be created before any images have been acquired. In this case, the <code>.status</code> will have a value of <code>registered</code>. A <code>registered</code>  ImagingStudy SHOULD NOT be used to load images.
 </p><p>
-After images have been acquired, the ImagingStudy will have a status of <code>available</code>. At this stage the ImagingStudy may be presented to viewing applications.
+After images have been acquired, the ImagingStudy will have a status of <code>available</code>. At this stage the ImagingStudy MAY be presented to viewing applications.
 </p><p>
-If the ImagingStudy is cancelled before images are acquired its status should be set to <code>cancelled</code>.
+If the ImagingStudy is cancelled before images are acquired its status SHOULD be set to <code>cancelled</code>.
 </p><p>
-If the ImagingStudy is incorrect it may be corrected with an update operation or set to <code>entered-in-error</code> and replaced with a new ImagingStudy.
+If the ImagingStudy is incorrect it MAY be corrected with an update operation or set to <code>entered-in-error</code> and replaced with a new ImagingStudy.
 </p><p>
-Additional DICOM images, key object notes, etc. may be created at a later time so a status of <code>complete</code> is not meaningful for an ImagingStudy. For this reason, this status is not defined for an ImagingStudy.
+Additional DICOM images, key object notes, etc. MAY be created at a later time so a status of <code>complete</code> is not meaningful for an ImagingStudy. For this reason, this status is not defined for an ImagingStudy.
 </p><p>
-Any applications waiting for the completion of an imaging-related ServiceRequest or Task should track the progress of those resources directly.
+Any applications waiting for the completion of an imaging-related ServiceRequest or Task SHOULD track the progress of those resources directly.
 </p>
 
 </div>

--- a/source/imagingstudy/imagingstudy-notes.xml
+++ b/source/imagingstudy/imagingstudy-notes.xml
@@ -132,7 +132,7 @@ https://pacs.hospital.org/wado-rs/studies/1.2.250.1.59.40211.12345678.678910/thu
 </pre>
 <p>
 For further details on DICOM WADO-RS capabilities including additional rendering parameters,
-see <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part18/PS3.18.html">DICOM PS 3.18</a>.
+see <a href="https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_10.4.html.">DICOM PS 3.18 Section 10.4</a>.
 </p>
 <a name="wado-uri"></a>
 <h3>WADO-URI</h3>
@@ -181,7 +181,7 @@ https://pacs.hospital.org/wado-uri?requestType=WADO&amp;studyUID=1.2.250.1.59.40
 </pre>
 <p>
 For further details on DICOM WADO-URI capabilities including additional rendering parameters,
-see <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part18/PS3.18.html">DICOM PS 3.18</a>.
+see <a href="https://dicom.nema.org/medical/dicom/current/output/chtml/part18/chapter_9.html">DICOM PS 3.18 Chapter 9</a>.
 </p>
 <a name="iid"></a>
 <h3>IID</h3>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -46,7 +46,7 @@
       <value value="http://www.hl7.org/Special/committees/imagemgt/index.cfm"/>
     </telecom>
   </contact>
-  <description value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities."/>
+  <description value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of instances (images or other data) acquired or produced in a common context.  A series shall have only one modality (e.g. X-ray, CT, MR, ultrasound). A study may have multiple series which may have different modality values."/>
   <fhirVersion value="6.0.0"/>
   <mapping>
     <identity value="workflow"/>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -409,46 +409,6 @@
         <map value="Not supported"/>
       </mapping>
     </element>
-    <element id="ImagingStudy.numberOfSeries">
-      <path value="ImagingStudy.numberOfSeries"/>
-      <short value="Number of Study Related Series"/>
-      <definition value="Number of Series in the Study. This value given MAY be larger than the number of series elements this Resource contains due to resource availability, security, or other factors. This element SHOULD be present if any series elements are present."/>
-      <alias value="NumberOfStudyRelatedSeries"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="unsignedInt"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target[classCode=OBSSER, moodCode=EVN].repeatNumber"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="(0020,1206)"/>
-      </mapping>
-    </element>
-    <element id="ImagingStudy.numberOfInstances">
-      <path value="ImagingStudy.numberOfInstances"/>
-      <short value="Number of Study Related Instances"/>
-      <definition value="Number of SOP Instances in Study. This value given MAY be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element SHOULD be present if any instance elements are present."/>
-      <alias value="NumberOfStudyRelatedInstances"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="unsignedInt"/>
-      </type>
-      <isSummary value="true"/>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target[classCode=DGIMG, moodCode=EVN].repeatNumber"/>
-      </mapping>
-      <mapping>
-        <identity value="dicom"/>
-        <map value="(0020,1208)"/>
-      </mapping>
-    </element>
     <element id="ImagingStudy.procedure">
       <path value="ImagingStudy.procedure"/>
       <short value="The performed procedure or code"/>
@@ -597,6 +557,46 @@
       <mapping>
         <identity value="dicom"/>
         <map value="(0008,1030)"/>
+      </mapping>
+    </element>
+    <element id="ImagingStudy.numberOfSeries">
+      <path value="ImagingStudy.numberOfSeries"/>
+      <short value="Number of Study Related Series"/>
+      <definition value="Number of Series in the Study. This value given MAY be larger than the number of series elements this Resource contains due to resource availability, security, or other factors. This element SHOULD be present if any series elements are present."/>
+      <alias value="NumberOfStudyRelatedSeries"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="unsignedInt"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target[classCode=OBSSER, moodCode=EVN].repeatNumber"/>
+      </mapping>
+      <mapping>
+        <identity value="dicom"/>
+        <map value="(0020,1206)"/>
+      </mapping>
+    </element>
+    <element id="ImagingStudy.numberOfInstances">
+      <path value="ImagingStudy.numberOfInstances"/>
+      <short value="Number of Study Related Instances"/>
+      <definition value="Number of SOP Instances in Study. This value given MAY be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element SHOULD be present if any instance elements are present."/>
+      <alias value="NumberOfStudyRelatedInstances"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="unsignedInt"/>
+      </type>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target[classCode=DGIMG, moodCode=EVN].repeatNumber"/>
+      </mapping>
+      <mapping>
+        <identity value="dicom"/>
+        <map value="(0020,1208)"/>
       </mapping>
     </element>
     <element id="ImagingStudy.series">

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -104,11 +104,11 @@
     </element>
     <element id="ImagingStudy.identifier">
       <path value="ImagingStudy.identifier"/>
-      <short value="Identifiers for the whole study"/>
-      <definition value="Identifiers for the ImagingStudy such as DICOM Study Instance UID."/>
-      <comment value="See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID."/>
-      <requirements value="If one or more series elements are present in the ImagingStudy, then there shall be one DICOM Study UID identifier (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
-      <alias value="StudyInstanceUID"/>
+      <short value="Business identifier for imaging study"/>
+      <definition value="Business identifiers assigned to this imaging study by the performer and/or other systems.  These identifiers remain constant as the resource is updated and propagates from server to server. Typically this will include the DICOM Study Instance UID and Accession Number."/>
+      <comment value="It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number. See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID and Accession Number."/>
+      <requirements value="ImagingStudy.identifier shall contain exactly one Study Instance UID value if one or more series element values are present (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
+      <alias value="StudyInstanceUID, AccessionNumber"/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -308,10 +308,10 @@
     </element>
     <element id="ImagingStudy.basedOn">
       <path value="ImagingStudy.basedOn"/>
-      <short value="Request fulfilled"/>
-      <definition value="A list of the diagnostic requests that resulted in this imaging study being performed."/>
-      <requirements value="To support grouped procedures (one imaging study supporting multiple ordered procedures, e.g. chest/abdomen/pelvis CT).&#xA;If the ImagingStudy is associated with an Accession Number, this field should include a reference to that value in the form:&#xA;-  type = ServiceRequest&#xA;-  identifier.value = (Accession Number Value)&#xA;-  identifier.type = ACSN&#xA;A reference value pointing to a ServiceRequest resource is allowed but is not required."/>
-      <alias value="AccessionNumber"/>
+      <short value="Fulfills plan or order"/>
+      <definition value="A plan or order that is fulfilled in whole or in part by this imaging study."/>
+      <requirements value="Allows tracing of authorization for the imaging study and tracking whether proposals/recommendations were acted upon."/>
+      <comment value="One imaging study may support multiple ordered procedures, e.g. chest/abdomen/pelvis CT orders being fulfilled by a single imaging study."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -46,7 +46,7 @@
       <value value="http://www.hl7.org/Special/committees/imagemgt/index.cfm"/>
     </telecom>
   </contact>
-  <description value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of instances (images or other data) acquired or produced in a common context.  A series shall have only one modality (e.g. X-ray, CT, MR, ultrasound). A study may have multiple series which may have different modality values."/>
+  <description value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of instances (images or other data) acquired or produced in a common context.  A series SHALL have only one modality (e.g. X-ray, CT, MR, ultrasound). A study MAY have multiple series which MAY have different modality values."/>
   <fhirVersion value="6.0.0"/>
   <mapping>
     <identity value="workflow"/>
@@ -82,7 +82,7 @@
     <element id="ImagingStudy">
       <path value="ImagingStudy"/>
       <short value="A set of images produced in single study (one or more series of references images)"/>
-      <definition value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple series of different modalities."/>
+      <definition value="Representation of the content produced in a DICOM imaging study. A study comprises a set of series, each of which includes a set of Service-Object Pair Instances (SOP Instances - images or other data) acquired or produced in a common context.  A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study MAY have multiple series of different modalities."/>
       <min value="0"/>
       <max value="*"/>
       <mapping>
@@ -106,8 +106,8 @@
       <path value="ImagingStudy.identifier"/>
       <short value="Business identifier for imaging study"/>
       <definition value="Business identifiers assigned to this imaging study by the performer and/or other systems.  These identifiers remain constant as the resource is updated and propagates from server to server. Typically this will include the DICOM Study Instance UID and Accession Number."/>
-      <comment value="It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number. See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID and Accession Number."/>
-      <requirements value="ImagingStudy.identifier shall contain exactly one Study Instance UID value if one or more series element values are present (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
+      <comment value="It is best practice for the identifier to only appear on a single resource instance, however business practices MAY occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number. See discussion under [Imaging Study Implementation Notes](imagingstudy.html#dicom-uids) for encoding of DICOM Study Instance UID and Accession Number."/>
+      <requirements value="ImagingStudy.identifier SHALL contain exactly one Study Instance UID value if one or more series element values are present (see [DICOM PS 3.3 C.7.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.2.html)."/>
       <alias value="StudyInstanceUID, AccessionNumber"/>
       <min value="0"/>
       <max value="*"/>
@@ -136,14 +136,14 @@
       <path value="ImagingStudy.status"/>
       <short value="registered | available | cancelled | entered-in-error | unknown"/>
       <definition value="The current state of the ImagingStudy resource. This is not the status of any ServiceRequest or Task resources associated with the ImagingStudy."/>
-      <comment value="Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>
+      <comment value="Unknown does not represent &quot;other&quot; - one of the defined statuses SHALL apply.  Unknown is used when the authoring system is not sure what the current status is."/>
       <min value="1"/>
       <max value="1"/>
       <type>
         <code value="code"/>
       </type>
       <isModifier value="true"/>
-      <isModifierReason value="This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid"/>
+      <isModifierReason value="This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource SHOULD NOT be treated as valid"/>
       <isSummary value="true"/>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -173,7 +173,7 @@
     <element id="ImagingStudy.modality">
       <path value="ImagingStudy.modality"/>
       <short value="All of the distinct values for series' modalities"/>
-      <definition value="A list of all the distinct values of series.modality. This may include both acquisition and non-acquisition modalities."/>
+      <definition value="A list of all the distinct values of series.modality. This MAY include both acquisition and non-acquisition modalities."/>
       <alias value="ModalitiesInStudy"/>
       <min value="0"/>
       <max value="*"/>
@@ -246,7 +246,7 @@
       <path value="ImagingStudy.encounter"/>
       <short value="Encounter with which this imaging study is associated"/>
       <definition value="The healthcare event (e.g. a patient and healthcare provider interaction) during which this ImagingStudy is made."/>
-      <comment value="This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission test)."/>
+      <comment value="This will typically be the encounter the event occurred within, but some events MAY be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission test)."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -311,7 +311,7 @@
       <short value="Fulfills plan or order"/>
       <definition value="A plan or order that is fulfilled in whole or in part by this imaging study."/>
       <requirements value="Allows tracing of authorization for the imaging study and tracking whether proposals/recommendations were acted upon."/>
-      <comment value="One imaging study may support multiple ordered procedures, e.g. chest/abdomen/pelvis CT orders being fulfilled by a single imaging study."/>
+      <comment value="One imaging study MAY support multiple ordered procedures, e.g. chest/abdomen/pelvis CT orders being fulfilled by a single imaging study."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -412,7 +412,7 @@
     <element id="ImagingStudy.numberOfSeries">
       <path value="ImagingStudy.numberOfSeries"/>
       <short value="Number of Study Related Series"/>
-      <definition value="Number of Series in the Study. This value given may be larger than the number of series elements this Resource contains due to resource availability, security, or other factors. This element should be present if any series elements are present."/>
+      <definition value="Number of Series in the Study. This value given MAY be larger than the number of series elements this Resource contains due to resource availability, security, or other factors. This element SHOULD be present if any series elements are present."/>
       <alias value="NumberOfStudyRelatedSeries"/>
       <min value="0"/>
       <max value="1"/>
@@ -432,7 +432,7 @@
     <element id="ImagingStudy.numberOfInstances">
       <path value="ImagingStudy.numberOfInstances"/>
       <short value="Number of Study Related Instances"/>
-      <definition value="Number of SOP Instances in Study. This value given may be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element should be present if any instance elements are present."/>
+      <definition value="Number of SOP Instances in Study. This value given MAY be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element SHOULD be present if any instance elements are present."/>
       <alias value="NumberOfStudyRelatedInstances"/>
       <min value="0"/>
       <max value="1"/>
@@ -452,7 +452,7 @@
     <element id="ImagingStudy.procedure">
       <path value="ImagingStudy.procedure"/>
       <short value="The performed procedure or code"/>
-      <definition value="This field corresponds to the DICOM Procedure Code Sequence (0008,1032). This is different from the FHIR Procedure resource that may include the ImagingStudy."/>
+      <definition value="This field corresponds to the DICOM Procedure Code Sequence (0008,1032). This is different from the FHIR Procedure resource that MAY include the ImagingStudy."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -563,7 +563,7 @@
     <element id="ImagingStudy.note">
       <path value="ImagingStudy.note"/>
       <short value="User-defined comments"/>
-      <definition value="Per the recommended DICOM mapping, this element is derived from the Study Description attribute (0008,1030). Observations or findings about the imaging study should be recorded in another resource, e.g. Observation, and not in this element."/>
+      <definition value="Per the recommended DICOM mapping, this element is derived from the Study Description attribute (0008,1030). Observations or findings about the imaging study SHOULD be recorded in another resource, e.g. Observation, and not in this element."/>
       <min value="0"/>
       <max value="*"/>
       <type>
@@ -670,7 +670,7 @@
     <element id="ImagingStudy.series.modality">
       <path value="ImagingStudy.series.modality"/>
       <short value="The modality used for this series"/>
-      <definition value="The distinct modality for this series. This may include both acquisition and non-acquisition modalities."/>
+      <definition value="The distinct modality for this series. This MAY include both acquisition and non-acquisition modalities."/>
       <alias value="Modality"/>
       <min value="1"/>
       <max value="1"/>
@@ -725,7 +725,7 @@
     <element id="ImagingStudy.series.numberOfInstances">
       <path value="ImagingStudy.series.numberOfInstances"/>
       <short value="Number of Series Related Instances"/>
-      <definition value="Number of SOP Instances in the Study. The value given may be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element should be present if any instance elements are present."/>
+      <definition value="Number of SOP Instances in the Study. The value given MAY be larger than the number of instance elements this resource contains due to resource availability, security, or other factors. This element SHOULD be present if any instance elements are present."/>
       <alias value="NumberOfSeriesRelatedInstances"/>
       <min value="0"/>
       <max value="1"/>
@@ -763,7 +763,7 @@
     <element id="ImagingStudy.series.bodySite">
       <path value="ImagingStudy.series.bodySite"/>
       <short value="Body part examined"/>
-      <definition value="The anatomic structures examined. See [DICOM Part 16 Annex L](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html) for DICOM to SNOMED-CT mappings. The bodySite may indicate the laterality of body part imaged; if so, it shall be consistent with any content of ImagingStudy.series.laterality."/>
+      <definition value="The anatomic structures examined. See [DICOM Part 16 Annex L](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html) for DICOM to SNOMED-CT mappings. The bodySite MAY indicate the laterality of body part imaged; if so, it SHALL be consistent with any content of ImagingStudy.series.laterality."/>
       <alias value="BodyPartExamined"/>
       <min value="0"/>
       <max value="1"/>
@@ -795,7 +795,7 @@
     <element id="ImagingStudy.series.laterality">
       <path value="ImagingStudy.series.laterality"/>
       <short value="Body part laterality"/>
-      <definition value="The laterality of the (possibly paired) anatomic structures examined. E.g., the left knee, both lungs, or unpaired abdomen. If present, shall be consistent with any laterality information indicated in ImagingStudy.series.bodySite."/>
+      <definition value="The laterality of the (possibly paired) anatomic structures examined. E.g., the left knee, both lungs, or unpaired abdomen. If present, SHALL be consistent with any laterality information indicated in ImagingStudy.series.bodySite."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -868,8 +868,8 @@
       <path value="ImagingStudy.series.performer"/>
       <short value="Who performed the series"/>
       <definition value="Indicates who or what performed the series and how they were involved."/>
-      <comment value="If the person who performed the series is not known, their Organization may be recorded. A patient, or related person, may be the performer, e.g. for patient-captured images."/>
-      <requirements value="The performer is recorded at the series level, since each series in a study may be performed by a different performer, at different times, and using different devices. A series may be performed by multiple performers."/>
+      <comment value="If the person who performed the series is not known, their Organization MAY be recorded. A patient, or related person, MAY be the performer, e.g. for patient-captured images."/>
+      <requirements value="The performer is recorded at the series level, since each series in a study MAY be performed by a different performer, at different times, and using different devices. A series MAY be performed by multiple performers."/>
       <alias value="PerformingPhysicianName"/>
       <alias value="OperatorName"/>
       <min value="0"/>

--- a/source/spelling/add.txt
+++ b/source/spelling/add.txt
@@ -1,11 +1,15 @@
 _language
 _query
+excluded_structure
 _in
 _security
 _type
 _lastupdated
 _filter
 _list
+lifecycle
+subject_state
+included_structure
 _profile
 _tag
 _has
@@ -13,3 +17,4 @@ _source
 _id
 _content
 _text
+hrf


### PR DESCRIPTION
ImagingStudy and ImagingSelection approved jira tickets.

## HL7 FHIR Pull Request

- FHIR-48644
- FHIR-47626
- FHIR-47624
- FHIR-47490
- FHIR-47473
- FHIR-47275, FHIR-47619
- FHIR-46262
- FHIR-45034

## Description

- Accession Number should be an ImagingStudy.identifier
- Improvements to 10.5 and 10.5.1
- Capitalize MAY, SHOULD, and SHALL
- Add/improve references
- Move numberOf elements to just before series element
- scope of ImagingSelection and Imaging Study overlaps
- Make the definition of ImagingSelection.frameOfReference clearer
- When both elements studyUid and derivedFrom are present, is not clear when to use one and when the other

