### PR TITLE
Fix faulty invariant FHIRPath expressions (+ regression fixtures)

### DIFF
--- a/source/activitydefinition/invariant-tests/adf-2.p1.pass.json
+++ b/source/activitydefinition/invariant-tests/adf-2.p1.pass.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "ActivityDefinition",
+  "status": "active",
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "http://x/Library/a",
+      "resourceReference": {
+        "reference": "Library/a"
+      }
+    }
+  ]
+}

--- a/source/activitydefinition/structuredefinition-ActivityDefinition.xml
+++ b/source/activitydefinition/structuredefinition-ActivityDefinition.xml
@@ -830,7 +830,7 @@
 				<key value="adf-2"/>
 				<severity value="warning"/>
 				<human value="Dependencies of an ActivityDefinition should reference a resource"/>
-				<expression value="type in ('depends-on' | 'part-of') implies ((resource.exists() xor resourceReference.exists()) or (artifact is canonical xor artifact is Reference))"/>
+				<expression value="type in ('depends-on' | 'part-of') implies (resource.exists() or resourceReference.exists())"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/ActivityDefinition"/>
 			</constraint>
 			<constraint>

--- a/source/bundle/invariant-tests/bdl-14.f2.fail.json
+++ b/source/bundle/invariant-tests/bdl-14.f2.fail.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Bundle",
+  "type": "history",
+  "entry": [
+    {
+      "fullUrl": "http://x/Patient/1",
+      "request": {
+        "method": "GET",
+        "url": "Patient/1"
+      },
+      "response": {
+        "status": "200"
+      }
+    },
+    {
+      "fullUrl": "http://x/Patient/2",
+      "request": {
+        "method": "PATCH",
+        "url": "Patient/2"
+      },
+      "resource": {
+        "resourceType": "Patient",
+        "id": "2"
+      },
+      "response": {
+        "status": "200"
+      }
+    }
+  ]
+}

--- a/source/bundle/invariant-tests/bdl-16.p2.pass.json
+++ b/source/bundle/invariant-tests/bdl-16.p2.pass.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Bundle",
+  "type": "batch-response",
+  "entry": [
+    {
+      "response": {
+        "status": "200"
+      }
+    }
+  ],
+  "issues": {
+    "resourceType": "OperationOutcome",
+    "issue": [
+      {
+        "severity": "warning",
+        "code": "informational"
+      },
+      {
+        "severity": "warning",
+        "code": "informational"
+      }
+    ]
+  }
+}

--- a/source/bundle/invariant-tests/bdl-7.p1.pass.json
+++ b/source/bundle/invariant-tests/bdl-7.p1.pass.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "http://x/Observation/123",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "123",
+        "status": "final",
+        "code": {
+          "text": "t"
+        },
+        "meta": {
+          "versionId": "4"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://x/Observation/12",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "12",
+        "status": "final",
+        "code": {
+          "text": "t"
+        },
+        "meta": {
+          "versionId": "34"
+        }
+      }
+    }
+  ]
+}

--- a/source/bundle/structuredefinition-Bundle.xml
+++ b/source/bundle/structuredefinition-Bundle.xml
@@ -107,7 +107,7 @@
 			<constraint>
 				<key value="bdl-3b"/>
 				<severity value="error"/>
-				<human value="For collections of type history, all entries must contain request or response elements, and resources if the method is POST, PUT or PATCH"/>
+				<human value="For collections of type history, all entries must contain request and response elements, and resources if the method is POST, PUT or PATCH"/>
 				<expression value="type = 'history' implies entry.all(request.exists() and response.exists() and ((request.method in ('POST' | 'PATCH' | 'PUT')) = resource.exists()))"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
 			</constraint>
@@ -129,7 +129,7 @@
 				<key value="bdl-7"/>
 				<severity value="error"/>
 				<human value="FullUrl must be unique in a bundle, or else entries with the same fullUrl must have different meta.versionId (except in history bundles)"/>
-				<expression value="(type = 'history') or entry.where(fullUrl.exists()).select(fullUrl&amp;iif(resource.meta.versionId.exists(), resource.meta.versionId, '')).isDistinct()"/>
+				<expression value="(type = 'history') or entry.where(fullUrl.exists()).select(fullUrl&amp;'|'&amp;iif(resource.meta.versionId.exists(), resource.meta.versionId, '')).isDistinct()"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
 			</constraint>
 			<constraint>
@@ -171,7 +171,7 @@
 				<key value="bdl-14"/>
 				<severity value="error"/>
 				<human value="entry.request.method PATCH not allowed for history"/>
-				<expression value="type = 'history' implies entry.request.method != 'PATCH'"/>
+				<expression value="type = 'history' implies entry.request.all(method != 'PATCH')"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
 			</constraint>
 			<constraint>
@@ -185,7 +185,7 @@
 				<key value="bdl-16"/>
 				<severity value="error"/>
 				<human value="Issue.severity for all issues within the OperationOutcome must be either 'information' or 'warning'."/>
-				<expression value="issues.exists() implies (issues.issue.severity = 'information' or issues.issue.severity = 'warning')"/>
+				<expression value="issues.exists() implies issues.issue.all(severity = 'information' or severity = 'warning')"/>
 			</constraint>
 			<constraint>
 				<key value="bdl-17"/>

