### PR TITLE
Removed bodyPosition in Observation map-sitting example

### DIFF
--- a/source/observation/observation-example-map-sitting.xml
+++ b/source/observation/observation-example-map-sitting.xml
@@ -2,7 +2,7 @@
 	<id value="map-sitting"/>
 
 	<!--	To be used only when the body position in not precoordinated in the observation code.-->
-	<extension url="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition">
+<!-- 	<extension url="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition">
 		<valueCodeableConcept>
 			<coding>
 				<system value="http://snomed.info/sct"/>
@@ -10,7 +10,7 @@
 				<display value="Sitting position (finding)"/>
 			</coding>
 		</valueCodeableConcept>
-	</extension>
+	</extension> -->
 		<!--	The qualitative change in the value relative to the previous measurement. Usually only recorded if the change is clinically significant.-->
 	<extension url="http://hl7.org/fhir/StructureDefinition/observation-delta">
 		<valueCodeableConcept>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

Removed no longer permitted extension from observation-example-map-sitting
