### PR TITLE
J#49875 PRE-APPLIED Add delimiter to EvidenceVariable.dataStorage and Improved the descriptions of two Evidence examples

### DIFF
--- a/source/evidence/list-Evidence-examples.xml
+++ b/source/evidence/list-Evidence-examples.xml
@@ -66,7 +66,7 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
-      <valueString value="An example of using the relatedArtifact element to quote a line of text from the evidence source."/>
+      <valueString value="An example using the relatedArtifact element to quote text from the evidence source"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
       <valueString value="evidence-example-quoted-source"/>
@@ -78,7 +78,7 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
-      <valueString value="Example Evidence Resource for EBMonFHIR IG using SingleStudyEvidence and ComparativeEvidence Profiles"/>
+      <valueString value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
       <valueString value="evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack"/>

--- a/source/evidencevariable/structuredefinition-EvidenceVariable.xml
+++ b/source/evidencevariable/structuredefinition-EvidenceVariable.xml
@@ -709,6 +709,17 @@
 				<code value="string"/>
 			</type>
 		</element>
+		<element id="EvidenceVariable.dataStorage.delimiter">
+			<path value="EvidenceVariable.dataStorage.delimiter"/>
+			<short value="Character(s) separating values in a string-based list"/>
+			<definition value="A character or series of characters that is used within a string to signal the separation of discrete values."/>
+			<comment value="The delimiter element SHOULD only be used when the datatype element is a string- or text-based datatype. The delimiter element is used when the data is stored in a string which contains a list or array of values."/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+		</element>
 		<element id="EvidenceVariable.dataStorage.component">
 		  <path value="EvidenceVariable.dataStorage.component"/>
 		  <definition value="A part of the value for a variable that is stored in 2 or more parts."/>


### PR DESCRIPTION
EvidenceVariable.dataStorage.delimiter 0..1 string

..short = Character(s) separating values in a string-based list

..definition = A character or series of characters that is used within a string to signal the separation of discrete values.

..comment = The delimiter element SHOULD only be used when the datatype element is a string- or text-based datatype. The delimiter element is used when the data is stored in a string which contains a list or array of values.