### PR TITLE
Changed the example resources' urls from fevir.net to hl7.org

### DIFF
--- a/source/citation/citation-example-dataset-citation.xml
+++ b/source/citation/citation-example-dataset-citation.xml
@@ -481,10 +481,6 @@
       <display value="Computable Publishing LLC"/>
     </assigner>
   </identifier>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.8.3"/>
-  </identifier>
   <version value="1.0.0-ballot2"/>
   <title value="DatasetCitation: Extrachromosomal DNA Amplification Contributes to Small Cell Lung Cancer Heterogeneity and is Associated with Worse Outcomes"/>
   <status value="active"/>

--- a/source/citation/citation-example-dataset-citation.xml
+++ b/source/citation/citation-example-dataset-citation.xml
@@ -465,7 +465,7 @@
       </name>
     </Practitioner>
   </contained>
-  <url value="https://fevir.net/resources/Citation/179559"/>
+  <url value="http://hl7.org/fhir/Citation/example-dataset-citation"/>
   <identifier>
     <type>
       <coding>

--- a/source/citation/citation-example-for-parachute-rct.xml
+++ b/source/citation/citation-example-for-parachute-rct.xml
@@ -575,10 +575,6 @@
     <system value="https://pubmed.ncbi.nlm.nih.gov"/>
     <value value="30545967"/>
   </identifier>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.8.2"/>
-  </identifier>
   <title value="30545967 Parachute use to prevent death and major trauma when jumping from aircraft: randomized controlled trial."/>
   <status value="active"/>
   <author>

--- a/source/citation/citation-example-for-parachute-rct.xml
+++ b/source/citation/citation-example-for-parachute-rct.xml
@@ -560,7 +560,7 @@
       </content>
     </ArtifactAssessment>
   </contained>
-  <url value="https://fevir.net/resources/Citation/306957"/>
+  <url value="http://hl7.org/fhir/Citation/example-for-parachute-rct"/>
   <identifier>
     <type>
       <text value="FEvIR Object Identifier"/>

--- a/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
+++ b/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
@@ -19,10 +19,6 @@
 			<display value="Computable Publishing LLC"/>
 		</assigner>
 	</identifier>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.10.8"/>
-  </identifier>
 	<title value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator"/>
 	<citeAs value="Death or Major Traumatic Injury on Impact comparing intervention vs. comparator [Database Entry: FHIR Evidence Resource]. Contributors: Joanne Dehnbostel [Authors/Creators]. In: Fast Evidence Interoperability Resources (FEvIR) Platform, FOI 318273. Revised 2025-02-17. Available at: https://fevir.net/resources/Evidence/318273. Computable resource at: https://fevir.net/resources/Evidence/318273#json."/>
 	<status value="active"/>

--- a/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
+++ b/source/evidence/evidence-example-death-or-major-injury-reduce-parachute-vs-empty-backpack.xml
@@ -8,7 +8,7 @@
 		<profile value="http://hl7.org/fhir/uv/ebm/StructureDefinition/comparative-evidence"/>
 		<profile value="http://hl7.org/fhir/uv/ebm/StructureDefinition/single-study-evidence"/>
 	</meta>
-	<url value="https://fevir.net/resources/Evidence/318273"/>
+	<url value="http://hl7.org/fhir/Evidence/example-death-or-major-injury-reduce-parachute-vs-empty-backpack"/>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>

--- a/source/evidence/evidence-example-statistic-model-include-if.xml
+++ b/source/evidence/evidence-example-statistic-model-include-if.xml
@@ -18,10 +18,6 @@
 			<display value="Computable Publishing LLC"/>
 		</assigner>
 	</identifier>
-  <identifier>
-    <system value="urn:ietf:rfc:3986"/>
-    <value value="urn:oid:2.16.840.1.113883.4.642.10.6"/>
-  </identifier>
 	<title value="Example of statistical analysis plan with different statistical test if non-normal distribution"/>
 	<status value="active"/>
 	<author>

--- a/source/evidence/evidence-example-statistic-model-include-if.xml
+++ b/source/evidence/evidence-example-statistic-model-include-if.xml
@@ -7,7 +7,7 @@
 		<lastUpdated value="2025-03-10T14:59:32.227Z"/>
 		<profile value="http://hl7.org/fhir/uv/ebm/StructureDefinition/statistic-model"/>
 	</meta>
-	<url value="https://fevir.net/resources/Evidence/346428"/>
+	<url value="http://hl7.org/fhir/Evidence/example-statistic-model-include-if"/>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>

--- a/source/evidencevariable/evidencevariable-example-group-assignment.xml
+++ b/source/evidencevariable/evidencevariable-example-group-assignment.xml
@@ -7,7 +7,7 @@
 		<lastUpdated value="2024-12-17T19:40:19.291Z"/>
 		<profile value="http://hl7.org/fhir/uv/ebm/StructureDefinition/group-assignment"/>
 	</meta>
-	<url value="https://fevir.net/resources/EvidenceVariable/297490"/>
+	<url value="http://hl7.org/fhir/EvidenceVariable/example-group-assignment"/>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>

--- a/source/evidencevariable/evidencevariable-example-outcome-death-or-major-injury.xml
+++ b/source/evidencevariable/evidencevariable-example-outcome-death-or-major-injury.xml
@@ -2,7 +2,7 @@
 
 <EvidenceVariable xmlns="http://hl7.org/fhir">
 	<id value="example-outcome-death-or-major-injury"/>
-	<url value="https://fevir.net/resources/EvidenceVariable/297743"/>
+	<url value="http://hl7.org/fhir/EvidenceVariable/example-outcome-death-or-major-injury"/>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>

--- a/source/evidencevariable/evidencevariable-example-participant-flow.xml
+++ b/source/evidencevariable/evidencevariable-example-participant-flow.xml
@@ -7,7 +7,7 @@
 		<lastUpdated value="2025-03-10T13:18:16.608Z"/>
 		<profile value="http://hl7.org/fhir/uv/ebm/StructureDefinition/participant-flow-evidence-variable"/>
 	</meta>
-	<url value="https://fevir.net/resources/EvidenceVariable/346779"/>
+	<url value="http://hl7.org/fhir/EvidenceVariable/example-participant-flow"/>
 	<identifier>
 		<type>
 			<text value="FEvIR Object Identifier"/>


### PR DESCRIPTION
Resolves first issue pointed out by @grahamegrieve here: https://chat.fhir.org/#narrow/channel/179192-fmg/topic/Agenda.20topic/near/509804759

> The first is use of [fevir.net](http://fevir.net/) in the examples. FMG believes that the usage in the examples is problematic, but we found other similar usages, though not as extensive. We generally believe that there's a prohibition in referencing real companies in examples, but none of us could find that written down. We are consulting the TSC to see who should own the policy, and whether TSC want to make rules, or leave it to us, but either way, it's likely that there'll have to be revisions here. But not for now