### PR TITLE
Removed relatedArtifact elements from Examples and added citeAs and relatesTo elements to examples

### DIFF
--- a/source/artifactassessment/artifactassessment-example-risk-of-bias-assessment-of-parachute-trial.xml
+++ b/source/artifactassessment/artifactassessment-example-risk-of-bias-assessment-of-parachute-trial.xml
@@ -13,17 +13,6 @@
 	<extension url="http://hl7.org/fhir/StructureDefinition/artifact-description">
 		<valueMarkdown value="This is an example of the RiskOfBias Profile."/>
 	</extension>
-	<extension url="http://hl7.org/fhir/StructureDefinition/artifact-relatedArtifact">
-		<valueRelatedArtifact>
-			<type value="derived-from"/>
-			<label value="Cloned from"/>
-			<resourceReference>
-				<reference value="ArtifactAssessment/306958"/>
-				<type value="ArtifactAssessment"/>
-				<display value="Joanne Dehnbostel&apos;s Risk of Bias Assessment of 30545967 Parachute use to prevent death and major trauma when jumping from aircraft: randomized controlled trial."/>
-			</resourceReference>
-		</valueRelatedArtifact>
-	</extension>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>

--- a/source/artifactassessment/structuredefinition-ArtifactAssessment.xml
+++ b/source/artifactassessment/structuredefinition-ArtifactAssessment.xml
@@ -127,6 +127,16 @@
       </type>
       <isSummary value="true"/>
     </element>
+    <element id="ArtifactAssessment.citeAs">
+      <path value="ArtifactAssessment.citeAs"/>
+      <short value="How to cite the comment or rating"/>
+      <definition value="Display of the bibliographic citation of the comment, classifier, or rating."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="markdown"/>
+      </type>
+    </element>
     <element id="ArtifactAssessment.artifact[x]">
       <path value="ArtifactAssessment.artifact[x]"/>
       <short value="The artifact assessed, commented upon or rated"/>
@@ -288,16 +298,6 @@
         <identity value="objimpl"/>
         <map value="no-gen-base"/>
       </mapping>
-    </element>
-    <element id="ArtifactAssessment.citeAs">
-      <path value="ArtifactAssessment.citeAs"/>
-      <short value="How to cite the comment or rating"/>
-      <definition value="Display of the bibliographic citation of the comment, classifier, or rating."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="markdown"/>
-      </type>
     </element>
     <element id="ArtifactAssessment.content">
       <path value="ArtifactAssessment.content"/>

--- a/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-ASTRAL-12-alteplase-mRS3-6.xml
@@ -20,15 +20,10 @@
   <name value="RiskOfMRS36At90DaysAfterAlteplaseForStrokeIfASTRALScore12"/>
   <title value="Risk of mRS3-6 at 90 days after Alteplase for Stroke if ASTRAL score 12"/>
   <status value="draft"/>
-  <relatedArtifact>
-    <type value="citation"/>
-    <label value="Cooray 2016 Validation Study"/>
-    <display value="External Validation of the ASTRAL and DRAGON Scores for Prediction of Functional Outcome in Stroke."/>
-    <citation value="Cooray C, Mazya M, Bottai M, Dorado L, Skoda O, Toni D, Ford GA, Wahlgren N, Ahmed N. External Validation of the ASTRAL and DRAGON Scores for Prediction of Functional Outcome in Stroke. Stroke. 2016 Jun;47(6):1493-9. Epub 2016 May 12. PMID 27174528"/>
-    <document>
-      <url value="https://doi.org/10.1161/STROKEAHA.116.012802"/>
-    </document>
-  </relatedArtifact>
+  <relatesTo>
+    <type value="cites"/>
+	<targetMarkdown value="External Validation of the ASTRAL and DRAGON Scores for Prediction of Functional Outcome in Stroke. &lt;b&gt;Citation:&lt;/b&gt; Cooray C, Mazya M, Bottai M, Dorado L, Skoda O, Toni D, Ford GA, Wahlgren N, Ahmed N. External Validation of the ASTRAL and DRAGON Scores for Prediction of Functional Outcome in Stroke. Stroke. 2016 Jun;47(6):1493-9. Epub 2016 May 12. PMID 27174528 &lt;b&gt;URL:&lt;/b&gt; https://doi.org/10.1161/STROKEAHA.116.012802"/>
+  </relatesTo>
   <description value="5.3% risk of mRS 3-6 at 90 days"/>
   <variableDefinition>
     <variableRole value="population"/>

--- a/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
+++ b/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
@@ -20,6 +20,7 @@
 		</assigner>
 	</identifier>
 	<title value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator"/>
