### PR TITLE
FHIR-41319: added improvementNotationGuidance

### DIFF
--- a/source/measure/measure-cms146-example.xml
+++ b/source/measure/measure-cms146-example.xml
@@ -103,14 +103,14 @@
   </type>
   <rationale value="Group A streptococcal bacterial infections and other infections that cause pharyngitis (which are most often viral) often produce the same signs and symptoms (IDSA 2002). The American Academy of Pediatrics, the Centers for Disease Control and Prevention, and the Infectious Diseases Society of America all recommend a diagnostic test for Strep A to improve diagnostic accuracy and avoid unnecessary antibiotic treatment (Linder et al. 2005). Estimated economic costs of pediatric streptococcal pharyngitis in the United States range from $224 million to $539 million per year, including indirect costs related to parental work losses. At a higher level, the economic cost of antibiotic resistance vary but have extended as high as $20 billion in excess direct healthcare costs, with additional costs to society for lost productivity as high as $35 billion a year (2008 dollars) (Roberts et al. 2009)."/>
   <clinicalRecommendationStatement value="The Infectious Diseases Society of America (IDSA) &#34;recommends swabbing the throat and testing for GAS pharyngitis by rapid antigen detection test (RADT) and/or culture because the clinical features alone do not reliably discriminate between GAS and viral pharyngitis except when overt viral features like rhinorrhea, cough, oral ulcers, and/or hoarseness are present&#34;"/>
-  <improvementNotation>
+  <guidance value="This is an episode of care measure that examines all eligible episodes for the patient during the measurement period. If the patient has more than one episode, include all episodes in the measure"/>
+  <group id="CMS146-group-1">
+    <improvementNotation>
     <coding>
       <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
       <code value="increase"/>
     </coding>
   </improvementNotation>
-  <guidance value="This is an episode of care measure that examines all eligible episodes for the patient during the measurement period. If the patient has more than one episode, include all episodes in the measure"/>
-  <group id="CMS146-group-1">
     <population>
       <code><coding><system value="http://terminology.hl7.org/CodeSystem/measure-population"/><code value="initial-population"/></coding></code>
       <criteria><language value="text/cql"/><expression value="CMS146.InitialPopulation"/></criteria>

--- a/source/measure/measure-exclusive-breastfeeding.xml
+++ b/source/measure/measure-exclusive-breastfeeding.xml
@@ -422,17 +422,17 @@
   </type>
   <rationale value="Exclusive breast milk feeding for the first 6 months of neonatal life has long been the expressed goal of World Health Organization (WHO), Department of Health and Human Services (DHHS), American Academy of Pediatrics (AAP) and American College of Obstetricians and Gynecologists (ACOG). ACOG has recently reiterated its position (ACOG, 2007). A recent Cochrane review substantiates the benefits (Kramer et al., 2002). Much evidence has now focused on the prenatal and intrapartum period as critical for the success of exclusive (or any) BF (Centers for Disease Control and Prevention [CDC], 2007; Petrova et al., 2007; Shealy et al., 2005; Taveras et al., 2004). Exclusive breast milk feeding rate during birth hospital stay has been calculated by the California Department of Public Health for the last several years using newborn genetic disease testing data. Healthy People 2010 and the CDC have also been active in promoting this goal."/>
   <clinicalRecommendationStatement value="Exclusive breast milk feeding for the first 6 months of neonatal life can result in numerous long-term health benefits for both mother and newborn and is recommended by a number of national and international organizations. Evidence suggests that the prenatal and intrapartum period is critical for the success of exclusive (or any) breast feeding. Therefore, it is recommended that newborns are fed breast milk only from birth to discharge."/>
-  <improvementNotation>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
-      <code value="increase"/>
-    </coding>
-  </improvementNotation>
   <term>
     <definition value="Gestational age is calculated using the ACOG ReVITALize guidelines with Estimated Due Date (EDD) http://www.acog.org/about_acog/acog_departments/patient_safety_and_quality_improvement/~/media/departments/patient%20safety%20and%20quality%20improvement/201213issuesandrationale-gestationalageterm.pdf. The exam used needs to be the most recent exam associated with this pregnancy"/>
   </term>
   <guidance value="A discharge to a designated cancer center or children's hospital should be captured as a discharge to an acute care facility. It is acceptable to calculate Gestational Age using the American College of Obstetricians and Gynecologists ReVITALize guidelines, which define Gestational Age as calculated using the best obstetrical Estimated Due Date (EDD) based on the formula: Gestational Age= (280-(EDD-Reference Date))/7 where Reference Date is the date on which you are trying to determine gestational age. For PC-05, Reference Date is the Birth Date. Note however that the calculation may yield a non-whole number and gestational age should be rounded off to the nearest completed week. For example, an infant born on the 5th day of the 36th week (35 weeks and 5/7 days) is at a gestational age of 35 weeks, not 36 weeks."/>
   <group id="PopulationGroup1">
