### PR TITLE
Questionnaire Example, before it was using the UCUM unit of [lb_i] but now it uses [lb_av]

### DIFF
--- a/source/questionnaire/questionnaire-profile-example-ussg-fht.xml
+++ b/source/questionnaire/questionnaire-profile-example-ussg-fht.xml
@@ -53,7 +53,7 @@ Note: The URLs used for LOINC objects have not been approved by the LOINC organi
 							<include>
 								<system value="http://unitsofmeasure.org"/>
 								<concept>
-									<code value="[lb_i]"/>
+									<code value="[[lb_av]]"/>
 									<display value="pounds"/>
 								</concept>
 								<concept>

--- a/source/questionnaire/questionnaire-profile-example-ussg-fht.xml
+++ b/source/questionnaire/questionnaire-profile-example-ussg-fht.xml
@@ -53,7 +53,7 @@ Note: The URLs used for LOINC objects have not been approved by the LOINC organi
 							<include>
 								<system value="http://unitsofmeasure.org"/>
 								<concept>
-									<code value="[[lb_av]]"/>
+									<code value="[lb_av]"/>
 									<display value="pounds"/>
 								</concept>
 								<concept>


### PR DESCRIPTION
This fixes a build crash. This can be pre-applied if someone from FHIR Infrastructure approves it.

I made a Jira tracker J# 50788
https://jira.hl7.org/browse/FHIR-50788