+	<citeAs value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator [Database Entry: FHIR Evidence Resource]. Contributors: Joanne Dehnbostel [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 318273. Revised 2025-02-17. Available at: https://fevir.net/resources/Evidence/318273. Computable resource at: https://fevir.net/resources/Evidence/318273#json."/>
 	<status value="active"/>
 	<author>
 		<name value="Joanne Dehnbostel"/>
@@ -32,18 +33,14 @@
 		</telecom>
 	</contact>
 	<copyright value="https://creativecommons.org/licenses/by-nc-sa/4.0/"/>
-	<relatedArtifact>
+	<relatesTo>
 		<type value="part-of"/>
-		<resourceReference>
+		<targetReference>
 			<reference value="Composition/312172"/>
 			<type value="Composition"/>
 			<display value="PARACHUTE Trial Results"/>
-		</resourceReference>
-	</relatedArtifact>
-	<relatedArtifact>
-		<type value="cite-as"/>
-		<citation value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator [Database Entry: FHIR Evidence Resource]. Contributors: Joanne Dehnbostel [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 318273. Revised 2025-02-17. Available at: https://fevir.net/resources/Evidence/318273. Computable resource at: https://fevir.net/resources/Evidence/318273#json."/>
-	</relatedArtifact>
+		</targetReference>
+	</relatesTo>
 	<description value="Example Evidence Resource for EBMonFHIR IG using SingleStudyEvidence and ComparativeEvidence Profiles"/>
 	<variableDefinition>
 		<variableRole value="population"/>

--- a/source/evidence/evidence-example-quoted-source.xml
+++ b/source/evidence/evidence-example-quoted-source.xml
@@ -2,24 +2,23 @@
 
 <Evidence xmlns="http://hl7.org/fhir">.
     <id value="example-quoted-source"/>
+<!--    <extension url="http://hl7.org/fhir/StructureDefinition/relates-to-with-quotation">
+        <extension url="type">
+            <valueCode value="derived-from"/>
+        </extension>
+        <extension url="quotation">
+            <valueMarkdown value="Prevalence of PASC at 30 days post-infection was 68.7% (95% confidence interval: 63.4, 73.9)."/>
+        </extension>
+        <extension url="targetReference">
+            <valueReference>
+                <reference value="Citation/238142"/>
+                <type value="Citation"/>
+                <display value="34347785 Post-acute sequelae of COVID-19 in a non-hospitalized cohort: Results from the Arizona CoVHORT"/>
+            </valueReference>
+        </extension>
+    </extension> !-->
 	<title value="Quoted Source: Prevalence of PASC at 30 days"/>
 	<status value="active"/>
-	<relatedArtifact>
-		<type value="derived-from"/>
-		<classifier>
-			<coding>
-				<system value="http://hl7.org/fhir/provenance-entity-role"/>
-				<code value="quotation"/>
-				<display value="Quotation"/>
-			</coding>
-			<text value="Prevalence of PASC at 30 days post-infection was 68.7% (95% confidence interval: 63.4, 73.9)."/>
-		</classifier>
-		<resourceReference>
-			<reference value="Citation/238142"/>
-			<type value="Citation"/>
-			<display value="34347785 Post-acute sequelae of COVID-19 in a non-hospitalized cohort: Results from the Arizona CoVHORT"/>
-		</resourceReference>
-	</relatedArtifact>
 	<description value="An example of using the relatedArtifact element to quote a line of text from the evidence source."/>
 	<variableDefinition>
 		<description value="People with a history of COVID-19 who were not hospitalized (Arizona CoVHORT)"/>

--- a/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
+++ b/source/evidence/evidence-example-stroke-0-3-alteplase-vs-no-alteplase-mRS3-6.xml
@@ -20,15 +20,10 @@
   <name value="EffectOfAlteplaseVsNoAlteplaseOnMRS36At90DaysInStroke03HoursPrior"/>
   <title value="Effect of Alteplase vs No alteplase on mRS 3-6 at 90 days in Stroke 0-3 hours prior"/>
   <status value="draft"/>
-  <relatedArtifact>
-    <type value="citation"/>
-    <label value="Wardlaw 2014"/>
-    <display value="Analysis 1.16 from Wardlaw 2014"/>
-    <citation value="Wardlaw JM, Murray V, Berge E, del Zoppo GJ. Thrombolysis for acute ischaemic stroke. Cochrane Database Syst Rev. 2014 Jul 29(7):CD000213. PMID 25072528"/>
-    <document>
-      <url value="https://doi.org/10.1002/14651858.CD000213.pub3"/>
-    </document>
-  </relatedArtifact>
+  <relatesTo>
+    <type value="cites"/>
+    <targetMarkdown value="Analysis 1.16 from Wardlaw 2014 &lt;b&gt;Citation:&lt;/b&gt; Wardlaw JM, Murray V, Berge E, del Zoppo GJ. Thrombolysis for acute ischaemic stroke. Cochrane Database Syst Rev. 2014 Jul 29(7):CD000213. PMID 25072528 &lt;b&gt;URL:&lt;/b&gt; https://doi.org/10.1002/14651858.CD000213.pub3"/>
+  </relatesTo>
   <description value="mRS 3-6 at 90 days Odds Ratio 0.65 for Alteplase vs. No Alteplase in patients with acute ischemic stroke 0-3 hours prior"/>
   <variableDefinition>
     <variableRole value="population"/>

--- a/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
+++ b/source/evidence/evidence-example-stroke-3-4half-alteplase-vs-no-alteplase-mRS0-2.xml
@@ -20,15 +20,10 @@
   <name value="EffectOfAlteplaseVsNoAlteplaseOnMRS02At90DaysInStroke345HoursPrior"/>
   <title value="Effect of Alteplase vs No alteplase on mRS 0-2 at 90 days in Stroke 3-4.5 hours prior"/>
   <status value="draft"/>
-  <relatedArtifact>
-    <type value="citation"/>
-    <label value="Lees 2016"/>
-    <display value="Figure 2 Lees 2016"/>
-    <citation value="Lees KR, Emberson J, Blackwell L, Bluhmki E, Davis SM, Donnan GA, et al; Stroke Thrombolysis Trialists’ Collaborators Group. Effects of alteplase for acute stroke on the distribution of functional outcomes: a pooled analysis of 9 trials. Stroke. 2016;47:2373-2379. PMID 27507856"/>
-    <document>
-      <url value="https://doi.org/10.1161/STROKEAHA.116.013644"/>
-    </document>
-  </relatedArtifact>
+  <relatesTo>
+    <type value="cites"/>
+    <targetMarkdown value="Figure 2 Lees 2016 &lt;b&gt;Citation:&lt;/b&gt; Lees KR, Emberson J, Blackwell L, Bluhmki E, Davis SM, Donnan GA, et al; Stroke Thrombolysis Trialists’ Collaborators Group. Effects of alteplase for acute stroke on the distribution of functional outcomes: a pooled analysis of 9 trials. Stroke. 2016;47:2373-2379. PMID 27507856 &lt;b&gt;URL:&lt;/b&gt; https://doi.org/10.1161/STROKEAHA.116.013644"/>
+  </relatesTo>
   <description value="mRS 0-2 at 90 days Odds Ratio 1.2 for Alteplase vs. No Alteplase in patients with acute ischemic stroke 3-4.5 hours prior"/>
   <variableDefinition>
     <variableRole value="population"/>

--- a/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-alteplase-fatalICH.xml
@@ -20,15 +20,10 @@
   <name value="RiskOfFatalICHWithAlteplaseForStroke"/>
   <title value="Risk of fatal ICH with alteplase for stroke"/>
   <status value="draft"/>
-  <relatedArtifact>
-    <type value="citation"/>
-    <label value="Emberson 2014"/>
-    <display value="Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials."/>
-    <citation value="Emberson J, Lees KR, Lyden P, Blackwell L, Albers G, Bluhmki E, et al;Stroke Thrombolysis Trialists' Collaborative Group. Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. Lancet 2014 Nov 29;384(9958):1929-35 PMID 25106063"/>
-    <document>
-      <url value="https://doi.org/10.1016/S0140-6736(14)60584-5"/>
-    </document>
-  </relatedArtifact>
+  <relatesTo>
+    <type value="cites"/>
+    <targetMarkdown value="Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. &lt;b&gt;Citation:&lt;/b&gt; Emberson J, Lees KR, Lyden P, Blackwell L, Albers G, Bluhmki E, et al;Stroke Thrombolysis Trialists' Collaborative Group. Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. Lancet 2014 Nov 29;384(9958):1929-35 PMID 25106063 &lt;b&gt;URL:&lt;/b&gt; https://doi.org/10.1016/S0140-6736(14)60584-5"/>
+  </relatesTo>
   <description value="2.7% incidence of fatal intracranial hemorrhage within 7 days with alteplase in patients with acute ischemic stroke"/>
   <variableDefinition>
     <variableRole value="population"/>

--- a/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
+++ b/source/evidence/evidence-example-stroke-no-alteplase-fatalICH.xml
@@ -20,15 +20,10 @@
   <name value="RiskOfFatalICHWithoutAlteplaseForStroke"/>
   <title value="Risk of fatal ICH without alteplase for stroke"/>
   <status value="draft"/>
-  <relatedArtifact>
-    <type value="citation"/>
-    <label value="Emberson 2014"/>
-    <display value="Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials."/>
-    <citation value="Emberson J, Lees KR, Lyden P, Blackwell L, Albers G, Bluhmki E, et al;Stroke Thrombolysis Trialists' Collaborative Group. Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. Lancet 2014 Nov 29;384(9958):1929-35 PMID 25106063"/>
-    <document>
-      <url value="https://doi.org/10.1016/S0140-6736(14)60584-5"/>
-    </document>
-  </relatedArtifact>
+  <relatesTo>
+    <type value="cites"/>
+    <targetMarkdown value="Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. &lt;b&gt;Citation:&lt;/b&gt; Emberson J, Lees KR, Lyden P, Blackwell L, Albers G, Bluhmki E, et al;Stroke Thrombolysis Trialists' Collaborative Group. Effect of treatment delay, age, and stroke severity on the effects of intravenous thrombolysis with alteplase for acute ischaemic stroke: a meta-analysis of individual patient data from randomised trials. Lancet 2014 Nov 29;384(9958):1929-35 PMID 25106063 &lt;b&gt;URL:&lt;/b&gt; https://doi.org/10.1016/S0140-6736(14)60584-5"/>
+  </relatesTo>
   <description value="0.4% incidence of fatal intracranial hemorrhage within 7 days without alteplase in patients with acute ischemic stroke"/>
   <variableDefinition>
     <variableRole value="population"/>

--- a/source/evidencevariable/evidencevariable-example-outcome-death-or-major-injury.xml
+++ b/source/evidencevariable/evidencevariable-example-outcome-death-or-major-injury.xml
@@ -15,6 +15,7 @@
 	</identifier>
 	<title value="Outcome: Death or Major Traumatic Injury on Impact"/>
 	<shortTitle value="Death or Major Traumatic Injury on Impact"/>
+	<citeAs value="Outcome: Death or Major Traumatic Injury on Impact [Database Entry: FHIR EvidenceVariable Resource]. Contributors: Joanne Dehnbostel [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 297743. Revised 2025-02-15. Available at: https://fevir.net/resources/EvidenceVariable/297743. Computable resource at: https://fevir.net/resources/EvidenceVariable/297743#json."/>
 	<status value="active"/>
 	<author>
 		<name value="Joanne Dehnbostel"/>
@@ -42,10 +43,6 @@
 		</valueCodeableConcept>
 	</useContext>
 	<copyright value="https://creativecommons.org/licenses/by-nc-sa/4.0/"/>
-	<relatedArtifact>
-		<type value="cite-as"/>
-		<citation value="Outcome: Death or Major Traumatic Injury on Impact [Database Entry: FHIR EvidenceVariable Resource]. Contributors: Joanne Dehnbostel [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 297743. Revised 2025-02-15. Available at: https://fevir.net/resources/EvidenceVariable/297743. Computable resource at: https://fevir.net/resources/EvidenceVariable/297743#json."/>
-	</relatedArtifact>
 	<actual value="true"/>
 	<definition>
 		<concept>

--- a/source/evidencevariable/evidencevariable-example-participant-flow.xml
+++ b/source/evidencevariable/evidencevariable-example-participant-flow.xml
@@ -19,6 +19,7 @@
 		</assigner>
 	</identifier>
 	<title value="PARACHUTE Trial Participants that declined randomization - Example EvidenceVariable"/>
+	<citeAs value="PARACHUTE Trial Participants that declined randomization - Example EvidenceVariable [Database Entry: FHIR EvidenceVariable Resource]. Contributors: Brian S. Alper, MD, MSPH [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 346779. Revised 2025-03-10. Available at: https://fevir.net/resources/EvidenceVariable/346779. Computable resource at: https://fevir.net/resources/EvidenceVariable/346779#json."/>
 	<status value="active"/>
 	<author>
 		<name value="Brian S. Alper, MD, MSPH"/>
@@ -46,19 +47,6 @@
 		</valueCodeableConcept>
 	</useContext>
 	<copyright value="https://creativecommons.org/licenses/by-nc-sa/4.0/"/>
-	<relatedArtifact>
-		<type value="cite-as"/>
-		<citation value="PARACHUTE Trial Participants that declined randomization - Example EvidenceVariable [Database Entry: FHIR EvidenceVariable Resource]. Contributors: Brian S. Alper, MD, MSPH [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 346779. Revised 2025-03-10. Available at: https://fevir.net/resources/EvidenceVariable/346779. Computable resource at: https://fevir.net/resources/EvidenceVariable/346779#json."/>
-	</relatedArtifact>
-	<relatedArtifact>
-		<type value="derived-from"/>
-		<label value="Cloned from"/>
-		<resourceReference>
-			<reference value="EvidenceVariable/297948"/>
-			<type value="EvidenceVariable"/>
-			<display value="PARACHUTE Trial Participants that declined randomization"/>
-		</resourceReference>
-	</relatedArtifact>
 	<actual value="true"/>
 	<definition>
 		<concept>


### PR DESCRIPTION
- Also re-arranged the element order for ArtifactAssessment
- Still don't have element examples for ArtifactAssessment.relatesTo and ArtifactAssessmentcontent.relatesTo
- Still need an element example for EvidenceVariable.relatesTo