+    <improvementNotation>
+      <coding>
+        <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
+        <code value="increase"/>
+      </coding>
+    </improvementNotation>  
     <population>
       <code>
         <coding>
@@ -479,6 +479,12 @@
     </population>
   </group>
   <group id="PopulationGroup2">
+    <improvementNotation>
+      <coding>
+        <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
+        <code value="increase"/>
+      </coding>
+    </improvementNotation>
     <population>
       <code>
         <coding>

--- a/source/measure/measure-predecessor-example.xml
+++ b/source/measure/measure-predecessor-example.xml
@@ -426,6 +426,12 @@
   </improvementNotation>
   <guidance value="A discharge to a designated cancer center or children's hospital should be captured as a discharge to an acute care facility. It is acceptable to calculate Gestational Age using the American College of Obstetricians and Gynecologists ReVITALize guidelines, which define Gestational Age as calculated using the best obstetrical Estimated Due Date (EDD) based on the formula: Gestational Age= (280-(EDD-Reference Date))/7 where Reference Date is the date on which you are trying to determine gestational age. For PC-05, Reference Date is the Birth Date. Note however that the calculation may yield a non-whole number and gestational age should be rounded off to the nearest completed week. For example, an infant born on the 5th day of the 36th week (35 weeks and 5/7 days) is at a gestational age of 35 weeks, not 36 weeks."/>
   <group id="PopulationGroup1">
+    <improvementNotation>
+      <coding>
+        <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
+        <code value="increase"/>
+      </coding>
+    </improvementNotation>  
     <population>
       <code>
         <coding>
@@ -472,6 +478,12 @@
     </population>
   </group>
   <group id="PopulationGroup2">
+    <improvementNotation>
+      <coding>
+        <system value="http://terminology.hl7.org/CodeSystem/measure-improvement-notation"/>
+        <code value="increase"/>
+      </coding>
+    </improvementNotation>  
     <population>
       <code>
         <coding>

--- a/source/measure/structuredefinition-Measure.xml
+++ b/source/measure/structuredefinition-Measure.xml
@@ -1066,6 +1066,33 @@
         <map value="N/A (to add?)"/>
       </mapping>
     </element>
+    <element id="Measure.improvementNotation">
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+				<valueCode value="deprecated"/>
+			</extension>       
+      <path value="Measure.improvementNotation"/>
+      <short value="increase | decrease"/>
+      <definition value="Information on whether an increase or decrease in score is the preferred result (e.g., a higher score indicates better quality OR a lower score indicates better quality OR quality is within a range)."/>
+      <requirements value="Measure consumers and implementers must be able to determine how to interpret a measure score."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="MeasureImprovementNotation"/>
+        </extension>
+        <strength value="required"/>
+        <description value="Observation values that indicate what change in a measurement value or score is indicative of an improvement in the measured item or scored issue."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
+      </binding>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".interpretationCode"/>
+      </mapping>
+    </element>    
     <element id="Measure.term">
       <path value="Measure.term"/>
       <short value="Defined terms used in the measure documentation"/>

--- a/source/measure/structuredefinition-Measure.xml
+++ b/source/measure/structuredefinition-Measure.xml
@@ -1066,30 +1066,6 @@
         <map value="N/A (to add?)"/>
       </mapping>
     </element>
-    <element id="Measure.improvementNotation">
-      <path value="Measure.improvementNotation"/>
-      <short value="increase | decrease"/>
-      <definition value="Information on whether an increase or decrease in score is the preferred result (e.g., a higher score indicates better quality OR a lower score indicates better quality OR quality is within a range)."/>
-      <requirements value="Measure consumers and implementers must be able to determine how to interpret a measure score."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <isSummary value="true"/>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="MeasureImprovementNotation"/>
-        </extension>
-        <strength value="required"/>
-        <description value="Observation values that indicate what change in a measurement value or score is indicative of an improvement in the measured item or scored issue."/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
-      </binding>
-      <mapping>
-        <identity value="rim"/>
-        <map value=".interpretationCode"/>
-      </mapping>
-    </element>
     <element id="Measure.term">
       <path value="Measure.term"/>
       <short value="Defined terms used in the measure documentation"/>
@@ -1390,7 +1366,7 @@
     <element id="Measure.group.improvementNotation">
       <path value="Measure.group.improvementNotation"/>
       <short value="increase | decrease"/>