--- a/source/codesystem/invariant-tests/csd-1.f2.fail.json
+++ b/source/codesystem/invariant-tests/csd-1.f2.fail.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://example.org/cs/csd1nested",
+  "status": "draft",
+  "content": "complete",
+  "concept": [
+    {
+      "code": "parent",
+      "concept": [
+        {
+          "code": "parent"
+        }
+      ]
+    }
+  ]
+}

--- a/source/codesystem/invariant-tests/csd-3.f3.fail.json
+++ b/source/codesystem/invariant-tests/csd-3.f3.fail.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://example.org/cs/csd3",
+  "status": "draft",
+  "content": "complete",
+  "property": [
+    {
+      "code": "parent",
+      "type": "code"
+    },
+    {
+      "code": "status",
+      "type": "string"
+    }
+  ],
+  "concept": [
+    {
+      "code": "root"
+    },
+    {
+      "code": "c1",
+      "property": [
+        {
+          "code": "status",
+          "valueString": "a"
+        },
+        {
+          "code": "parent",
+          "valueCode": "root"
+        }
+      ]
+    }
+  ]
+}

--- a/source/codesystem/invariant-tests/csd-6.p2.pass.json
+++ b/source/codesystem/invariant-tests/csd-6.p2.pass.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "CodeSystem", "url": "http://example.org/cs/csd6-multi", "status": "draft",
+  "caseSensitive": true, "content": "complete",
+  "concept": [
+    { "code": "A", "property": [ { "code": "alternateCode", "valueCode": "B" } ] },
+    { "code": "B", "property": [ { "code": "alternateCode", "valueCode": "A" }, { "code": "alternateCode", "valueCode": "C" } ] },
+    { "code": "C", "property": [ { "code": "alternateCode", "valueCode": "B" } ] }
+  ]
+}

--- a/source/codesystem/structuredefinition-CodeSystem.xml
+++ b/source/codesystem/structuredefinition-CodeSystem.xml
@@ -92,7 +92,7 @@
 				<key value="csd-1"/>
 				<severity value="error"/>
 				<human value="Within a code system definition, all the codes SHALL be unique"/>
-				<expression value="concept.exists() implies concept.code.combine(%resource.concept.descendants().concept.code).isDistinct()"/>
+				<expression value="concept.exists() implies concept.code.combine(concept.combine(concept.descendants()).concept.code).isDistinct()"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/CodeSystem"/>
 			</constraint>
 			<constraint>
@@ -106,7 +106,7 @@
 				<key value="csd-3"/>
 				<severity value="warning"/>
 				<human value="If there is an implicit hierarchy, a hierarchyMeaning should be provided"/>
-				<expression value="concept.where(property.code = 'parent' or property.code = 'child').exists() implies hierarchyMeaning.exists()"/>
+				<expression value="concept.where(property.where(code = 'parent' or code = 'child').exists()).exists() implies hierarchyMeaning.exists()"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/CodeSystem"/>
 			</constraint>
 			<constraint>
@@ -881,7 +881,7 @@
 				<key value="csd-6"/>
 				<severity value="error"/>
 				<human value="If a concept identifies an alternate, there must be a reciprocal relationship"/>
-				<expression value="defineVariable('sc', code).property.all((code = 'alternateCode') implies defineVariable('ac', value).%resource.repeat(concept).where(code = %ac).exists(property.where(code = 'alternateCode').value = %sc))"/>
+				<expression value="defineVariable('sc', code).property.all((code = 'alternateCode') implies defineVariable('ac', value).%resource.repeat(concept).where(code = %ac).exists(property.where(code = 'alternateCode' and value = %sc).exists()))"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/CodeSystem"/>
 			</constraint>
 		</element>

--- a/source/datatypes/count.xml
+++ b/source/datatypes/count.xml
@@ -3209,7 +3209,7 @@
     <Cell ss:StyleID="s106"><Data ss:Type="String">Count</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><Data ss:Type="String">There SHALL be a code with a value of "1" if there is a value. If system is present, it SHALL be UCUM.  If present, the value SHALL be a whole number.</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s83"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s106"><Data ss:Type="String">(code.exists() or value.empty()) and (system.empty() or system = %ucum) and (code.empty() or code = '1') and (value.empty() or value.hasValue().not() or value.toString().contains('.').not()) and (value.empty() or value.hasValue().not() or value &gt;= 0)</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s106"><Data ss:Type="String">(code.exists() or value.empty()) and (system.empty() or system = %ucum) and (code.empty() or code = '1') and (value.empty() or value.hasValue().not() or value = value.round()) and (value.empty() or value.hasValue().not() or value &gt;= 0)</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s106"><Data ss:Type="String">(f:code or not(f:value)) and (not(exists(f:system)) or (f:system/@value='http://unitsofmeasure.org' and f:code/@value='1')) and not(contains(f:value/@value, '.')) </Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">

--- a/source/datatypes/duration.xml
+++ b/source/datatypes/duration.xml
@@ -3302,7 +3302,7 @@
     <Cell ss:StyleID="s84"><Data ss:Type="String">Duration</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s107"><Data ss:Type="String">There SHALL be a code if there is a value and it SHALL be an expression of time.  If system is present, it SHALL be UCUM.</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s84"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s107"><Data ss:Type="String">code.exists() implies ((system = %ucum) and value.exists())</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s107"><Data ss:Type="String">(value.exists() implies code.exists()) and (system.exists() implies system = %ucum)</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s107"><Data ss:Type="String">(f:code or not(f:value)) and (not(exists(f:system)) or f:system/@value='http://unitsofmeasure.org')</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">

