### PR TITLE
correction to ist-6 and ist-7

### DIFF
--- a/source/deviceusage/deviceusage-event-mapping-exceptions.xml
+++ b/source/deviceusage/deviceusage-event-mapping-exceptions.xml
@@ -30,6 +30,22 @@
             <resource value="Allows tracing of authorization for the DeviceUsage and tracking whether proposals/recommendations were acted upon."/>
         </requirementsUnmatched>
     </divergentElement>
+    <divergentElement patternPath="Event.partOf" resourcePath="DeviceUsage.partOf">
+        <missingTypes _pattern="Reference(Event)" reason="Unknown"/>
+        <extraTypes _resource="Reference(DeviceUsage)" reason="Unknown"/>
+        <shortUnmatched reason="Unknown">
+            <_pattern value="Part of referenced event"/>
+            <resource value="Part of referenced device usage"/>
+        </shortUnmatched>
+        <definitionUnmatched reason="Unknown">
+            <_pattern value="A larger event of which this particular device usage is a component or step."/>
+            <resource value="A larger event of which this particular device usage is one part the usage."/>
+        </definitionUnmatched>
+        <commentsUnmatched reason="Unknown">
+            <_pattern value="Not to be used to link an device usage to an Encounter - use 'context' for that."/>
+            <resource value=""/>
+        </commentsUnmatched>
+    </divergentElement>
     <divergentElement patternPath="Event.status" resourcePath="DeviceUsage.status">
         <shortUnmatched reason="Unknown">
             <_pattern value="preparation | in-progress | not-done | suspended | aborted | completed | entered-in-error | unknown"/>
@@ -144,7 +160,6 @@
             <resource value="Details about the device statement that were not represented at all or sufficiently in one of the attributes provided in a class. These may include for example a comment, an instruction, or a note associated with the statement."/>
         </definitionUnmatched>
     </divergentElement>
-    <unmappedElement patternPath="Event.partOf" reason="Unknown"/>
     <unmappedElement patternPath="Event.reported" reason="Unknown"/>
     <unmappedElement patternPath="Event.relevantHistory" reason="Unknown"/>
     <unmappedElement patternPath="Event.code" reason="Unknown"/>

--- a/source/imagingstudy/invariant-tests/ist-6.f1.fail.xml
+++ b/source/imagingstudy/invariant-tests/ist-6.f1.fail.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is used with detectedissue-example-dup, so don't make changes that would cause it to no longer be a duplicate -->
+<ImagingStudy xmlns="http://hl7.org/fhir">
+	<id value="ist-4.f2.fail"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">CT Chest.  John Smith (MRN: 09236). Accession: W12342398. Performed: 2011-01-01. 3 series, 12 images.</div>
+	</text>
+	<identifier>
+		<system value="urn:dicom:uid"/>
+		<value value="urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045"/>
+	</identifier>
+	<status value="available"/>
+	<subject>
+		<reference value="Patient/dicom"/>
+	</subject>
+	<started value="2011-01-01T11:01:20+03:00"/>
+	<reason>
+		<reference>
+			<reference value="Observation/656"/>
+		</reference>
+	</reason>
+
+	<series>
+		<uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
+		<number value="3"/>
+		<modality>
+		  <coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="CT"/>
+		  </coding>
+		</modality> 
+		<description value="CT Surview 180"/>
+		<numberOfInstances value="1"/>
+		<bodySite>
+			<reference>
+				<reference value="BodyStructure/tumor"/>
+			</reference>
+		</bodySite>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092903"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="1"/>
+		</instance>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092904"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="4"/>
+		</instance>
+	</series>   
+</ImagingStudy>

--- a/source/imagingstudy/invariant-tests/ist-6.f2.fail.xml
+++ b/source/imagingstudy/invariant-tests/ist-6.f2.fail.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is used with detectedissue-example-dup, so don't make changes that would cause it to no longer be a duplicate -->
+<ImagingStudy xmlns="http://hl7.org/fhir">
+	<id value="ist-4.f2.fail"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">CT Chest.  John Smith (MRN: 09236). Accession: W12342398. Performed: 2011-01-01. 3 series, 12 images.</div>
+	</text>
+	<identifier>
+		<system value="urn:dicom:uid"/>
+		<value value="urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045"/>
+	</identifier>
+	<status value="available"/>
+	<subject>
+		<reference value="Patient/dicom"/>
+	</subject>
+	<started value="2011-01-01T11:01:20+03:00"/>
+	<reason>
+		<reference>
+			<reference value="Observation/656"/>
+		</reference>
+	</reason>
+<!-- ist-6 needs to not have the root level numberOf values as those are caught by others, but does need a series that has the series numberOfInstances different than the count of instances -->
+	<series>
+		<uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
+		<number value="3"/>
+		<modality>
+		  <coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="CT"/>
+		  </coding>
+		</modality> 
+		<description value="CT Surview 180"/>
+		<numberOfInstances value="2"/>
+		<bodySite>
+			<reference>
+				<reference value="BodyStructure/tumor"/>
+			</reference>
+		</bodySite>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092903"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="1"/>
+		</instance>
+
+	</series>   
+</ImagingStudy>