-      <definition value="Information on whether an increase or decrease in score is the preferred result (e.g., a higher score indicates better quality OR a lower score indicates better quality OR quality is within a range)."/>
+      <definition value="Information on whether an increase or decrease in score is the preferred result (e.g., a higher score indicates better quality OR a lower score indicates better quality OR quality is within a range). Exercise caution when using any values besides increase or decrease for improvementNotation."/>
       <comment value="When specified at the group level, this element defines the improvementNotation for this specific group. If not specified, improvementNotation for this group is determined by the root improvementNotation element"/>
       <requirements value="Measure consumers and implementers must be able to determine how to interpret a measure score."/>
       <min value="0"/>
@@ -1403,7 +1379,7 @@
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
           <valueString value="MeasureImprovementNotation"/>
         </extension>
-        <strength value="required"/>
+        <strength value="extensible"/>
         <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
       </binding>
       <mapping>
@@ -1411,6 +1387,23 @@
         <map value=".methodCode { the aspect of how the calculation is performed }"/>
       </mapping>
     </element>
+    <element id="Measure.group.improvementNotationGuidance">
+      <path value="Measure.group.improvementNotationGuidance"/>
+      <short value="Explanation of improvement notation"/>
+      <definition value="Narrative text to explain the improvement notation and how to interpret it."/>
+      <comment value="This element allows explanation to the improvementNotation be provided. In some cases, additional guidance is required to clearly communicate measure intent around improvement notation. For example, a measure looking at Ceasarean-section births may have an improvement notation of “decrease”, but it is critical to be able to communicate that a measure score of 0 is not the intent."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+      <isModifier value="false"/>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value=".methodCode { the aspect of how the calculation is performed }"/>
+      </mapping>
+    </element>       
     <element id="Measure.group.library">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
         <valueString value="Library is not required to allow for measures that are strictly narrative, as well as for measures that have inline criteria expressions."/>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -416,38 +416,6 @@
         <map value="methodCode"/>
       </mapping>
     </element>
-    <element id="MeasureReport.improvementNotation">
-      <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
-        <valueString value="Improvement notation is included in MeasureReport because it is critical to interpreting the measure, but it must match the improvementNotation of the measure being reported."/>
-      </extension>
-      <path value="MeasureReport.improvementNotation"/>
-      <short value="increase | decrease"/>
-      <definition value="Whether improvement in the measure is noted by an increase or decrease in the measure score."/>
-      <comment value="This element is typically defined by the measure, but reproduced here to ensure the measure score can be interpreted. The element is labeled as a modifier because it changes the interpretation of the reported measure score. Note also that a MeasureReport instance includes the improvementNotation as defined by the Measure being reported. It is duplicated in the MeasureReport because it is a critical aspect of interpreting the measure score but it is not intended to reflect whether the measure report is an increase or decrease. It helps interpret if the measure score is an increase or decrease, I.e., moving in the direction of the desired outcome."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="CodeableConcept"/>
-      </type>
-      <isModifier value="true"/>
-      <isModifierReason value="Improvement notation determines how to interpret the measure score (i.e. whether an increase is an improvement)"/>
-      <isSummary value="true"/>
-      <binding>
-        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="MeasureImprovementNotation"/>
-        </extension>
-        <extension url="http://hl7.org/fhir/tools/StructureDefinition/binding-definition">
-          <valueString value="Observation values that indicate what change in a measurement value or score is indicative of an improvement in the measured item or scored issue."/>
-        </extension>
-        <strength value="required"/>
-        <description value="The improvement notation of the measure report (e.g. increase or decrease)"/>
-        <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
-      </binding>
-      <mapping>
-        <identity value="rim"/>
-        <map value="interpretationCode"/>
-      </mapping>
-    </element>
     <element id="MeasureReport.group">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
         <valueCode value="360,0"/>
@@ -494,7 +462,7 @@
         <identity value="rim"/>
         <map value="participation[typeCode=AUT].time"/>
       </mapping>
-    </element>
+    </element>    
     <element id="MeasureReport.group.code">
       <path value="MeasureReport.group.code"/>
       <short value="Meaning of the group"/>
@@ -550,6 +518,55 @@
         <map value="participation[typeCode=SBJ]"/>
       </mapping>
     </element>