--- a/source/datatypes/elementdefinition.xml
+++ b/source/datatypes/elementdefinition.xml
@@ -4699,7 +4699,7 @@
     <Cell ss:StyleID="s92"><Data ss:Type="String">ElementDefinition.binding</Data></Cell>
     <Cell ss:StyleID="s92"><Data ss:Type="String">ValueSet SHALL start with http:// or https:// or urn: or #</Data></Cell>
     <Cell ss:StyleID="s92"/>
-    <Cell ss:StyleID="s92"><Data ss:Type="String">valueSet.exists() implies (valueSet.startsWith('http:') or valueSet.startsWith('https') or valueSet.startsWith('urn:') or valueSet.startsWith('#'))</Data></Cell>
+    <Cell ss:StyleID="s92"><Data ss:Type="String">valueSet.exists() implies (valueSet.startsWith('http:') or valueSet.startsWith('https:') or valueSet.startsWith('urn:') or valueSet.startsWith('#'))</Data></Cell>
     <Cell ss:StyleID="s109"><Data ss:Type="String">(starts-with(string(f:valueSet/@value), 'http:') or starts-with(string(f:valueSet/@value), 'https:') or starts-with(string(f:valueSet/@value), 'urn:') or starts-with(string(f:valueSet/@value), 'x'))</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="60">
@@ -4789,7 +4789,7 @@
     <Cell ss:StyleID="s92"><Data ss:Type="String">ElementDefinition.constraint</Data></Cell>
     <Cell ss:StyleID="s92"><Data ss:Type="String">Constraints should have an expression or else validators will not be able to enforce them</Data></Cell>
     <Cell ss:StyleID="s92"/>
-    <Cell ss:StyleID="s92"><Data ss:Type="String">expression.exists()</Data></Cell>
+    <Cell ss:StyleID="s92"><Data ss:Type="String">expression.hasValue()</Data></Cell>
     <Cell ss:StyleID="s110"><Data ss:Type="String">exists(f:expression/@value)</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="30">

--- a/source/datatypes/expression.xml
+++ b/source/datatypes/expression.xml
@@ -3457,7 +3457,7 @@
     <Cell ss:StyleID="s84"><Data ss:Type="String">error</Data></Cell>
     <Cell ss:StyleID="s84"><Data ss:Type="String">Expression</Data></Cell>
     <Cell ss:StyleID="s84"><Data ss:Type="String">The name must be a valid variable name in most computer languages</Data></Cell>
-    <Cell ss:StyleID="s84"><Data ss:Type="String">name.hasValue() implies name.matches('[A-Za-z][A-Za-z0-9\\_]{0,63}')</Data></Cell>
+    <Cell ss:StyleID="s84"><Data ss:Type="String">name.hasValue() implies name.matches('^[A-Za-z][A-Za-z0-9\\_]{0,63}$')</Data></Cell>
     <Cell ss:StyleID="s102"><Data ss:Type="String">exists(f:expression) or exists(f:reference)</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">

--- a/source/documentreference/structuredefinition-DocumentReference.xml
+++ b/source/documentreference/structuredefinition-DocumentReference.xml
@@ -106,7 +106,7 @@
       <constraint>
         <key value="docRef-2"/>
         <severity value="warning"/>
-        <human value="practiceSetting SHALL only be present if context is not present"/>
+        <human value="practiceSetting SHALL only be present if context is not an encounter"/>
         <expression value="practiceSetting.empty() or context.where(resolve() is Encounter).empty()"/>
         <source value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
       </constraint>

--- a/source/event/event-spreadsheet.xml
+++ b/source/event/event-spreadsheet.xml
@@ -1762,7 +1762,7 @@
     <Cell ss:StyleID="s94"/>
     <Cell ss:StyleID="s119"><Data ss:Type="String">Event</Data></Cell>
     <Cell ss:StyleID="s94"><Data ss:Type="String">reason elements can only be specified if status is NOT 'not-done'</Data></Cell>
-    <Cell ss:StyleID="s94"><Data ss:Type="String">status!='not-done' or (reasonCode.exists().not() and reasonReference.exists().not())</Data></Cell>
+    <Cell ss:StyleID="s94"><Data ss:Type="String">status!='not-done' or reason.exists().not()</Data></Cell>
     <Cell ss:StyleID="s120"><Data ss:Type="String">not(f:status/@value='not-done') or not(exists(f:reasonCode) or exists(f:reasonReference))</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="62">

--- a/source/imagingselection/invariant-tests/isl-10.p1.pass.json
+++ b/source/imagingselection/invariant-tests/isl-10.p1.pass.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "ImagingSelection",
+  "status": "available",
+  "code": {
+    "text": "s"
+  },
+  "instance": [
+    {
+      "uid": "a",
+      "frameNumber": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "uid": "b",
+      "segmentNumber": [
+        1
+      ]
+    }
+  ]
+}

--- a/source/imagingselection/invariant-tests/isl-11.f2.fail.json
+++ b/source/imagingselection/invariant-tests/isl-11.f2.fail.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "ImagingSelection",
+  "status": "available",
+  "code": {
+    "text": "r"
+  },
+  "instance": [
+    {
+      "uid": "a",
+      "waveFormChannel": [
+        1
+      ]
+    },
+    {
+      "uid": "b",
+      "waveFormChannel": [
+        1,
+        2,
+        3
+      ]
+    }
+  ]
+}

