### PR TITLE
FHIR-49183: move DeviceAlert codesystems to THO

### DIFF
--- a/source/devicealert/codesystem-devicealert-activationState.xml
+++ b/source/devicealert/codesystem-devicealert-activationState.xml
@@ -9,7 +9,7 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="draft"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>

--- a/source/devicealert/codesystem-devicealert-activationState.xml
+++ b/source/devicealert/codesystem-devicealert-activationState.xml
@@ -21,15 +21,11 @@
   <status value="active"/>
   <experimental value="false"/>
   <date value="2023-12-10T10:01:24+11:00"/>
-  <publisher value="HL7 (FHIR Project)"/>
+  <publisher value="HL7 International / Health Care Devices"/>
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org/fhir"/>
-    </telecom>
-    <telecom>
-      <system value="email"/>
-      <value value="fhir@lists.hl7.org"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="Describes the activation state of a DeviceAlert."/>

--- a/source/devicealert/codesystem-devicealert-activationState.xml
+++ b/source/devicealert/codesystem-devicealert-activationState.xml
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <id value="devicealert-activationState" />
+  <id value="devicealert-activationState"/>
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="dev" />
+    <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft" />
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="2" />
+    <valueInteger value="2"/>
   </extension>
-  <url value="http://hl7.org/fhir/devicealert-activationState" />
-  <version value="6.0.0" />
-  <name value="DeviceAlertActivationState" />
-  <title value="Device Alert Activation State" />
-  <status value="draft" />
-  <experimental value="false" />
-  <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <url value="http://hl7.org/fhir/CodeSystem/devicealert-activationState"/>
+  <version value="1.0.0"/>
+  <name value="DeviceAlertActivationState"/>
+  <title value="Device Alert Activation State"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2023-12-10T10:01:24+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
     </telecom>
     <telecom>
-      <system value="email" />
-      <value value="fhir@lists.hl7.org" />
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Describes the activation state of a DeviceAlert." />
-  <caseSensitive value="true" />
-  <valueSet value="http://hl7.org/fhir/ValueSet/devicealert-activationState" />
-  <content value="complete" />
+  <description value="Describes the activation state of a DeviceAlert."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/devicealert-activationState"/>
+  <content value="complete"/>
   <concept>
-    <code value="on" />
-    <display value="On" />
-    <definition value="The signal will be announciated during an alert condition" />
+    <code value="on"/>
+    <display value="On"/>
+    <definition value="The signal will be annunciated during an alert condition"/>
   </concept>
   <concept>
-    <code value="off" />
-    <display value="Off" />
-    <definition value="The signal will not be announciated during an alert condition" />
+    <code value="off"/>
+    <display value="Off"/>
+    <definition value="The signal will not be annunciated during an alert condition"/>
   </concept>
   <concept>
-    <code value="paused" />
-    <display value="Paused" />
-    <definition value="Annunciation of the signal during an alert condition has been suppressed temporarily" />
+    <code value="paused"/>
+    <display value="Paused"/>
+    <definition value="Annunciation of the signal during an alert condition has been suppressed temporarily"/>
   </concept>
 </CodeSystem>

--- a/source/devicealert/codesystem-devicealert-priority.xml
+++ b/source/devicealert/codesystem-devicealert-priority.xml
@@ -9,7 +9,7 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="draft"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>

--- a/source/devicealert/codesystem-devicealert-priority.xml
+++ b/source/devicealert/codesystem-devicealert-priority.xml
@@ -21,15 +21,11 @@
   <status value="active"/>
   <experimental value="false"/>
   <date value="2023-12-10T10:01:24+11:00"/>
-  <publisher value="HL7 (FHIR Project)"/>
+  <publisher value="HL7 International / Health Care Devices"/>
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org"/>
-    </telecom>
-    <telecom>
-      <system value="email"/>
-      <value value="fhir@lists.hl7.org"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="Describes the priority of a DeviceAlert."/>

