### PR TITLE
J#57262 & J#57263 added Evidence.classification and Composition.classification

### DIFF
--- a/source/composition/composition-introduction.xml
+++ b/source/composition/composition-introduction.xml
@@ -4,7 +4,7 @@
 <blockquote class="ballot-note" id="bn1">
 <p><b>Note to Balloters:</b> The key changes made since FHIR 6.0.0-ballot4 include:</p>
 <p>Changed the Composition.participant.type short description to &quot;Meaning and purpose of participation, in creation of the clinical document&quot; as a correction.</p>
-<p>Added Composition.classification BackboneElement to provide classification data for scaled use of Composition.</p>
+<p>Added Composition.classification BackboneElement to provide classification data.</p>
 </blockquote>
 <blockquote style="background-color: lightblue">
 	<p><b>Release Notes:</b></p>

--- a/source/composition/composition-introduction.xml
+++ b/source/composition/composition-introduction.xml
@@ -4,6 +4,7 @@
 <blockquote class="ballot-note" id="bn1">
 <p><b>Note to Balloters:</b> The key changes made since FHIR 6.0.0-ballot4 include:</p>
 <p>Changed the Composition.participant.type short description to &quot;Meaning and purpose of participation, in creation of the clinical document&quot; as a correction.</p>
+<p>Added Composition.classification BackboneElement to provide classification data for scaled use of Composition.</p>
 </blockquote>
 <blockquote style="background-color: lightblue">
 	<p><b>Release Notes:</b></p>
@@ -13,6 +14,7 @@
 		<li><a href="https://jira.hl7.org/browse/FHIR-54182">FHIR-54182</a></li>
 		<li><a href="https://jira.hl7.org/browse/FHIR-54343">FHIR-54343</a></li>
 		<li><a href="https://jira.hl7.org/browse/FHIR-54986">FHIR-54986</a></li>
+		<li><a href="https://jira.hl7.org/browse/FHIR-57263">FHIR-57263</a></li>
 	</ul>
 </blockquote>
 <a name="scope"></a>

--- a/source/composition/structuredefinition-Composition.xml
+++ b/source/composition/structuredefinition-Composition.xml
@@ -625,6 +625,51 @@
         <code value="Annotation"/>
       </type>
     </element>
+    <element id="Composition.classification">
+        <path value="Composition.classification"/>
+        <short value="The assignment to an organizing scheme"/>
+        <definition value="The assignment to an organizing scheme, including the type of classification and one ore more classifier values."/>
+        <min value="0"/>
+        <max value="*"/>
+        <type>
+        <code value="BackboneElement"/>
+        </type>
+        <isSummary value="true"/>
+    </element>
+    <element id="Composition.classification.type">
+        <path value="Composition.classification.type"/>
+        <short value="The kind of classifier (e.g. population, intervention)"/>
+        <definition value="The kind of classifier (e.g. population, intervention, comparator, outcome)."/>
+        <min value="0"/>
+        <max value="1"/>
+        <type>
+        <code value="CodeableConcept"/>
+        </type>
+        <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+            <valueString value="EvidenceClassifierTypeExample"/>
+        </extension>
+        <strength value="example"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/evidence-classifier-type-example"/>
+        </binding>
+    </element>
+    <element id="Composition.classification.classifier">
+        <path value="Composition.classification.classifier"/>
+        <short value="The specific classification value"/>
+        <min value="0"/>
+        <max value="*"/>
+        <type>
+        <code value="CodeableReference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
+        </type>
+        <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+            <valueString value="ConditionProblemDiagnosisCodes"/>
+        </extension>
+        <strength value="example"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/condition-code"/>
+        </binding>
+    </element>
     <element id="Composition.attester">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/uml-dir">
         <valueCode value="down"/>

