### PR TITLE
J#56598 Updating the ResearchSubject.subjectMilestone.milestone terminology binding url and name

### DIFF
--- a/source/researchsubject/structuredefinition-ResearchSubject.xml
+++ b/source/researchsubject/structuredefinition-ResearchSubject.xml
@@ -312,11 +312,11 @@
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-          <valueString value="ResearchSubjectMilestone"/>
+          <valueString value="ResearchSubjectMilestones"/>
         </extension>
         <strength value="example"/>
         <description value="Indicates the progression of a study subject through a study."/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/research-subject-milestone"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/research-subject-milestones"/>
       </binding>
     </element>
     <element id="ResearchSubject.subjectMilestone.date">


### PR DESCRIPTION
Now: http://terminology.hl7.org/ValueSet/research-subject-milestones
Because that THO ValueSet was updated to have an 's' at the end.