+    <element id="MeasureReport.group.improvementNotation">
+      <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
+        <valueString value="Improvement notation is included in MeasureReport because it is critical to interpreting the measure, but it must match the improvementNotation of the measure being reported."/>
+      </extension>
+      <path value="MeasureReport.group.improvementNotation"/>
+      <short value="increase | decrease"/>
+      <definition value="Whether improvement in the measure is noted by an increase or decrease in the measure score. Exercise caution when using any values besides increase or decrease for improvementNotation."/>
+      <comment value="This element is typically defined by the measure, but reproduced here to ensure the measure score can be interpreted. The element is labeled as a modifier because it changes the interpretation of the reported measure score. Note also that a MeasureReport instance includes the improvementNotation as defined by the Measure being reported. It is duplicated in the MeasureReport because it is a critical aspect of interpreting the measure score but it is not intended to reflect whether the measure report is an increase or decrease. It helps interpret if the measure score is an increase or decrease, I.e., moving in the direction of the desired outcome."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isModifier value="true"/>
+      <isModifierReason value="Improvement notation determines how to interpret the measure score (i.e. whether an increase is an improvement)"/>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="MeasureImprovementNotation"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/binding-definition">
+          <valueString value="Observation values that indicate what change in a measurement value or score is indicative of an improvement in the measured item or scored issue."/>
+        </extension>
+        <strength value="extensible"/>
+        <description value="The improvement notation of the measure report (e.g. increase or decrease)"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
+      </binding>
+      <mapping>
+        <identity value="rim"/>
+        <map value="interpretationCode"/>
+      </mapping>
+    </element>    
+    <element id="MeasureReport.group.improvementNotationGuidance">
+      <path value="MeasureReport.group.improvementNotationGuidance"/>
+      <short value="Explanation of improvement notation"/>
+      <definition value="Narrative text to explain the improvement notation and how to interpret it."/>
+      <comment value="This element allows explanation to the improvementNotation be provided. In some cases, additional guidance is required to clearly communicate measure intent around improvement notation. For example, a measure looking at Ceasarean-section births may have an improvement notation of “decrease”, but it is critical to be able to communicate that a measure score of 0 is not the intent."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+      <isModifier value="false"/>
+      <isSummary value="true"/>
+      <mapping>
+        <identity value="rim"/>
+        <map value="interpretationCode"/>
+      </mapping>
+    </element>       
     <element id="MeasureReport.group.population">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
         <valueCode value="0,240"/>

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -416,6 +416,41 @@
         <map value="methodCode"/>
       </mapping>
     </element>
+    <element id="MeasureReport.improvementNotation">
+      <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
+        <valueString value="Improvement notation is included in MeasureReport because it is critical to interpreting the measure, but it must match the improvementNotation of the measure being reported."/>
+      </extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+				<valueCode value="deprecated"/>
+			</extension>        
+      <path value="MeasureReport.improvementNotation"/>
+      <short value="increase | decrease"/>
+      <definition value="Whether improvement in the measure is noted by an increase or decrease in the measure score."/>
+      <comment value="This element is typically defined by the measure, but reproduced here to ensure the measure score can be interpreted. The element is labeled as a modifier because it changes the interpretation of the reported measure score. Note also that a MeasureReport instance includes the improvementNotation as defined by the Measure being reported. It is duplicated in the MeasureReport because it is a critical aspect of interpreting the measure score but it is not intended to reflect whether the measure report is an increase or decrease. It helps interpret if the measure score is an increase or decrease, I.e., moving in the direction of the desired outcome."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isModifier value="true"/>
+      <isModifierReason value="Improvement notation determines how to interpret the measure score (i.e. whether an increase is an improvement)"/>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="MeasureImprovementNotation"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/binding-definition">
+          <valueString value="Observation values that indicate what change in a measurement value or score is indicative of an improvement in the measured item or scored issue."/>
+        </extension>
+        <strength value="required"/>
+        <description value="The improvement notation of the measure report (e.g. increase or decrease)"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/measure-improvement-notation"/>
+      </binding>
+      <mapping>
+        <identity value="rim"/>
+        <map value="interpretationCode"/>
+      </mapping>
+    </element>    
     <element id="MeasureReport.group">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
         <valueCode value="360,0"/>
@@ -521,7 +556,7 @@
     <element id="MeasureReport.group.improvementNotation">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
         <valueString value="Improvement notation is included in MeasureReport because it is critical to interpreting the measure, but it must match the improvementNotation of the measure being reported."/>
-      </extension>
+      </extension>    
       <path value="MeasureReport.group.improvementNotation"/>
       <short value="increase | decrease"/>
       <definition value="Whether improvement in the measure is noted by an increase or decrease in the measure score. Exercise caution when using any values besides increase or decrease for improvementNotation."/>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-41319 `

## Description

_Please describe your pull request here._
Applied changes to https://jira.hl7.org/browse/FHIR-41319
1) Added a new improvementNotationGuidance element to MeasureReport.group. Note that because of https://jira.hl7.org/browse/FHIR-49922, a new tracker that was approved to simplify Measure/MeasureReport structure overall, this PR does not add improvementNotationGuidance as root element
2) Instead of adding improvementNotation to group, removed the improvementNotation from the root as part of this PR (because of resolution FHIR-49922) and moved it to MeasureReport.group
3) Updated binding of improvementNotation for Measure and MeasureReport to extensible
4) Added "Exercise caution when using any values besides increase or decrease for improvementNotation" to improvementNotation definition
5) Updated examples that have improvementNotation