### PR TITLE
Use new kindling + compile for Java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,6 @@ task("printVersion") {
 }
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Versions
-kindlingVersion=1.9.8-SNAPSHOT
+kindlingVersion=1.10.0-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.daemon=true


### PR DESCRIPTION
## HL7 FHIR Pull Request

No changes to `./source` 

## Description

Update to use the new release of Kindling and use Java 11 (which is our pipeline Java version anyway)