--- a/source/evidence/codesystem-evidence-classifier-type-example.xml
+++ b/source/evidence/codesystem-evidence-classifier-type-example.xml
@@ -16,7 +16,7 @@
   <name value="Evidence Classifier Type Example"/>
   <title value="EvidenceClassifierTypeExample"/>
   <status value="active"/>
-  <experimental value="false"/>
+  <experimental value="true"/>
   <date value="2026-05-19T14:55:11+11:00"/>
   <publisher value="HL7 (FHIR Project)"/>
   <contact>

--- a/source/evidence/codesystem-evidence-classifier-type-example.xml
+++ b/source/evidence/codesystem-evidence-classifier-type-example.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="evidence-classifier-type-example"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="normative"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/evidence-classifier-type-example"/>
+  <version value="6.0.0"/>
+  <name value="Evidence Classifier Type Example"/>
+  <title value="EvidenceClassifierTypeExample"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2026-05-19T14:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="The kind of classifier."/>
+  <caseSensitive value="true"/>
+  <valueSet value="http://hl7.org/fhir/ValueSet/evidence-classifier-type-example"/>
+  <content value="complete"/>
+  <concept>
+    <code value="population"/>
+    <display value="Population"/>
+    <definition value="The group from which the observations were obtained."/>
+  </concept>
+  <concept>
+    <code value="intervention"/>
+    <display value="Intervention"/>
+    <definition value="An independant variable of primary interest."/>
+  </concept>
+  <concept>
+    <code value="comparator"/>
+    <display value="Comparator"/>
+    <definition value="An independant variable of primary interest."/>
+  </concept>
+  <concept>
+    <code value="outcome-measure"/>
+    <display value="Outcome Measure"/>
+    <definition value="A dependent variable."/>
+  </concept>
+  <concept>
+    <code value="pico-specification"/>
+    <display value="PICO Specification"/>
+    <definition value="A PICO question."/>
+  </concept>
+</CodeSystem>

--- a/source/evidence/codesystem-evidence-classifier-type-example.xml
+++ b/source/evidence/codesystem-evidence-classifier-type-example.xml
@@ -36,22 +36,22 @@
   <concept>
     <code value="population"/>
     <display value="Population"/>
-    <definition value="The group from which the observations were obtained."/>
+    <definition value="The Population this evidence or evidence-related report is about."/>
   </concept>
   <concept>
     <code value="intervention"/>
     <display value="Intervention"/>
-    <definition value="An independent variable of primary interest."/>
+    <definition value="The Intervention this evidence or evidence-related report is about."/>
   </concept>
   <concept>
     <code value="comparator"/>
     <display value="Comparator"/>
-    <definition value="An independent variable to compare to the primary interest."/>
+    <definition value="The Comparator this evidence or evidence-related report is about."/>
   </concept>
   <concept>
     <code value="outcome-measure"/>
     <display value="Outcome Measure"/>
-    <definition value="A dependent variable."/>
+    <definition value="The Outcome this evidence or evidence-related report is about."/>
   </concept>
   <concept>
     <code value="pico-specification"/>

--- a/source/evidence/codesystem-evidence-classifier-type-example.xml
+++ b/source/evidence/codesystem-evidence-classifier-type-example.xml
@@ -41,12 +41,12 @@
   <concept>
     <code value="intervention"/>
     <display value="Intervention"/>
-    <definition value="An independant variable of primary interest."/>
+    <definition value="An independent variable of primary interest."/>
   </concept>
   <concept>
     <code value="comparator"/>
     <display value="Comparator"/>
-    <definition value="An independant variable of primary interest."/>
+    <definition value="An independent variable to compare to the primary interest."/>
   </concept>
   <concept>
     <code value="outcome-measure"/>

--- a/source/evidence/codesystem-variable-role.xml
+++ b/source/evidence/codesystem-variable-role.xml
@@ -45,7 +45,7 @@
   <concept>
     <code value="exposure"/>
     <display value="Exposure"/>
