### PR TITLE
Use maven central for kindling snapshot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,15 @@ repositories {
     jcenter()
     google()
     mavenLocal()
+    maven {
+        name = "Central Portal Snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+
+        // Only search this repository for the specific dependency
+        content {
+            includeModule("org.hl7.fhir", "kindling")
+        }
+    }
     mavenCentral()
     maven {
         url = uri("https://jitpack.io")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
-
 plugins {
     java
     application
 }
 
 repositories {
-    jcenter()
+
     google()
     mavenLocal()
+    mavenCentral()
     maven {
         name = "Central Portal Snapshots"
         url = uri("https://central.sonatype.com/repository/maven-snapshots/")
@@ -17,18 +17,11 @@ repositories {
             includeModule("org.hl7.fhir", "kindling")
         }
     }
-    mavenCentral()
     maven {
         url = uri("https://jitpack.io")
     }
     maven {
         url = uri("https://plugins.gradle.org/m2/")
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
     }
 }
 


### PR DESCRIPTION
## Description

Infrastructure change.

The sonatype artifact repository that provided kindling snapshots is being sunset.

Maven central now provides snapshot deployments, and this change in config will allow its use.
