### PR TITLE
FHIR-53906: device alert standards status

### DIFF
--- a/source/devicealert/bundle-DeviceAlert-search-params.xml
+++ b/source/devicealert/bundle-DeviceAlert-search-params.xml
@@ -12,7 +12,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -41,7 +41,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -74,7 +74,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -111,7 +111,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -140,7 +140,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -169,11 +169,11 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-          <valueInteger value="1" />
+          <valueInteger value="2" />
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="DeviceAlert.category" />
@@ -198,7 +198,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -227,11 +227,11 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-          <valueInteger value="0" />
+          <valueInteger value="2" />
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="DeviceAlert.acknowledged" />
@@ -256,7 +256,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -285,7 +285,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -314,7 +314,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -343,7 +343,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -374,7 +374,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -404,7 +404,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -433,7 +433,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -463,7 +463,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -493,7 +493,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -522,7 +522,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-          <valueCode value="draft" />
+          <valueCode value="normative" />
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
@@ -555,7 +555,7 @@
         </extension>
         <extension
           url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-          <valueInteger value="1" />
+          <valueInteger value="2" />
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
           <valueString value="DeviceAlert.procedure" />

--- a/source/devicealert/codesystem-devicealert-category.xml
+++ b/source/devicealert/codesystem-devicealert-category.xml
@@ -6,10 +6,10 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="informative"/>
+    <valueCode value="normative"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/devicealert-category"/>
   <version value="6.0.0"/>

--- a/source/devicealert/codesystem-devicealert-signalType.xml
+++ b/source/devicealert/codesystem-devicealert-signalType.xml
@@ -6,10 +6,10 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="informative"/>
+    <valueCode value="normative"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/devicealert-signalType"/>
   <version value="6.0.0"/>

--- a/source/devicealert/devicealert-event-mapping-exceptions.xml
+++ b/source/devicealert/devicealert-event-mapping-exceptions.xml
@@ -109,7 +109,7 @@
             <_pattern value="The date, period or timing when the device alert did occur or is occurring."/>
             <resource value="This element is used to record the date or time period when the alert condition did occur or is occurring."/>
         </definitionUnmatched>
-        <commentsUnmatched reason="Unknown">
+        <commentsUnmatched reason="More precise, resource-specific wording.">
             <_pattern value="This indicates when the activity actually occurred or is occurring, not when it was asked/requested/ordered to occur.  For the latter, look at the occurence element of the  Request this {{event}} is &quot;basedOn&quot;.  The status code allows differentiation of whether the timing reflects a historic event or an ongoing event.  Ongoing events should not include an upper bound in the Period or Timing.bounds.&#10;."/>
             <resource value="This element is used to record the time period during which the alert condition is or was active. The status code allows differentiation of whether the timing reflects a historic event or an ongoing event. A date/time value SHOULD be used for instantaneous conditions. Partial date/time values are ambiguous about whether they represent the condition occurring at some point in the partially specified period, or for all of the period, and (absent additional guidance) SHOULD be avoided. Ongoing events SHOULD not include a Period upper bound."/>
         </commentsUnmatched>

--- a/source/devicealert/devicealert-introduction.xml
+++ b/source/devicealert/devicealert-introduction.xml
@@ -1,6 +1,16 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
         <div>