-    <definition value="An independant variable of primary interest."/>
+    <definition value="An independent variable of primary interest."/>
   </concept>
   <concept>
     <code value="outcome"/>

--- a/source/evidence/evidence-introduction.xml
+++ b/source/evidence/evidence-introduction.xml
@@ -5,12 +5,14 @@
 <p><b>Note to Balloters:</b> The key changes made since FHIR 6.0.0-ballot4 include:</p>
 <p>Changed the Evidence.studyDesign ValueSet binding to be HL7 Terminology, and removed the FHIR version of the StudyDesign ValueSet.</p>
 <p>Changed the Evidence.status cardinality from 1..1 to 0..1.</p>
+<p>Added Evidence.classification BackboneElement to provide classification data for scaled use of Evidence</p>
 </blockquote>
 <blockquote style="background-color: lightblue">
 	<p><b>Release Notes:</b></p>
 	<ul>
 		<li><a href="https://jira.hl7.org/browse/FHIR-53699">FHIR-53699</a></li>
 		<li><a href="https://jira.hl7.org/browse/FHIR-56390">FHIR-56390</a></li>
+		<li><a href="https://jira.hl7.org/browse/FHIR-57262">FHIR-57262</a></li>
 	</ul>
 </blockquote>
 <a name="scope"></a>

--- a/source/evidence/evidence-introduction.xml
+++ b/source/evidence/evidence-introduction.xml
@@ -5,7 +5,7 @@
 <p><b>Note to Balloters:</b> The key changes made since FHIR 6.0.0-ballot4 include:</p>
 <p>Changed the Evidence.studyDesign ValueSet binding to be HL7 Terminology, and removed the FHIR version of the StudyDesign ValueSet.</p>
 <p>Changed the Evidence.status cardinality from 1..1 to 0..1.</p>
-<p>Added Evidence.classification BackboneElement to provide classification data for scaled use of Evidence</p>
+<p>Added Evidence.classification BackboneElement to provide classification data for scaled use of Evidence.</p>
 </blockquote>
 <blockquote style="background-color: lightblue">
 	<p><b>Release Notes:</b></p>

--- a/source/evidence/evidence-introduction.xml
+++ b/source/evidence/evidence-introduction.xml
@@ -5,7 +5,7 @@
 <p><b>Note to Balloters:</b> The key changes made since FHIR 6.0.0-ballot4 include:</p>
 <p>Changed the Evidence.studyDesign ValueSet binding to be HL7 Terminology, and removed the FHIR version of the StudyDesign ValueSet.</p>
 <p>Changed the Evidence.status cardinality from 1..1 to 0..1.</p>
-<p>Added Evidence.classification BackboneElement to provide classification data for scaled use of Evidence.</p>
+<p>Added Evidence.classification BackboneElement to provide classification data.</p>
 </blockquote>
 <blockquote style="background-color: lightblue">
 	<p><b>Release Notes:</b></p>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -558,6 +558,51 @@
 				<code value="Annotation"/>
 			</type>
 		</element>
+		<element id="Evidence.classification">
+			<path value="Evidence.classification"/>
+			<short value="The assignment to an organizing scheme"/>
+			definition value="The assignment to an organizing scheme, including the type of classification and one ore more classifier values."/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="BackboneElement"/>
+			</type>
+			<isSummary value="true"/>
+		</element>
+		<element id="Evidence.classification.type">
+			<path value="Evidence.classification.type"/>
+			<short value="The kind of classifier (e.g. population, intervention)"/>
+			<definition value="The kind of classifier (e.g. population, intervention, comparator, outcome)."/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="CodeableConcept"/>
+			</type>
+			<binding>
+				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+					<valueString value="EvidenceClassifierTypeExample"/>
+				</extension>
+				<strength value="example"/>
+				<valueSet value="http://hl7.org/fhir/ValueSet/evidence-classifier-type-example"/>
+			</binding>
+		</element>
+		<element id="Evidence.classification.classifier">
+			<path value="Evidence.classification.classifier"/>
+			<short value="The specific classification value"/>
+			<min value="0"/>
+			<max value="*"/>
+			<type>
+				<code value="CodeableReference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>
+			</type>
+			<binding>
+				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+					<valueString value="ConditionProblemDiagnosisCodes"/>
+				</extension>
+				<strength value="example"/>
+				<valueSet value="http://hl7.org/fhir/ValueSet/condition-code"/>
+			</binding>
+		</element>
 		<element id="Evidence.variableDefinition">
 			<extension url="http://hl7.org/fhir/build/StructureDefinition/svg">
 				<valueCode value="490,150"/>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -620,7 +620,6 @@
 		<element id="Evidence.variableDefinition.description">
 			<path value="Evidence.variableDefinition.description"/>
 			<short value="A text description or summary of the variable"/>
