### PR TITLE
Br cds updates 2025 03 06

### DIFF
--- a/source/clinicalreasoning-knowledge-artifact-distribution.html
+++ b/source/clinicalreasoning-knowledge-artifact-distribution.html
@@ -69,7 +69,12 @@
 <p>
   For distribution via a FHIR server, the search and read interactions defined by the FHIR infrastructure can be used for this purpose. The <a href="library.html">Library</a>, <a href="activitydefinition.html">ActivityDefinition</a>, <a href="plandefinition.html">PlanDefinition</a>, <a href="questionnaire.html">Questionnaire</a>, and <a href="measure.html">Measure</a> resources can all be used to represent knowledge artifacts, and so define several search parameters specifically to enable searching based on the various attributes of a knowledge artifact. A FHIR service that supports at least searching and retrieval of these resources is then a basic Knowledge Artifact Repository. More advanced knowledge management capabilities such as change management, semantic indexing, and dependency tracking can all be provided on top of this basic infrastructure.</p>
 
-<p>Some general considerations for use are documented in what follows, with a more complete and ongoing treatment provided as part of the <a href="[%ig crmi%]">Canonical Resource Management Infrastructure</a> implementation guide.</p>
+<p>Some general considerations for use are documented in what follows, with a more complete and ongoing treatment provided as part of the <a href="[%ig crmi%]">Canonical Resource Management Infrastructure</a> implementation guide, including:</p>
+
+<ul>
+  <li><a href="https://hl7.org/fhir/uv/crmi/artifact-repository-service.html">Artifact Repository Service</a></li>
+  <li><a href="https://hl7.org/fhir/uv/crmi/artifact-terminology-service.html">Artifact Terminology Service</a></li>
+</ul>
 
 <p>In particular, the <code>useContext</code> and <code>topic</code> elements are intended to provide both semantic and topical indexing functionality for use in knowledge repositories. For example, the following fragment illustrates the use of the <code>useContext</code> element to indicate semantic usage context for an example suicide risk order set:</p>
 

--- a/source/detectedissue/detectedissue-example.xml
+++ b/source/detectedissue/detectedissue-example.xml
@@ -29,7 +29,13 @@
       <display value="Drug Interaction Alert"/>
     </coding>
   </code>
-  <severity value="high"/>
+  <severity>
+    <coding>
+      <system value="http://hl7.org/fhir/detectedissue-severity"/>
+      <code value="high"/>
+      <display value="High"/>
+    </coding>
+  </severity>
   <subject>
     <reference value="Device/example"/>
   </subject>

--- a/source/detectedissue/structuredefinition-DetectedIssue.xml
+++ b/source/detectedissue/structuredefinition-DetectedIssue.xml
@@ -242,7 +242,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="code"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
       <binding>
@@ -252,7 +252,7 @@
         <extension url="http://hl7.org/fhir/build/StructureDefinition/v3-map">
           <valueString value="SeverityObservation"/>
         </extension>
-        <strength value="required"/>
+        <strength value="preferred"/>
         <description value="Indicates the potential degree of impact of the identified issue on the patient."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/detectedissue-severity"/>
       </binding>

--- a/source/library/library-introduction.xml
+++ b/source/library/library-introduction.xml
@@ -10,6 +10,8 @@
 
 <p>Note that because the library content may be embedded as well as be retrievable from an external repository via the attachment URL, the possibility exists for the embedded content to be different from the content on the repository. With proper versioning and governance, this should never occur, but to minimize the potential impact of this possibility, implementers SHALL give precedence to the embedded content of a library when it is present.</p>
 
+<p>A common use case for the Library resource is to establish the release dependencies of a collection of artifacts. A library with a type of <code>asset-collection</code> can be used to define the collection of artifacts, as well as the required dependencies, especially when the artifacts in the collection have version-independent canonical references, as is often the case with CodeSystem and ValueSet references. This usage is known as an <i>artifact manifest</i>, and is described more fully in the <a href="http://hl7.org/fhir/uv/crmi/version-manifest.html">Artifact Manifest</a> topic of the <a href="http://hl7.org/fhir/uv/crmi/index.html">Canonical Resource Management Infrastructure</a> implementation guide.</p>
+
 </div>
 
 <div>

--- a/source/plandefinition/structuredefinition-PlanDefinition.xml
+++ b/source/plandefinition/structuredefinition-PlanDefinition.xml
@@ -1544,7 +1544,7 @@
 			<path value="PlanDefinition.action.condition"/>
 			<short value="Whether or not the action is applicable"/>
 			<definition value="An expression that describes applicability criteria or start/stop conditions for the action."/>
-			<comment value="When multiple conditions of the same kind are present, the effects are combined using AND semantics, so the overall condition is true only if all the conditions are true."/>
+			<comment value="If no applicability conditions are present, the action is considered applicable (i.e. it should be performed). When multiple conditions of the same kind are present, the effects are combined using AND semantics, so the overall condition is true only if all the conditions are true. Conditions of different kinds are always considered separately (e.g. applicability and start criteria are never considered together)"/>
 			<min value="0"/>
 			<max value="*"/>
 			<type>