-                <h2>Scope and Usage</h2>
+        <blockquote class="ballot-note" id="bn1">
+            <p><b>Note to Balloters:</b>Key changes made since the January 2026 R6 ballot include:</p>
+            <ul>
+                <li>Non-substantive changes:
+                    <ul>
+                        <li>Updated the DeviceAlert resource's standards status to normative, along with the CodeSystem, ValueSet, and SearchParameters resources it uses. (<a href="https://jira.hl7.org/browse/FHIR-53906">FHIR-53906</a>)</li>
+                    </ul>
+                </li>
+            </ul>
+        </blockquote>
+        <h2>Scope and Usage</h2>
                 <p>DeviceAlert represents a single alert condition detected and signaled by a device to create clinician&apos;s awareness of a patient safety risk that needs to be addressed.</p>
                 <p>The device is often a communicating, physical, patient-connected health/medical device operating in an acute care setting (e.g., patient monitor, ventilator, infusion pump, etc.). However, Software as a Medical Device (SaMD), non-patient connected devices, and other Health Software &#x201C;apps,&#x201D; as well as lower acuity care settings (e.g., a fall detector app running on a patient&apos;s mobile device at home) are in scope as well.</p>
                 <p>Alerts can relate to physiological (e.g., Patient Lucy has a low SpO2), technical (e.g., Infusion Pump #2 has a fluid line occlusion), or other conditions. Alerts can also  have different priorities based on the hazard&apos;s severity and urgency of clinicians&apos; action, ranging from High (e.g., a life-threatening condition requiring immediate response) to Advisory (e.g., information to create contextual awareness without requiring timely response).</p>

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -32,7 +32,7 @@
     <contact>
         <telecom>
             <system value="url" />
-            <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
+            <value value="http://www.hl7.org/Special/committees/healthcaredevices" /> 
         </telecom>
     </contact>
     <description value="Describes a physiological or technical alert condition report originated by a device.  The DeviceAlert resource is derived from the ISO/IEEE 11073-10201 Domain Information Model standard, but is more widely applicable. " />

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -35,12 +35,6 @@
             <value value="http://www.hl7.org/Special/committees/healthcaredevices" />
         </telecom>
     </contact>
-    <contact>
-        <telecom>
-            <system value="url" />
-            <value value="http://www.hl7.org/Special/committees/healthcaredevices/index.cfm" />
-        </telecom>
-    </contact>
     <description value="Describes a physiological or technical alert condition report originated by a device.  The DeviceAlert resource is derived from the ISO/IEEE 11073-10201 Domain Information Model standard, but is more widely applicable. " />
     <fhirVersion value="6.0.0" />
     <mapping>

--- a/source/devicealert/structuredefinition-DeviceAlert.xml
+++ b/source/devicealert/structuredefinition-DeviceAlert.xml
@@ -8,7 +8,7 @@
         <valueString value="Base.Entities" />
     </extension>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-        <valueCode value="draft" />
+        <valueCode value="normative" />
     </extension>
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
         <valueInteger value="2" />

--- a/source/devicealert/valueset-devicealert-category.xml
+++ b/source/devicealert/valueset-devicealert-category.xml
@@ -6,10 +6,10 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="informative"/>
+    <valueCode value="normative"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/ValueSet/devicealert-category"/>
   <version value="6.0.0"/>

--- a/source/devicealert/valueset-devicealert-signalType.xml
+++ b/source/devicealert/valueset-devicealert-signalType.xml
@@ -6,10 +6,10 @@
     <valueCode value="dev"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="informative"/>
+    <valueCode value="normative"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/>
+    <valueInteger value="2"/>
   </extension>
   <url value="http://hl7.org/fhir/ValueSet/devicealert-signalType"/>
   <version value="6.0.0"/>

--- a/source/devicealert/valueset-observation-codes.xml
+++ b/source/devicealert/valueset-observation-codes.xml
@@ -6,7 +6,7 @@
     <valueCode value="oo"/>
   </extension>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-    <valueCode value="informative"/>
+    <valueCode value="normative"/>
   </extension>
   <url value="http://hl7.org/fhir/ValueSet/observation-codes"/>
   <identifier>

--- a/source/devicemetric/structuredefinition-DeviceMetric.xml
+++ b/source/devicemetric/structuredefinition-DeviceMetric.xml
@@ -42,7 +42,7 @@
   <contact>
     <telecom>
       <system value="url"/>
-      <value value="http://www.hl7.org/Special/committees/healthcaredevices/index.cfm"/>
+      <value value="http://www.hl7.org/Special/committees/healthcaredevices"/>
     </telecom>
   </contact>
   <description value="Describes a measurement, calculation or setting capability of a device. The DeviceMetric resource is derived from the ISO/IEEE 11073-10201 Domain Information Model standard, but is more widely applicable."/>


### PR DESCRIPTION
## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `FHIR-53906`

## Description

Correct standards status and FMM level for DeviceAlert and associated search params, code systems, value sets; also updated mapping exceptions; added changelog.