--- a/source/imagingstudy/invariant-tests/ist-6.f3.fail.xml
+++ b/source/imagingstudy/invariant-tests/ist-6.f3.fail.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is used with detectedissue-example-dup, so don't make changes that would cause it to no longer be a duplicate -->
+<ImagingStudy xmlns="http://hl7.org/fhir">
+	<id value="ist-4.f2.fail"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">CT Chest.  John Smith (MRN: 09236). Accession: W12342398. Performed: 2011-01-01. 3 series, 12 images.</div>
+	</text>
+	<identifier>
+		<system value="urn:dicom:uid"/>
+		<value value="urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045"/>
+	</identifier>
+	<status value="available"/>
+	<subject>
+		<reference value="Patient/dicom"/>
+	</subject>
+	<started value="2011-01-01T11:01:20+03:00"/>
+	<reason>
+		<reference>
+			<reference value="Observation/656"/>
+		</reference>
+	</reason>
+<!-- ist-6 needs to not have the root level numberOf values as those are caught by others, but does need a series that has the series numberOfInstances different than the count of instances -->
+    <series>
+        <uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805631"/>
+        <number value="4"/>
+        <modality>
+            <coding>
+                <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+                <code value="CT"/>
+            </coding>
+        </modality>
+        <description value="CT Surview 180"/>
+        <numberOfInstances value="1"/>
+        <bodySite>
+            <reference>
+                <reference value="BodyStructure/tumor"/>
+            </reference>
+        </bodySite>
+        <instance>
+            <uid value="2.16.124.113543.6003.189642796.63084.16748.2599092904"/>
+            <sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+            <number value="4"/>
+        </instance>
+    </series>
+	<series>
+		<uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
+		<number value="3"/>
+		<modality>
+		  <coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="CT"/>
+		  </coding>
+		</modality> 
+		<description value="CT Surview 180"/>
+		<numberOfInstances value="1"/>
+		<bodySite>
+			<reference>
+				<reference value="BodyStructure/tumor"/>
+			</reference>
+		</bodySite>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092903"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="1"/>
+		</instance>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092904"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="4"/>
+		</instance>
+	</series>   
+</ImagingStudy>

--- a/source/imagingstudy/invariant-tests/ist-6.p1.pass.xml
+++ b/source/imagingstudy/invariant-tests/ist-6.p1.pass.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is used with detectedissue-example-dup, so don't make changes that would cause it to no longer be a duplicate -->
+<ImagingStudy xmlns="http://hl7.org/fhir">
+	<id value="ist-4.f2.fail"/>
+	<text>
+		<status value="generated"/>
+		<div xmlns="http://www.w3.org/1999/xhtml">CT Chest.  John Smith (MRN: 09236). Accession: W12342398. Performed: 2011-01-01. 3 series, 12 images.</div>
+	</text>
+	<identifier>
+		<system value="urn:dicom:uid"/>
+		<value value="urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045"/>
+	</identifier>
+	<status value="available"/>
+	<subject>
+		<reference value="Patient/dicom"/>
+	</subject>
+	<started value="2011-01-01T11:01:20+03:00"/>
+	<reason>
+		<reference>
+			<reference value="Observation/656"/>
+		</reference>
+	</reason>
+<!-- ist-6 needs to not have the root level numberOf values as those are caught by others, but does need a series that has the series numberOfInstances different than the count of instances -->
+	<series>
+		<uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
+		<number value="3"/>
+		<modality>
+		  <coding>
+			<system value="http://dicom.nema.org/resources/ontology/DCM"/>
+			<code value="CT"/>
+		  </coding>
+		</modality> 
+		<description value="CT Surview 180"/>
+		<numberOfInstances value="2"/>
+		<bodySite>
+			<reference>
+				<reference value="BodyStructure/tumor"/>
+			</reference>
+		</bodySite>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092903"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="1"/>
+		</instance>
+		<instance>
+			<uid value="2.16.124.113543.6003.189642796.63084.16748.2599092904"/>
+			<sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+			<number value="4"/>
+		</instance>
+	</series>   
+</ImagingStudy>