--- a/source/requestorchestration/structuredefinition-RequestOrchestration.xml
+++ b/source/requestorchestration/structuredefinition-RequestOrchestration.xml
@@ -615,7 +615,7 @@
       <path value="RequestOrchestration.action.condition"/>
       <short value="Whether or not the action is applicable"/>
       <definition value="An expression that describes applicability criteria, or start/stop conditions for the action."/>
-      <comment value="When multiple conditions of the same kind are present, the effects are combined using AND semantics, so the overall condition is true only if all of the conditions are true."/>
+      <comment value="If no applicability conditions are present, the action is considered applicable (i.e. it should be performed). When multiple conditions of the same kind are present, the effects are combined using AND semantics, so the overall condition is true only if all the conditions are true. Conditions of different kinds are always considered separately (e.g. applicability and start criteria are never considered together)"/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/requestorchestration/structuredefinition-RequestOrchestration.xml
+++ b/source/requestorchestration/structuredefinition-RequestOrchestration.xml
@@ -472,7 +472,7 @@
         <key value="rqg-1"/>
         <severity value="error"/>
         <human value="Must have resource or action but not both"/>
-        <expression value="resource.exists() != action.exists()"/>
+        <expression value="resource.exists() implies action.exists().not()"/>
         <source value="http://hl7.org/fhir/StructureDefinition/RequestOrchestration"/>
       </constraint>
     </element>

--- a/source/riskassessment/codesystem-risk-assessment-method.xml
+++ b/source/riskassessment/codesystem-risk-assessment-method.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="risk-assessment-method"/>
+  <meta>
+    <lastUpdated value="2021-01-05T10:01:24.148+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/risk-assessment-method"/>
+  <version value="6.0.0"/>
+  <name value="RiskAssessmentMethod"/>
+  <title value="Risk Assessment Method"/>
+  <status value="active"/>
+  <experimental value="true"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Example code system illustrating possible codes for identifying the mechanism or algorithm used to make the assessment; e.g. TIMI, PRISM, Cardiff Type 2 diabetes, etc."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/risk-assessment-method"/>
+  <content value="complete"/>
+  <concept>
+    <code value="timi"/>
+    <display value="TIMI"/>
+    <definition value="Thrombolysis in Myocardial Infarction Risk"/>
+  </concept>
+  <concept>
+    <code value="prism"/>
+    <display value="PRISM"/>
+    <definition value="Pediatric risk of mortality (PRISM)"/>
+  </concept>
+  <concept>
+    <code value="cardiff-t2d"/>
+    <display value="Cardiff T2D"/>
+    <definition value="Cardiff Type 2 Diabetes Risk"/>
+  </concept>
+</CodeSystem>

--- a/source/riskassessment/codesystem-risk-assessment-outcome.xml
+++ b/source/riskassessment/codesystem-risk-assessment-outcome.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="risk-assessment-outcome"/>
+  <meta>
+    <lastUpdated value="2021-01-05T10:01:24.148+11:00"/>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/risk-assessment-outcome"/>
+  <version value="6.0.0"/>
+  <name value="RiskAssessmentOutcome"/>
+  <title value="Risk Assessment Outcome"/>
+  <status value="active"/>
+  <experimental value="true"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Example code system illustrating possible codes for identifying the condition or other outcome; e.g. death, remission, amputation, infection, etc."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/risk-assessment-outcome"/>
+  <content value="complete"/>
+  <concept>
+    <code value="death"/>
+    <display value="Death"/>
+    <definition value="Death"/>
+  </concept>
+  <concept>
+    <code value="remission"/>
+    <display value="Remission"/>
+    <definition value="Remission"/>
+  </concept>
+  <concept>
+    <code value="amputation"/>
+    <display value="Amputation"/>
+    <definition value="Amputation"/>
+  </concept>
+  <concept>
+    <code value="infection"/>
+    <display value="Infection"/>
+    <definition value="Infection"/>
+  </concept>
+</CodeSystem>

--- a/source/riskassessment/riskassessment-event-mapping-exceptions.xml
+++ b/source/riskassessment/riskassessment-event-mapping-exceptions.xml
@@ -71,7 +71,6 @@
         </commentsUnmatched>
     </divergentElement>
     <divergentElement patternPath="Event.code" resourcePath="RiskAssessment.code">
-        <bindingExistence _pattern="true" _resource="false" reason="Unknown"/>
         <shortUnmatched reason="Unknown">
             <_pattern value="What service was done"/>
             <resource value="Type of assessment"/>

--- a/source/riskassessment/structuredefinition-RiskAssessment.xml
+++ b/source/riskassessment/structuredefinition-RiskAssessment.xml
@@ -208,6 +208,7 @@
         </extension>
         <strength value="example"/>
         <description value="The mechanism or algorithm used to make the assessment; e.g. TIMI, PRISM, Cardiff Type 2 diabetes, etc."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/risk-assessment-method"/>
       </binding>
       <mapping>
         <identity value="w5"/>