--- a/source/devicealert/codesystem-devicealert-priority.xml
+++ b/source/devicealert/codesystem-devicealert-priority.xml
@@ -1,59 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <id value="devicealert-priority" />
+  <id value="devicealert-priority"/>
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem" />
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
   </meta>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="dev" />
+    <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft" />
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="2" />
+    <valueInteger value="2"/>
   </extension>
-  <url value="http://hl7.org/fhir/devicealert-priority" />
-  <version value="6.0.0" />
-  <name value="DeviceAlertPriority" />
-  <title value="Device Alert Priority" />
-  <status value="draft" />
-  <experimental value="false" />
-  <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <url value="http://hl7.org/fhir/CodeSystem/devicealert-priority"/>
+  <version value="1.0.0"/>
+  <name value="DeviceAlertPriority"/>
+  <title value="Device Alert Priority"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2023-12-10T10:01:24+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <system value="url"/>
+      <value value="http://hl7.org"/>
     </telecom>
     <telecom>
-      <system value="email" />
-      <value value="fhir@lists.hl7.org" />
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
     </telecom>
   </contact>
-  <description value="Describes the priority of a DeviceAlert." />
-  <caseSensitive value="true" />
-  <valueSet value="http://hl7.org/fhir/ValueSet/devicealert-priority" />
-  <content value="complete" />
+  <description value="Describes the priority of a DeviceAlert."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/devicealert-priority"/>
+  <content value="complete"/>
   <concept>
-    <code value="high" />
-    <display value="High Priority" />
-    <definition value="The alert is about a potentially life-threatening condition that should be addressed immediately." />
+    <code value="high"/>
+    <display value="High Priority"/>
+    <definition value="The alert is about a potentially life-threatening condition that should be addressed immediately."/>
   </concept>
   <concept>
-    <code value="medium" />
-    <display value="Medium Priority" />
-    <definition value="The alert is about a significant condition that should be addressed promptly." />
+    <code value="medium"/>
+    <display value="Medium Priority"/>
+    <definition value="The alert is about a significant condition that should be addressed promptly."/>
   </concept>
   <concept>
-    <code value="low" />
-    <display value="Low Priority" />
-    <definition value="The alert is about a condition that should be addressed." />
+    <code value="low"/>
+    <display value="Low Priority"/>
+    <definition value="The alert is about a condition that should be addressed."/>
   </concept>
   <concept>
-    <code value="info" />
-    <display value="Information Only" />
-    <definition value="The alert is about a condition that does not need addressing." />
+    <code value="info"/>
+    <display value="Information Only"/>
+    <definition value="The alert is about a condition that does not need addressing."/>
   </concept>
 </CodeSystem>

--- a/source/devicealert/valueset-devicealert-activationState.xml
+++ b/source/devicealert/valueset-devicealert-activationState.xml
@@ -9,18 +9,19 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/ValueSet/devicealert-activationState"/>
-  <version value="6.0.0"/>
+  <version value="1.0.0"/>
   <name value="DeviceAlertActivationStateCodes"/>
   <title value="DeviceAlert Activation State Codes"/>
-  <status value="draft"/>
+  <status value="active"/>
   <experimental value="false"/>
-  <publisher value="FHIR Project team"/>
+  <date value="2025-07-07T09:02:11-06:00"/>
+  <publisher value="HL7 International / Health Care Devices"/>
   <contact>
     <telecom>
       <system value="url"/>
@@ -30,7 +31,7 @@
   <description value="DeviceAlert Activation State Codes"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/devicealert-activationState"/>
+      <system value="http://hl7.org/fhir/CodeSystem/devicealert-activationState"/>
     </include>
   </compose>
 </ValueSet>

--- a/source/devicealert/valueset-devicealert-activationState.xml
+++ b/source/devicealert/valueset-devicealert-activationState.xml
@@ -9,7 +9,7 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="draft"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>

--- a/source/devicealert/valueset-devicealert-activationState.xml
+++ b/source/devicealert/valueset-devicealert-activationState.xml
@@ -25,7 +25,7 @@
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org/fhir"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="DeviceAlert Activation State Codes"/>