--- a/source/imagingstudy/invariant-tests/ist-7.p4.pass.xml
+++ b/source/imagingstudy/invariant-tests/ist-7.p4.pass.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is used with detectedissue-example-dup, so don't make changes that would cause it to no longer be a duplicate -->
+<ImagingStudy xmlns="http://hl7.org/fhir">
+    <id value="ist-7.f2.fail"/>
+    <text>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">CT Chest.  John Smith (MRN: 09236). Accession: W12342398. Performed: 2011-01-01. 3 series, 12 images.</div>
+    </text>
+    <identifier>
+        <system value="urn:dicom:uid"/>
+        <value value="urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045"/>
+    </identifier>
+    <status value="available"/>
+    <modality>
+        <coding>
+            <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+            <code value="MR"/>
+        </coding>
+    </modality>
+    <modality>
+        <coding>
+            <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+            <code value="CT"/>
+        </coding>
+    </modality>
+    <subject>
+        <reference value="Patient/dicom"/>
+    </subject>
+    <started value="2011-01-01T11:01:20+03:00"/>
+    <reason>
+        <reference>
+            <reference value="Observation/656"/>
+        </reference>
+    </reason>
+    <numberOfSeries value="2"/>
+    <numberOfInstances value="2"/>
+    <series>
+        <uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805630"/>
+        <number value="3"/>
+        <modality>
+            <coding>
+                <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+                <code value="CT"/>
+            </coding>
+        </modality>
+        <description value="CT Surview 180"/>
+        <numberOfInstances value="1"/>
+        <bodySite>
+            <reference>
+                <reference value="BodyStructure/tumor"/>
+            </reference>
+        </bodySite>
+        <instance>
+            <uid value="2.16.124.113543.6003.189642796.63084.16748.2599092903"/>
+            <sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+            <number value="1"/>
+        </instance>
+    </series>
+    <series>
+        <uid value="2.16.124.113543.6003.2588828330.45298.17418.2723805631"/>
+        <number value="4"/>
+        <modality>
+            <coding>
+                <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+                <code value="MR"/>
+            </coding>
+        </modality>
+        <description value="MR Surview 180"/>
+        <numberOfInstances value="1"/>
+        <bodySite>
+            <reference>
+                <reference value="BodyStructure/tumor"/>
+            </reference>
+        </bodySite>
+        <instance>
+            <uid value="2.16.124.113543.6003.189642796.63084.16748.2599092904"/>
+            <sopClass value="urn:oid:1.2.840.10008.5.1.4.1.1.2"/>
+            <number value="4"/>
+        </instance>
+    </series>
+</ImagingStudy>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -125,7 +125,7 @@
         <key value="ist-7"/>
         <severity value="error"/>
         <human value="If modality is present, modality SHALL equal all of the distinct values of series.modality"/>
-        <expression value="modality.exists() implies modality.distinct() = series.modality.distinct()"/>
+        <expression value="modality.exists() implies modality.exclude(series.modality).empty()"/>
       </constraint>
       <mapping>
         <identity value="workflow"/>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -125,7 +125,7 @@
         <key value="ist-7"/>
         <severity value="error"/>
         <human value="If modality is present, modality SHALL equal all of the distinct values of series.modality"/>
-        <expression value="modality.coding.select(system&amp;'|'&amp;code).exclude(series.modality.coding.select(system&amp;'|'&amp;code)).empty() and modality.text.exclude(series.modality.text).empty()"/>
+        <expression value="modality.exists() implies modality.coding.select(system&amp;'|'&amp;code).trace('r').exclude(series.modality.coding.select(system&amp;'|'&amp;code).trace('c')).empty() and modality.text.exclude(series.modality.text).empty() and series.modality.coding.select(system&amp;'|'&amp;code).trace('r').exclude(modality.coding.select(system&amp;'|'&amp;code).trace('c')).empty() and series.modality.text.exclude(modality.text).empty()"/>
       </constraint>
       <mapping>
         <identity value="workflow"/>
@@ -599,7 +599,6 @@
       <condition value="ist-4"/>
       <condition value="ist-5"/>
       <condition value="ist-6"/>
-      <condition value="ist-8"/>
       <isSummary value="true"/>
       <mapping>
         <identity value="rim"/>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -125,7 +125,7 @@
         <key value="ist-7"/>
         <severity value="error"/>
         <human value="If modality is present, modality SHALL equal all of the distinct values of series.modality"/>