@@ -228,6 +229,14 @@
         <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="RiskAssessmentCode"/>
+        </extension>
+        <strength value="example"/>
+        <description value="The type of risk assessment performed."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/risk-assessment-method"/>
+      </binding>
       <mapping>
         <identity value="workflow"/>
         <map value="Event.code"/>
@@ -446,6 +455,7 @@
         </extension>
         <strength value="example"/>
         <description value="The condition or other outcome; e.g. death, remission, amputation, infection, etc."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/risk-assessment-outcome"/>
       </binding>
       <mapping>
         <identity value="rim"/>

--- a/source/riskassessment/valueset-risk-assessment-method.xml
+++ b/source/riskassessment/valueset-risk-assessment-method.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="risk-assessment-method"/>
+  <meta>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/risk-assessment-method"/>
+  <version value="6.0.0"/>
+  <name value="RiskAssessmentMethod"/>
+  <title value="Risk Assessment Method"/>
+  <status value="draft"/>
+  <experimental value="true"/>
+  <publisher value="FHIR Project team"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+  </contact>
+  <description value="Example value set illustrating possible codes for identifying the mechanism or algorithm used to make the assessment; e.g. TIMI, PRISM, Cardiff Type 2 diabetes, etc."/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/risk-assessment-method"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/riskassessment/valueset-risk-assessment-outcome.xml
+++ b/source/riskassessment/valueset-risk-assessment-outcome.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="risk-assessment-outcome"/>
+  <meta>
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+  </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/risk-assessment-outcome"/>
+  <version value="6.0.0"/>
+  <name value="RiskAssessmentOutcome"/>
+  <title value="Risk Assessment Outcome"/>
+  <status value="active"/>
+  <experimental value="true"/>
+  <publisher value="FHIR Project team"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+  </contact>
+  <description value="Example value set illustrating possible codes for identifying the condition or other outcome; e.g. death, remission, amputation, infection, etc."/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/risk-assessment-outcome"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/terminologies/codesystem-cdshooks-indicator.xml
+++ b/source/terminologies/codesystem-cdshooks-indicator.xml
@@ -8,9 +8,13 @@
   </identifier>
   <name value="Indicator"/>
   <title value="CDS Hooks Indicator"/>
-  <status value="draft"/>
+  <status value="retired"/>
   <experimental value="false"/>
   <description value="This codesystem captures the indicator codes defined by the CDS Hooks specification. The indicator is included as an element of the cards in a CDS Hooks response and conveys the urgency and/or importance of the information in each card. See [Card Attributes](https://cds-hooks.hl7.org/1.0/#card-attributes) in the CDS Hooks specification for more information."/>
+  <relatedArtifact>
+    <type value="successor"/>
+    <resource value="http://terminology.hl7.org/CodeSystem/cdshooks-indicator"/>
+  </relatedArtifact>
   <caseSensitive value="true"/>
   <content value="complete"/>
   <concept>

--- a/source/terminologies/codesystem-cdshooks-indicator.xml
+++ b/source/terminologies/codesystem-cdshooks-indicator.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="deprecated"/>
+  </extension>
   <url value="http://cds-hooks.hl7.org/CodeSystem/indicator"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>

--- a/source/terminologies/valueset-cdshooks-indicator.xml
+++ b/source/terminologies/valueset-cdshooks-indicator.xml
@@ -11,7 +11,7 @@
   </identifier>
   <name value="Indicator"/>
   <title value="Indicator"/>
-  <status value="draft"/>
+  <status value="retired"/>
   <experimental value="true"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/terminologies/valueset-cdshooks-indicator.xml
+++ b/source/terminologies/valueset-cdshooks-indicator.xml
@@ -4,6 +4,9 @@
   <meta>
     <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="deprecated"/>
+  </extension>
   <url value="http://cds-hooks.hl7.org/ValueSet/indicator"/>
   <identifier>
     <system value="urn:ietf:rfc:3986"/>


### PR DESCRIPTION
* [FHIR-38925](https://jira.hl7.org/browse/FHIR-38925): Added missing example bindings on RiskAssessment
* [FHIR-32639](https://jira.hl7.org/browse/FHIR-32639): Added summary of artifact manifest use case and reference to CRMI
* [FHIR-32643](https://jira.hl7.org/browse/FHIR-32643): Added references to CRMI capability discussions
* [FHIR-19786](https://jira.hl7.org/browse/FHIR-19786): Retired CDSHooksIndicator terminology in favor of THO
* [FHIR-44528](https://jira.hl7.org/browse/FHIR-44528): Relaxed DetectedIssue.severity binding to preferred
* [FHIR-48868](https://jira.hl7.org/browse/FHIR-48868): Corrected RequestOrchestration constraint that resource implies no actions
* [FHIR-46179](https://jira.hl7.org/browse/FHIR-46179): Clarified semantics when no conditions are present