### PR TITLE
FHIR-48895: Add DeviceAlert.derivedFrom.component

### DIFF
--- a/source/devicealert/bundle-DeviceAlert-search-params.xml
+++ b/source/devicealert/bundle-DeviceAlert-search-params.xml
@@ -358,13 +358,13 @@
           <valueInteger value="2" />
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="DeviceAlert.derivedFrom" />
+          <valueString value="DeviceAlert.derivedFrom.observation" />
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/DeviceAlert-derivedFrom" />
         <description value="Whether the alert is currently occurring" />
         <code value="derived-from" />
         <type value="reference" />
-        <expression value="DeviceAlert.derivedFrom" />
+        <expression value="DeviceAlert.derivedFrom.observation" />
         <processingMode value="normal" />
       </SearchParameter>
     </resource>

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -342,7 +342,7 @@
         <element id="DeviceAlert.derivedFrom.observation">
             <path value="DeviceAlert.derivedFrom.observation" />
             <short value="The Observation having a value causing the alert condition" />
-            <definition value="The Observation whose value is is causing the alert condition; or, if `component` is present, the Observation with a component causing the alert condition." />
+            <definition value="The Observation whose value is causing the alert condition; or, if `component` is present, the Observation with a component causing the alert condition." />
             <min value="1" />
             <max value="1" />
             <isSummary value="false" />

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -336,14 +336,36 @@
                 <map value="FiveWs.why[x]" />
             </mapping>
             <type>
+                <code value="BackboneElement" />
+            </type>
+        </element>
+        <element id="DeviceAlert.derivedFrom.observation">
+            <path value="DeviceAlert.derivedFrom.observation" />
+            <short value="The Observation having a value causing the alert condition" />
+            <definition value="The Observation whose value is is causing the alert condition; or, if `component` is present, the Observation with a component causing the alert condition." />
+            <min value="1" />
+            <max value="1" />
+            <isSummary value="false" />
+            <type>
                 <code value="Reference" />
                 <targetProfile value="http://hl7.org/fhir/StructureDefinition/Observation" />
             </type>
         </element>
-        <element id="DeviceAlert.limit">
-            <path value="DeviceAlert.limit" />
-            <short value="The boundaries outside of which a value was detected to cause the alert condition" />
-            <definition value="The limits beyond which a value was detected to cause the alert condition. The actual value is in DeviceAlert.derivedFrom." />
+        <element id="DeviceAlert.derivedFrom.component">
+            <path value="DeviceAlert.derivedFrom.component" />
+            <short value="The `Observation.component` having a value causing the alert condition" />
+            <definition value="If applicable, the code of the component (of the Observation identified in `derivedFrom.observation`) having a value causing the alert condition. This may be used when the alert is associated with a specific component of an Observation, rather than the overall Observation; for example, a low diastolic blood pressure. Since the component is identified by matching `Observation.component.code`, if more than one component have the same code, the specific component is ambiguous. Repetitions of this element indicate additional components contributing to the alert condition." />
+            <min value="0" />
+            <max value="1" />
+            <isSummary value="false" />
+            <type>
+                <code value="Coding" />
+            </type>
+        </element>
+        <element id="DeviceAlert.derivedFrom.limit">
+            <path value="DeviceAlert.derivedFrom.limit" />
+            <short value="The boundaries beyond which a value was detected to cause the alert condition" />
+            <definition value="The limits beyond which a value was detected to cause the alert condition. The actual value is the `Observation.value[x]` referenced by `derivedFrom.observation` or, if specified, the `Observation.component.value[x]` of the component (with `Observation.component.code` matching `derivedFrom.component`) of the reference Observation." />
             <min value="0" />
             <max value="1" />
             <isSummary value="false" />


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-48895 `

## Description

* Added new DeviceAlert backbone element `derivedFrom`
* Moved existing `derivedFrom` element to `derivedFrom.observation`
* Added new DeviceAlert.derivedFrom.component element
* Moved existing `limit` element to `derivedFrom.limit`