-			<definition value="A text description or summary of the variable."/>
 			<min value="0"/>
 			<max value="1"/>
 			<type>

--- a/source/evidence/structuredefinition-Evidence.xml
+++ b/source/evidence/structuredefinition-Evidence.xml
@@ -561,7 +561,7 @@
 		<element id="Evidence.classification">
 			<path value="Evidence.classification"/>
 			<short value="The assignment to an organizing scheme"/>
-			definition value="The assignment to an organizing scheme, including the type of classification and one ore more classifier values."/>
+			<definition value="The assignment to an organizing scheme, including the type of classification and one ore more classifier values."/>
 			<min value="0"/>
 			<max value="*"/>
 			<type>

--- a/source/evidence/valueset-evidence-classifier-type-example.xml
+++ b/source/evidence/valueset-evidence-classifier-type-example.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="evidence-classifier-type-example"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="cds"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="normative"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/evidence-classifier-type-example"/>
+  <version value="6.0.0"/>
+  <name value="EvidenceClassifierTypeExample"/>
+  <title value="Evidence Classifier Type Example"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2026-05-19T14:55:11+11:00"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="The kind of classifier."/>
+  <immutable value="true"/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/evidence-classifier-type-example"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/evidence/valueset-evidence-classifier-type-example.xml
+++ b/source/evidence/valueset-evidence-classifier-type-example.xml
@@ -16,7 +16,7 @@
   <name value="EvidenceClassifierTypeExample"/>
   <title value="Evidence Classifier Type Example"/>
   <status value="active"/>
-  <experimental value="false"/>
+  <experimental value="true"/>
   <date value="2026-05-19T14:55:11+11:00"/>
   <publisher value="HL7 (FHIR Project)"/>
   <contact>

--- a/source/evidence/valueset-evidence-classifier-type-example.xml
+++ b/source/evidence/valueset-evidence-classifier-type-example.xml
@@ -30,7 +30,6 @@
     </telecom>
   </contact>
   <description value="The kind of classifier."/>
-  <immutable value="true"/>
   <compose>
     <include>
       <system value="http://hl7.org/fhir/evidence-classifier-type-example"/>


### PR DESCRIPTION
Added a backbone element to Evidence and Composition.

The structure for Evidence below, but it's the same for Composition.

Evidence.classification 0..* BackboneElement

..short = The assignment to an organizing scheme

..definition = The assignment to an organizing scheme, including the type of classification and one ore more classifier values.

Evidence.classification.type 0..1 CodeableConcept

..short = The kind of classifier (e.g. population, intervention)

..definition = The kind of classifier (e.g. population, intervention, comparator, outcome).

..binding to EvidenceClassifierTypeExample ValueSet (Example) which will draw from EvidenceClassifierTypeExample CodeSystem which will contain population, intervention, comparator, outcome-measure, and pico-classification

Evidence.classification.classifier 0..* CodeableReference (any)

..short = The specific classification value

..definition = The specific classification value.

..binding to http://hl7.org/fhir/ValueSet/condition-code (Example)