### PR TITLE
FHIR-51699 correct DeviceAlert vocab metadata

### DIFF
--- a/source/devicealert/codesystem-devicealert-activationState.xml
+++ b/source/devicealert/codesystem-devicealert-activationState.xml
@@ -18,14 +18,14 @@
   <version value="6.0.0" />
   <name value="DeviceAlertActivationState" />
   <title value="Device Alert Activation State" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />
@@ -39,12 +39,12 @@
   <concept>
     <code value="on" />
     <display value="On" />
-    <definition value="The signal will be announciated during an alert condition" />
+    <definition value="The signal will be annunciated during an alert condition" />
   </concept>
   <concept>
     <code value="off" />
     <display value="Off" />
-    <definition value="The signal will not be announciated during an alert condition" />
+    <definition value="The signal will not be annunciated during an alert condition" />
   </concept>
   <concept>
     <code value="paused" />

--- a/source/devicealert/codesystem-devicealert-annunciation.xml
+++ b/source/devicealert/codesystem-devicealert-annunciation.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertAnnunciation" />
   <title value="Device Alert Annunciation" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-category.xml
+++ b/source/devicealert/codesystem-devicealert-category.xml
@@ -18,14 +18,14 @@
   <version value="6.0.0" />
   <name value="DeviceAlertCategory" />
   <title value="Device Alert Category" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-manifestation.xml
+++ b/source/devicealert/codesystem-devicealert-manifestation.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertManifestation" />
   <title value="Device Alert Manifestation" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-presence.xml
+++ b/source/devicealert/codesystem-devicealert-presence.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertPresence" />
   <title value="Device Alert Presence" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-priority.xml
+++ b/source/devicealert/codesystem-devicealert-priority.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertPriority" />
   <title value="Device Alert Priority" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-signalType.xml
+++ b/source/devicealert/codesystem-devicealert-signalType.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertSignalType" />
   <title value="Device Alert Signal Type" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-status.xml
+++ b/source/devicealert/codesystem-devicealert-status.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertStatus" />
   <title value="Device Alert Status" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/codesystem-devicealert-type.xml
+++ b/source/devicealert/codesystem-devicealert-type.xml
@@ -18,14 +18,15 @@
   <version value="6.0.0" />
   <name value="DeviceAlertType" />
   <title value="Device Alert Type" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <date value="2023-12-10T10:01:24+11:00" />
-  <publisher value="HL7 (FHIR Project)" />
+  <publisher value="HL7 International / Health Care Devices" />
+
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
     <telecom>
       <system value="email" />

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -33,7 +33,7 @@
     <contact>
         <telecom>
             <system value="url" />
-            <value value="http://hl7.org/fhir" />
+            <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
         </telecom>
     </contact>
     <contact>

--- a/source/devicealert/valueset-devicealert-activationState.xml
+++ b/source/devicealert/valueset-devicealert-activationState.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertActivationStateCodes"/>
   <title value="DeviceAlert Activation State Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-annunciation.xml
+++ b/source/devicealert/valueset-devicealert-annunciation.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertAnnunciationCodes"/>
   <title value="DeviceAlert Annunciation Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-category.xml
+++ b/source/devicealert/valueset-devicealert-category.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertCategoryCodes"/>
   <title value="DeviceAlert Category Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-condition.xml
+++ b/source/devicealert/valueset-devicealert-condition.xml
@@ -21,13 +21,13 @@
   <version value="6.0.0" />
   <name value="DeviceAlertConditionCodes" />
   <title value="DeviceAlert Condition Codes" />
-  <status value="draft" />
+  <status value="active" />
   <experimental value="false" />
   <publisher value="FHIR Project team" />
   <contact>
     <telecom>
       <system value="url" />
-      <value value="http://hl7.org/fhir" />
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
     </telecom>
   </contact>
   <description value="DeviceAlert Condition Codes" />

--- a/source/devicealert/valueset-devicealert-manifestation.xml
+++ b/source/devicealert/valueset-devicealert-manifestation.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertManifestationCodes"/>
   <title value="DeviceAlert Manifestation Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-presence.xml
+++ b/source/devicealert/valueset-devicealert-presence.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertPresenceCodes"/>
   <title value="DeviceAlert Presence Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-priority.xml
+++ b/source/devicealert/valueset-devicealert-priority.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertPriorityCodes"/>
   <title value="DeviceAlert Priority Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-signalType.xml
+++ b/source/devicealert/valueset-devicealert-signalType.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertSignalTypeCodes"/>
   <title value="DeviceAlert Signal Type Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-status.xml
+++ b/source/devicealert/valueset-devicealert-status.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertStatusCodes"/>
   <title value="DeviceAlert Status Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>

--- a/source/devicealert/valueset-devicealert-type.xml
+++ b/source/devicealert/valueset-devicealert-type.xml
@@ -18,7 +18,7 @@
   <version value="6.0.0"/>
   <name value="DeviceAlertTypeCodes"/>
   <title value="DeviceAlert Type Codes"/>
-  <status value="draft"/>
+  <status value="active" />
   <experimental value="false"/>
   <publisher value="FHIR Project team"/>
   <contact>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-51699`

## Description

Changed DeviceAlert terminology to active status, corrected publisher and publisher url to Devices committee, corrected a spelling error in concept definition.