### PR TITLE
QA: Removed references to removed usageContext-group extension

### DIFF
--- a/source/clinicalreasoning-knowledge-artifact-distribution.html
+++ b/source/clinicalreasoning-knowledge-artifact-distribution.html
@@ -112,7 +112,7 @@
   &lt;/coverage&gt;
 </code></pre>
 
-<p>The <code>useContext</code> element can contain any number of characteristics that define the particular context of use for the artifact. Note that the base resource does not communicate the intended semantics when multiple useContext elements are present. To accomplish this, a core extension is defined, <a href="[%extensions-location%]StructureDefinition-usagecontext-group.html">usagecontext-group</a>. All use contexts within a group apply, while groups of use contexts indicate that any group applies.</p>
+<p>The <code>useContext</code> element can contain any number of characteristics that define the particular context of use for the artifact. Note that the base resource does not communicate the intended semantics when multiple useContext elements are present.</p>
 
 <p>In addition, the <code>useContext</code> element is intended to convey <i>prescriptive</i> semantics about the appropriate context of use for an artifact, while the <code>topic</code> element is intended to convey <i>descriptive</i> semantics suitable for indexing and searching using the <code>topic</code> search parameter.</p>
 

--- a/source/plandefinition/plandefinition-example-kdn5-simplified.xml
+++ b/source/plandefinition/plandefinition-example-kdn5-simplified.xml
@@ -234,9 +234,6 @@
   <publisher value="National Comprehensive Cancer Network, Inc."/>
   <description value="Gemcitabine/CARBOplatin"/>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="A"/>
-    </extension>
     <code>
       <system value="http://example.org/fhir/CodeSystem/indications"/>
       <code value="treamentSetting-or-diseaseStatus"/>
@@ -246,9 +243,6 @@
     </valueCodeableConcept>
   </useContext>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="A"/>
-    </extension>
     <code>
       <system value="http://example.org/fhir/CodeSystem/indications"/>
       <code value="disease-or-histology"/>
@@ -258,9 +252,6 @@
     </valueCodeableConcept>
   </useContext>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="A"/>
-    </extension>
     <code>
       <system value="http://terminology.hl7.org/CodeSystem/usage-context-type"/>
       <code value="focus"/>
@@ -270,9 +261,6 @@
     </valueCodeableConcept>
   </useContext>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="B"/>
-    </extension>
     <code>
       <system value="http://example.org/fhir/CodeSystem/indications"/>
       <code value="treatmentSetting-or-diseaseStatus"/>
@@ -282,9 +270,6 @@
     </valueCodeableConcept>
   </useContext>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="B"/>
-    </extension>
     <code>
       <system value="http://example.org/fhir/CodeSystem/indications"/>
       <code value="disease-or-histology"/>
@@ -294,9 +279,6 @@
     </valueCodeableConcept>
   </useContext>
   <useContext>
-    <extension url="http://hl7.org/fhir/StructureDefinition/usagecontext-group">
-      <valueString value="B"/>
-    </extension>
     <code>
       <system value="http://terminology.hl7.org/CodeSystem/usage-context-type"/>
       <code value="focus"/>


### PR DESCRIPTION
The usagecontext-group extension was removed per agreement from the CDS WG. Removing references to this extension from the base specification.