-        <expression value="modality.exists() implies modality.exclude(series.modality).empty()"/>
+        <expression value="modality.coding.select(system&amp;'|'&amp;code).exclude(series.modality.coding.select(system&amp;'|'&amp;code)).empty() and modality.text.exclude(series.modality.text).empty()"/>
       </constraint>
       <mapping>
         <identity value="workflow"/>

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -119,7 +119,7 @@
         <key value="ist-6"/>
         <severity value="error"/>
         <human value="For each series element, if numberOfInstances and instance are both present, the numberOfInstances value SHALL match the number of instance elements"/>
-        <expression value="numberOfInstances.exists() and series.exists() implies numberOfInstances = series.instance.count()"/>
+        <expression value="series.where(numberOfInstances.empty() or instance.empty() or numberOfInstances = instance.count()).count() = series.count()"/>
       </constraint>
       <constraint>
         <key value="ist-7"/>

--- a/source/visionprescription/visionprescription-fivews-mapping-exceptions.xml
+++ b/source/visionprescription/visionprescription-fivews-mapping-exceptions.xml
@@ -11,7 +11,6 @@
     <unmappedElement patternPath="FiveWs.why" reason="Unknown"/>
     <unmappedElement patternPath="FiveWs.source" reason="Unknown"/>
     <unmappedElement patternPath="FiveWs.who" reason="Unknown"/>
-    <unmappedElement patternPath="FiveWs.grade" reason="Unknown"/>
     <unmappedElement patternPath="FiveWs.planned" reason="Unknown"/>
     <unmappedElement patternPath="FiveWs.done" reason="Unknown"/>
 </mappingExceptions>

--- a/source/visionprescription/visionprescription-request-mapping-exceptions.xml
+++ b/source/visionprescription/visionprescription-request-mapping-exceptions.xml
@@ -35,6 +35,24 @@
             <resource value=""/>
         </requirementsUnmatched>
     </divergentElement>
+    <divergentElement patternPath="Request.groupIdentifier" resourcePath="VisionPrescription.groupIdentifier">
+        <shortUnmatched reason="Unknown">
+            <_pattern value="Composite request this is part of"/>
+            <resource value="Composite request identifier"/>
+        </shortUnmatched>
+        <definitionUnmatched reason="Unknown">
+            <_pattern value="A shared identifier common to all requests that were authorized more or less simultaneously by a single author, representing the identifier of the requisition, prescription or similar form."/>
+            <resource value="A shared identifier common to all Vision Prescriptions that were authorized more or less simultaneously by a single author, representing the composite or group identifier."/>
+        </definitionUnmatched>
+        <commentsUnmatched reason="Unknown">
+            <_pattern value="Requests are linked either by a &quot;basedOn&quot; relationship (i.e. one request is fulfilling another) or by having a common requisition.  Requests that are part of the same requisition are generally treated independently from the perspective of changing their state or maintaining them after initial creation."/>
+            <resource value=""/>
+        </commentsUnmatched>
+        <requirementsUnmatched reason="Unknown">
+            <_pattern value="Some business processes need to know if multiple items were ordered as part of the same &quot;prescription&quot; or &quot;requisition&quot; for billing or other purposes."/>
+            <resource value=""/>
+        </requirementsUnmatched>
+    </divergentElement>
     <divergentElement patternPath="Request.status" resourcePath="VisionPrescription.status">
         <shortUnmatched reason="Unknown">
             <_pattern value="draft | active | on-hold | revoked | completed | entered-in-error | unknown"/>
@@ -108,9 +126,7 @@
     </divergentElement>
     <unmappedElement patternPath="Request.intent" reason="Unknown"/>
     <unmappedElement patternPath="Request.insurance" reason="Unknown"/>
-    <unmappedElement patternPath="Request.priority" reason="Unknown"/>
     <unmappedElement patternPath="Request.occurrence" reason="Unknown"/>
-    <unmappedElement patternPath="Request.groupIdentifier" reason="Unknown"/>
     <unmappedElement patternPath="Request.deliverTo" reason="Unknown"/>
     <unmappedElement patternPath="Request.replaces" reason="Unknown"/>
     <unmappedElement patternPath="Request.supportingInfo" reason="Unknown"/>


### PR DESCRIPTION
In reviewing the CI build, I am noticing that I failed to update the expression of ist-6, it is a copy of ist-4. According to the jira ticket [FHIR-50771](http://jira.hl7.org/browse/FHIR-50771) it should be

series.where(numberOfInstances.empty() or instance.empty() or numberOfInstances = instance.count()).count() = series.count()

although I think the ending ".count() - series.count()" is not in scope of the ticket for ist-6