--- a/source/imagingselection/invariant-tests/isl-7.f2.fail.json
+++ b/source/imagingselection/invariant-tests/isl-7.f2.fail.json
@@ -1,0 +1,32 @@
+{
+  "resourceType": "ImagingSelection",
+  "status": "available",
+  "code": {
+    "text": "r"
+  },
+  "instance": [
+    {
+      "uid": "i",
+      "imageRegion2D": [
+        {
+          "regionType": "polyline",
+          "coordinate": [
+            0.1,
+            0.2,
+            0.3
+          ]
+        },
+        {
+          "regionType": "polyline",
+          "coordinate": [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/imagingselection/invariant-tests/isl-8.f2.fail.json
+++ b/source/imagingselection/invariant-tests/isl-8.f2.fail.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "ImagingSelection",
+  "status": "available",
+  "code": {
+    "text": "r"
+  },
+  "imageRegion3D": [
+    {
+      "regionType": "polygon",
+      "coordinate": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "regionType": "polygon",
+      "coordinate": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    }
+  ]
+}

--- a/source/imagingselection/structuredefinition-ImagingSelection.xml
+++ b/source/imagingselection/structuredefinition-ImagingSelection.xml
@@ -126,14 +126,14 @@
         <key value="isl-7"/>
         <severity value="error"/>
         <human value="if present, instance.imageRegion2D.coordinate SHALL have a value count that is a multiple of 2"/>
-        <expression value="instance.imageRegion2D.coordinate.exists() implies instance.imageRegion2D.coordinate.count() mod 2 = 0"/>
+        <expression value="instance.imageRegion2D.all(coordinate.count() mod 2 = 0)"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ImagingSelection"/>
       </constraint>
       <constraint>
         <key value="isl-8"/>
         <severity value="error"/>
         <human value="if present, imageRegion3D.coordinate SHALL have a value count that is a multiple of 3"/>
-        <expression value="imageRegion3D.coordinate.exists() implies imageRegion3D.coordinate.count() mod 3 = 0"/>
+        <expression value="imageRegion3D.all(coordinate.count() mod 3 = 0)"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ImagingSelection"/>
       </constraint>
       <constraint>
@@ -149,14 +149,14 @@
         <human value="only one of instance.frameNumber, instance.referencedContentItemIdentifier, instance.segmentNumber, instance.regionOfInterest and instance.waveFormChannel SHALL be present"/>
 <!--        <expression value="instance.frameNumber.exists() xor instance.referencedContentItemIdentifier.exists() xor instance.segmentNumber.exists() xor instance.regionOfInterest.exists() xor instance.waveFormChannel.exists()"/> -->
 <!--        <expression value="(instance.frameNumber.exists() and not(instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists())) or (instance.referencedContentItemIdentifier.exists() and not(instance.frameNumber.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists())) or (instance.segmentNumber.exists() and not(instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists())) or (instance.regionOfInterest.exists() and not(instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.waveFormChannel.exists())) or (instance.waveFormChannel.exists() and not(instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists()))"/> -->
-        <expression value="(instance.frameNumber.exists() implies (instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists()).not()) and (instance.referencedContentItemIdentifier.exists() implies (instance.frameNumber.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists()).not()) and (instance.segmentNumber.exists() implies (instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.regionOfInterest.exists() or instance.waveFormChannel.exists()).not()) and (instance.regionOfInterest.exists() implies (instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.waveFormChannel.exists()).not()) and (instance.waveFormChannel.exists() implies (instance.frameNumber.exists() or instance.referencedContentItemIdentifier.exists() or instance.segmentNumber.exists() or instance.regionOfInterest.exists()).not())"/>
+        <expression value="instance.all((frameNumber.exists() implies (referencedContentItemIdentifier.exists() or segmentNumber.exists() or regionOfInterest.exists() or waveFormChannel.exists()).not()) and (referencedContentItemIdentifier.exists() implies (frameNumber.exists() or segmentNumber.exists() or regionOfInterest.exists() or waveFormChannel.exists()).not()) and (segmentNumber.exists() implies (frameNumber.exists() or referencedContentItemIdentifier.exists() or regionOfInterest.exists() or waveFormChannel.exists()).not()) and (regionOfInterest.exists() implies (frameNumber.exists() or referencedContentItemIdentifier.exists() or segmentNumber.exists() or waveFormChannel.exists()).not()) and (waveFormChannel.exists() implies (frameNumber.exists() or referencedContentItemIdentifier.exists() or segmentNumber.exists() or regionOfInterest.exists()).not()))"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ImagingSelection"/>
       </constraint>
       <constraint>
         <key value="isl-11"/>
         <severity value="error"/>
         <human value="if present, instance.waveFormChannel SHALL have a value count that is a multiple of 2"/>
-        <expression value="instance.waveFormChannel.exists() implies instance.waveFormChannel.count() mod 2 = 0"/>
+        <expression value="instance.all(waveFormChannel.count() mod 2 = 0)"/>
         <source value="http://hl7.org/fhir/StructureDefinition/ImagingSelection"/>
       </constraint>
       <mapping>

--- a/source/imagingstudy/invariant-tests/ist-4.p1.pass.json
+++ b/source/imagingstudy/invariant-tests/ist-4.p1.pass.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "ImagingStudy",
+  "status": "available",
+  "subject": {
+    "reference": "Patient/x"
+  },
+  "numberOfInstances": 5,
+  "series": [
+    {
+      "uid": "1.2.3",
+      "modality": {
+        "coding": [
+          {
+            "system": "http://dicom.nema.org/resources/ontology/DCM",
+            "code": "CT"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/imagingstudy/structuredefinition-ImagingStudy.xml
+++ b/source/imagingstudy/structuredefinition-ImagingStudy.xml
@@ -110,7 +110,7 @@
         <key value="ist-4"/>
         <severity value="error"/>
         <human value="If numberOfInstances and series.instance are both present, the numberOfInstances value SHALL match the total number of series.instance elements"/>
-        <expression value="numberOfInstances.exists() and series.exists() implies numberOfInstances = series.instance.count()"/>
+        <expression value="numberOfInstances.exists() and series.instance.exists() implies numberOfInstances = series.instance.count()"/>
       </constraint>
       <constraint>
         <key value="ist-5"/>

--- a/source/measurereport/invariant-tests/mrp-3.p1.pass.json
+++ b/source/measurereport/invariant-tests/mrp-3.p1.pass.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "MeasureReport",
+  "status": "complete",
+  "type": "individual",
+  "measure": "http://x/Measure/m",
+  "period": {
+    "start": "2013-01-01",
+    "end": "2013-12-31"
+  },
+  "group": [
+    {
+      "population": [
+        {
+          "code": {
+            "text": "initial-population"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/measurereport/invariant-tests/mrp-4.p1.pass.json
+++ b/source/measurereport/invariant-tests/mrp-4.p1.pass.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "MeasureReport",
+  "status": "complete",
+  "type": "individual",
+  "measure": "http://x/Measure/m",
+  "period": {
+    "start": "2013-01-01",
+    "end": "2013-12-31"
+  },
+  "group": [
+    {
+      "stratifier": [
+        {
+          "stratum": [
+            {
+              "population": [
+                {
+                  "code": {
+                    "text": "numerator"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/measurereport/structuredefinition-MeasureReport.xml
+++ b/source/measurereport/structuredefinition-MeasureReport.xml
@@ -662,7 +662,7 @@
         <key value="mrp-3"/>
         <severity value="error"/>
         <human value="The count and countQuantity elements SHALL be mutually exclusive"/>
-        <expression value="count.exists() xor countQuantity.exists()"/>
+        <expression value="(count.exists() and countQuantity.exists()).not()"/>
         <source value="http://hl7.org/fhir/StructureDefinition/MeasureReport"/>
       </constraint>         
       <type>
@@ -1104,7 +1104,7 @@
         <key value="mrp-4"/>
         <severity value="error"/>
         <human value="The count and countQuantity elements for a statum population SHALL be mutually exclusive"/>
-        <expression value="count.exists() xor countQuantity.exists()"/>
+        <expression value="(count.exists() and countQuantity.exists()).not()"/>
         <source value="http://hl7.org/fhir/StructureDefinition/MeasureReport"/>
       </constraint>         
       <mapping>

--- a/source/parameters/invariant-tests/cnt-3.p1.pass.json
+++ b/source/parameters/invariant-tests/cnt-3.p1.pass.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "x", "valueCount": { "value": 5.0, "system": "http://unitsofmeasure.org", "code": "1" } }
+  ]
+}

--- a/source/parameters/invariant-tests/drt-1.f1.fail.json
+++ b/source/parameters/invariant-tests/drt-1.f1.fail.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "x",
+      "valueDuration": {
+        "value": 30
+      }
+    }
+  ]
+}

--- a/source/parameters/invariant-tests/drt-1.p1.pass.json
+++ b/source/parameters/invariant-tests/drt-1.p1.pass.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "x",
+      "valueDuration": {
+        "value": 30,
+        "code": "min"
+      }
+    }
+  ]
+}

--- a/source/plandefinition/invariant-tests/exp-2.f1.fail.json
+++ b/source/plandefinition/invariant-tests/exp-2.f1.fail.json
@@ -1,0 +1,19 @@
+{
+  "resourceType": "PlanDefinition",
+  "status": "active",
+  "action": [
+    {
+      "title": "a",
+      "condition": [
+        {
+          "kind": "applicability",
+          "expression": {
+            "name": "9-bad name",
+            "language": "text/fhirpath",
+            "expression": "true"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/plandefinition/invariant-tests/pld-3.p1.pass.json
+++ b/source/plandefinition/invariant-tests/pld-3.p1.pass.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "PlanDefinition",
+  "status": "active",
+  "goal": [
+    {
+      "id": "g1",
+      "description": {
+        "text": "x"
+      }
+    },
+    {
+      "id": "g2",
+      "description": {
+        "text": "y"
+      }
+    }
+  ],
+  "action": [
+    {
+      "title": "a",
+      "goalId": [
+        "g1",
+        "g2"
+      ]
+    }
+  ]
+}

--- a/source/plandefinition/invariant-tests/pld-6.p1.pass.json
+++ b/source/plandefinition/invariant-tests/pld-6.p1.pass.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "PlanDefinition",
+  "status": "active",
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "http://x/Library/a",
+      "resourceReference": {
+        "reference": "Library/a"
+      }
+    }
+  ]
+}

--- a/source/plandefinition/structuredefinition-PlanDefinition.xml
+++ b/source/plandefinition/structuredefinition-PlanDefinition.xml
@@ -99,7 +99,7 @@
 				<key value="pld-3"/>
 				<severity value="warning"/>
 				<human value="goalid should reference the id of a goal definition"/>
-				<expression value="%context.repeat(action).where((goalId in %context.goal.id).not()).exists().not()"/>
+				<expression value="%context.repeat(action).goalId.all($this in %context.goal.id)"/>
 			</constraint>
 			<constraint>
 				<key value="pld-4"/>
@@ -874,7 +874,7 @@
 				<key value="pld-6"/>
 				<severity value="warning"/>
 				<human value="Dependencies of a PlanDefinition should reference a resource"/>
-				<expression value="type in ('depends-on' | 'part-of') implies ((resource.exists() xor resourceReference.exists()) or (artifact is canonical xor artifact is Reference))"/>
+				<expression value="type in ('depends-on' | 'part-of') implies (resource.exists() or resourceReference.exists())"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/PlanDefinition"/>
 			</constraint>
 			<constraint>

--- a/source/questionnaire/invariant-tests/que-16.f1.fail.json
+++ b/source/questionnaire/invariant-tests/que-16.f1.fail.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "item": [
+    {
+      "linkId": "double  space",
+      "type": "string"
+    }
+  ]
+}

--- a/source/questionnaire/invariant-tests/que-5.p1.pass.json
+++ b/source/questionnaire/invariant-tests/que-5.p1.pass.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "item": [
+    {
+      "linkId": "u",
+      "type": "url",
+      "answerOption": [
+        {
+          "valueUri": "http://example.org/a"
+        }
+      ]
+    }
+  ]
+}

--- a/source/questionnaire/invariant-tests/que-5b.p1.pass.json
+++ b/source/questionnaire/invariant-tests/que-5b.p1.pass.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "item": [
+    {
+      "linkId": "u",
+      "type": "url",
+      "answerValueSet": "http://example.org/vs"
+    }
+  ]
+}

--- a/source/questionnaire/structuredefinition-Questionnaire.xml
+++ b/source/questionnaire/structuredefinition-Questionnaire.xml
@@ -762,14 +762,14 @@
 				<key value="que-5"/>
 				<severity value="error"/>
 				<human value="Only coding, decimal, integer, date, dateTime, time, string, quantity, reference, or uri items can have answerOption"/>
-				<expression value="(('coding' | 'decimal' | 'integer' | 'date' | 'dateTime' | 'time' | 'string' | 'quantity' | 'reference' | 'uri') contains type) or answerOption.empty()"/>
+				<expression value="(('coding' | 'decimal' | 'integer' | 'date' | 'dateTime' | 'time' | 'string' | 'quantity' | 'reference' | 'url') contains type) or answerOption.empty()"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/Questionnaire"/>
 			</constraint>
 			<constraint>
 				<key value="que-5b"/>
 				<severity value="error"/>
-				<human value="Only coding, decimal, integer, date, dateTime, time, string or quantity  items can have answerOption"/>
-				<expression value="(('coding' | 'string' | 'uri') contains type) or answerValueSet.empty()"/>
+				<human value="Only coding, string or url items can have an answerValueSet"/>
+				<expression value="(('coding' | 'string' | 'url') contains type) or answerValueSet.empty()"/>
 				<source value="http://hl7.org/fhir/StructureDefinition/Questionnaire"/>
 			</constraint>
 			<constraint>
@@ -892,7 +892,7 @@
         <key value="que-16"/>
         <severity value="error"/>
         <human value="LinkId cannot have leading or trailing spaces or intevening whitespace other than single space characters"/>
-        <expression value="$this.matches('[^\\s]+( [^\\s]+)*')"/>
+        <expression value="$this.matches('^[^\\s]+( [^\\s]+)*$')"/>
       </constraint>
 			<mapping>
 				<identity value="rim"/>

--- a/source/questionnaireresponse/invariant-tests/qrs-2.f1.fail.json
+++ b/source/questionnaireresponse/invariant-tests/qrs-2.f1.fail.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "item": [
+    {
+      "linkId": "group",
+      "item": [
+        {
+          "linkId": "dup",
+          "answer": [
+            {
+              "valueString": "a"
+            }
+          ]
+        },
+        {
+          "linkId": "dup",
+          "answer": [
+            {
+              "valueString": "b"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/questionnaireresponse/invariant-tests/qrs-3.f1.fail.json
+++ b/source/questionnaireresponse/invariant-tests/qrs-3.f1.fail.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "item": [
+    {
+      "linkId": "double  space"
+    }
+  ]
+}

--- a/source/questionnaireresponse/structuredefinition-QuestionnaireResponse.xml
+++ b/source/questionnaireresponse/structuredefinition-QuestionnaireResponse.xml
@@ -397,7 +397,7 @@
         <key value="qrs-2"/>
         <severity value="error"/>
         <human value="Repeated answers are combined in the answers array of a single item"/>
-        <expression value="repeat(answer|item).select(item.where(answer.value.exists()).linkId.isDistinct()).allTrue()"/>
+        <expression value="item.where(answer.value.exists()).linkId.isDistinct() and repeat(answer|item).select(item.where(answer.value.exists()).linkId.isDistinct()).allTrue()"/>
         <source value="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"/>
       </constraint>
       <mapping>
@@ -421,7 +421,7 @@
         <key value="qrs-3"/>
         <severity value="error"/>
         <human value="LinkId cannot have leading or trailing spaces or intevening whitespace other than single space characters"/>
-        <expression value="$this.matches('[^\\s]+( [^\\s]+)*')"/>
+        <expression value="$this.matches('^[^\\s]+( [^\\s]+)*$')"/>
       </constraint>
       <mapping>
         <identity value="rim"/>

--- a/source/structuredefinition/invariant-tests/eld-12.f1.fail.json
+++ b/source/structuredefinition/invariant-tests/eld-12.f1.fail.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "StructureDefinition",
+  "url": "http://example.org/sd/eld12",
+  "name": "Eld12",
+  "status": "draft",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.status",
+        "path": "Observation.status",
+        "binding": {
+          "strength": "required",
+          "valueSet": "httpsfoo"
+        }
+      }
+    ]
+  }
+}

--- a/source/structuredefinition/invariant-tests/eld-21.f1.fail.json
+++ b/source/structuredefinition/invariant-tests/eld-21.f1.fail.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "StructureDefinition",
+  "url": "http://example.org/sd/eld21",
+  "name": "Eld21",
+  "status": "draft",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.name",
+        "path": "Patient.name",
+        "constraint": [
+          {
+            "key": "x-1",
+            "severity": "error",
+            "human": "must be set",
+            "_expression": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                  "valueCode": "unknown"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Fix faulty invariant FHIRPath expressions (+ regression fixtures)

## What this does
Corrects invariant (`constraint`) FHIRPath expressions whose evaluation does **not** match the
rule's stated `human` text, and adds a new invariant-test fixture for each so the behavior is
locked in.

**Key evaluation fact this relies on:** the validator passes a constraint only when its FHIRPath
converts to boolean **`true`**; `false`, an **empty result `{}`**, and a thrown runtime error all
count as **fail**. Several of the fixes (and several *non*-fixes, see below) turn on this.

## How each fix was verified
Every change was checked against the real validator (`org.hl7.fhir.core` 6.9.8, R6) and/or a
`convertToBoolean` wrapper that reproduces the validator's pass/fail mapping. Each new fixture's
instance was evaluated under **both the old and the new expression** and the verdict **flips** in
the intended direction (a `.fail` fixture that the old expression wrongly *passed*; a `.pass`
fixture the old expression wrongly *failed*). Abbreviations below: **FP** = false-positive (rejects
valid data), **FN** = false-negative (accepts invalid data).

## Fixes included (≈29 invariants, 15 files) + new fixtures

### Single-value operators (`=`/`!=`/`in`) on repeating elements
`=`/`!=` on different-length collections return `false`; `in` throws on a multi-item operand.
| key | dir | sev | issue | fixture |
|---|---|---|---|---|
| `bdl-14` | Bundle | error | FN: a PATCH in a multi-entry history bundle isn't caught → `entry.request.all(method != 'PATCH')` | `bdl-14.f2.fail.json` |
| `bdl-16` | Bundle | error | FP: any OperationOutcome with ≥2 issues is rejected → `issues.issue.all(severity = …)` | `bdl-16.p2.pass.json` |
| `csd-3` | CodeSystem | warning | FN: a concept with >1 property never warns → `property.where(code='parent' or code='child').exists()` | `csd-3.f3.fail.json` |
| `csd-6` | CodeSystem | error | FP: a concept that is the alternate of two others fails reciprocity → `…where(code='alternateCode' and value=%sc).exists()` | `csd-6.p2.pass.json` |
| `pld-3` | PlanDefinition | warning | FP: an action with 2+ goalIds throws → `…goalId.all($this in %context.goal.id)` | `pld-3.p1.pass.json` |

### `count()`/`exists()` aggregated across all repeats instead of per item
| key | dir | issue | fixture |
|---|---|---|---|
| `isl-7`/`isl-8`/`isl-11` | error | FN: odd per-region/instance counts summing even pass → `instance.imageRegion2D.all(coordinate.count() mod 2 = 0)` (and `mod 3`, waveform) | `isl-7.f2`, `isl-8.f2`, `isl-11.f2` `.fail.json` |
| `isl-10` | error | FP: two instances each using one selection mechanism are rejected → wrap in `instance.all(...)` | `isl-10.p1.pass.json` |

### `xor` used for "mutually exclusive"
| key | dir | issue | fixture |
|---|---|---|---|
| `mrp-3`/`mrp-4` | error | FP: a population with **neither** `count` nor `countQuantity` is rejected → `(count.exists() and countQuantity.exists()).not()` | `mrp-3.p1`, `mrp-4.p1` `.pass.json` |

### Unanchored `matches()` (partial match)
| key | dir | issue | fixture |
|---|---|---|---|
| `que-16` / `qrs-3` | error | FN: a linkId like `"double  space"` passes → anchor with `^…$` | `que-16.f1`, `qrs-3.f1` `.fail.json` |
| `exp-2` | error | FN: an `Expression.name` like `"9-bad name"` passes → anchor | `exp-2.f1.fail.json` |
| `eld-12` | error | FN: `startsWith('https')` (no colon) accepts `'httpsfoo'` → `startsWith('https:')` | `eld-12.f1.fail.json` |

### Tree-walk that skips a level
| key | dir | issue | fixture |
|---|---|---|---|
| `csd-1` | error | FN: code-uniqueness misses concepts one level deep → `concept.code.combine(concept.combine(concept.descendants()).concept.code).isDistinct()` | `csd-1.f2.fail.json` |
| `qrs-2` | error | FN: duplicate-linkId children of a top-level item aren't checked (`repeat()` excludes the seed) → also check the item's own children | `qrs-2.f1.fail.json` |

### Other
| key | dir | issue | fixture |
|---|---|---|---|
| `eld-21` | warning | FN: `expression.exists()` is true for an extension-only primitive → `expression.hasValue()` | `eld-21.f1.fail.json` |
| `cnt-3` | error | FP: a whole number written `5.0` is rejected (`toString()` keeps the `.`) → `value = value.round()` | `cnt-3.p1.pass.json` |
| `bdl-7` | error | FP: delimiter-less `fullUrl & versionId` key collides → insert `'\|'` | `bdl-7.p1.pass.json` |
| `drt-1` | error | FN+FP: implication inverted (`code→value`) **and** a code-only Duration is rejected → `(value.exists() implies code.exists()) and (system.exists() implies system = %ucum)` | `drt-1.f1.fail` + `drt-1.p1.pass.json` |
| `pld-6` / `adf-2` | warning | FP: clause references a non-existent `artifact` element; both `resource`+`resourceReference` (allowed) is rejected → `… implies (resource.exists() or resourceReference.exists())` | `pld-6.p1`, `adf-2.p1` `.pass.json` |
| `que-5` / `que-5b` | error | FP: the type list says `'uri'` but the item-type code is `'url'` → use `'url'` | `que-5.p1`, `que-5b.p1` `.pass.json` |
| `ist-4` | error | FP: antecedent gates on `series.exists()` instead of `series.instance.exists()` → a summary-only study is rejected | `ist-4.p1.pass.json` |

### Text-only (the FHIRPath was already correct — only the `human` text was wrong; no fixture)
- `bdl-3b` (Bundle): text said "request **or** response" but the spec/expression require **both** → text fixed to "and".
- `docRef-2` (DocumentReference): text said "context is not present" but the expression (matching its sibling `docRef-1` and its own pass fixture) means "context is **not an encounter**" → text fixed.

### Element-rename only (no fixture possible)
- `inv-2` (Event pattern): referenced the obsolete `reasonCode`/`reasonReference` (R6 merged these into `reason`) so it could never fire → updated to `reason.exists().not()`. It's defined only on the abstract Event *pattern* and isn't applied to concrete resources, so there is no instance that can exercise it.

## Left out, and why

### Earlier-suspected, but verified CORRECT (no change) — ~16 invariants
An earlier reasoning pass (before validating) wrongly assumed an empty FHIRPath result meant
"pass." The validator treats empty as **fail**, so the following are actually correct and were
**not** touched:
- "Max is a number or `*`" family: `eld-3`, `md-1`, `opd-9`, `smp-3` (a non-numeric `max` →
  `toInteger()` empty → fails, which is right).
- "Empty-antecedent" family: `que-10`, `que-13`, `que-17`, `sdf-1`, `vsd-9`, `opd-2`, `opd-3`,
  `sdf-21`, `sdf-30` (the empty result lands on the violation, so it fails correctly; valid edge
  cases produce a real `true`).
- `obd-0` (the Java engine supports `.value` on a primitive), `eld-11` (special-cased in Java),
  `apd-1` (fires correctly for resolvable `formOf`; only the universal `resolve()` limitation
  remains).

### Confirmed issues deferred (need work this branch can't safely do)
- **`dgr-1`** (DiagnosticReport): only walks top-level `section.entry`, missing nested sub-section
  entries. The traversal fix (`repeat(section)`) is verified in isolation, but the full invariant
  depends on `resolve()`/`%resource`/`hasMember` membership, which can't be evaluated outside full
  validation — so I couldn't construct a fixture whose end-to-end verdict provably flips. **Reverted**
  here pending validation-context confirmation.
- **`cmp-3`** (Composition): the rule is anchored on `Composition.section`, so it can't fail when
  reached and never reaches its real violation (attester + no text + no section). The fix is to
  **re-anchor** the constraint to the resource root (a structural move, not just an expression
  edit) — left for a deliberate change.
- **`tst-1` / `tst-2` / `tst-3`** (TestScript): 3-way chained `xor` is true for an odd count, so
  "all three present" passes; `tst-3`'s `or`-of-empties only catches all-three. These are authored
  in a **binary `.xlsx` spreadsheet** that isn't editable in this workflow; they need fixing in the
  TestScript spreadsheet source.

## Notes
- A few invariants (`isl-7/8/10/11`, `pld-6`, `adf-2`, `cnt-3`, `drt-1`, `eld-12`, `eld-21`) are
  newer than, or are datatype invariants not surfaced by, the validator's loaded core package, so
  they were verified via the validator's FHIRPath **engine** + the `convertToBoolean` rule rather
  than a full package validation. Datatype-invariant fixtures are hosted on a carrier resource
  (`cnt-3`/`drt-1` under `Parameters`, `exp-2` under `PlanDefinition`, `eld-*` under
  `StructureDefinition`), following the existing convention (e.g. `qty-4` under `Observation`).
- `csd-1`'s gap is also masked at full validation by a separate built-in duplicate-code check, but
  the invariant's own FHIRPath is corrected regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