--- a/source/devicealert/valueset-devicealert-condition.xml
+++ b/source/devicealert/valueset-devicealert-condition.xml
@@ -9,7 +9,7 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="draft"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>

--- a/source/devicealert/valueset-devicealert-condition.xml
+++ b/source/devicealert/valueset-devicealert-condition.xml
@@ -25,7 +25,7 @@
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org/fhir"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="DeviceAlert Condition Codes"/>

--- a/source/devicealert/valueset-devicealert-condition.xml
+++ b/source/devicealert/valueset-devicealert-condition.xml
@@ -1,36 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="devicealert-condition" />
+  <id value="devicealert-condition"/>
   <meta>
-    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset" />
+    <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
   </meta>
-  <extension
-    url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
-    <valueCode value="dev" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="dev"/>
   </extension>
-  <extension
-    url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="trial-use"/>
   </extension>
-  <extension
-    url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="2" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="2"/>
   </extension>
-  <url value="http://hl7.org/fhir/ValueSet/devicealert-condition" />
-  <version value="6.0.0" />
-  <name value="DeviceAlertConditionCodes" />
-  <title value="DeviceAlert Condition Codes" />
-  <status value="draft" />
-  <experimental value="false" />
-  <publisher value="FHIR Project team" />
+  <url value="http://hl7.org/fhir/ValueSet/devicealert-condition"/>
+  <version value="1.0.0"/>
+  <name value="DeviceAlertConditionCodes"/>
+  <title value="DeviceAlert Condition Codes"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2025-07-07T09:02:11-06:00"/>
+  <publisher value="HL7 International / Health Care Devices"/>
   <contact>
     <telecom>
-      <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
     </telecom>
   </contact>
-  <description value="DeviceAlert Condition Codes" />
+  <description value="DeviceAlert Condition Codes"/>
   <compose>
     <include>
       <system value="urn:iso:std:iso:11073:10101"/>

--- a/source/devicealert/valueset-devicealert-priority.xml
+++ b/source/devicealert/valueset-devicealert-priority.xml
@@ -9,7 +9,7 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="trial-use"/>
+    <valueCode value="draft"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>

--- a/source/devicealert/valueset-devicealert-priority.xml
+++ b/source/devicealert/valueset-devicealert-priority.xml
@@ -25,7 +25,7 @@
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://hl7.org/fhir"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="DeviceAlert Priority Codes"/>

--- a/source/devicealert/valueset-devicealert-priority.xml
+++ b/source/devicealert/valueset-devicealert-priority.xml
@@ -9,18 +9,19 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="draft"/>
+    <valueCode value="trial-use"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
     <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/ValueSet/devicealert-priority"/>
-  <version value="6.0.0"/>
+  <version value="1.0.0"/>
   <name value="DeviceAlertPriorityCodes"/>
   <title value="DeviceAlert Priority Codes"/>
-  <status value="draft"/>
+  <status value="active"/>
   <experimental value="false"/>
-  <publisher value="FHIR Project team"/>
+  <date value="2025-07-07T09:02:11-06:00"/>
+  <publisher value="HL7 International / Health Care Devices"/>
   <contact>
     <telecom>
       <system value="url"/>
@@ -30,7 +31,7 @@
   <description value="DeviceAlert Priority Codes"/>
   <compose>
     <include>
-      <system value="http://hl7.org/fhir/devicealert-priority"/>
+      <system value="http://hl7.org/fhir/CodeSystem/devicealert-priority"/>
     </include>
   </compose>
 </ValueSet>

--- a/source/spelling/add.txt
+++ b/source/spelling/add.txt
@@ -1,15 +1,11 @@
 _language
 _query
-excluded_structure
 _in
 _security
 _type
 _lastupdated
 _filter
 _list
-lifecycle
-subject_state
-included_structure
 _profile
 _tag
 _has
@@ -17,4 +13,3 @@ _source
 _id
 _content
 _text
-hrf


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-49183`

## Description

* Remove DeviceAlert code systems and value sets moved to THO
* Update DeviceAlert to use THO value sets