### PR TITLE
security/consent/FHIR-54629: revise all instances of using 'exception' in reference to provisions.

### DIFF
--- a/source/consent/consent-introduction.xml
+++ b/source/consent/consent-introduction.xml
@@ -91,9 +91,9 @@ make rules about what signatures are required, and how they are to be shared and
         <a name="bnc"></a>
         <h2>Background and Context</h2>
         <p>
-The Consent resource is structured with a base policy (represented as Consent.decision) which is either permit or deny, followed by a listing of exceptions to that policy (represented as Consent.provision(s)). The exceptions can be additional positive 
-or negative exceptions upon the base policy. The set of exceptions include a list of data objects, 
-list of authors, list of recipients, list of Organizations, list of purposeOfUse, and Date Range.
+The computable rules in the Consent resource are structured as a base <code>permit</code> or <code>deny</code> decision (<code>Consent.decision</code>), followed by a hierarchical provision structure. 
+The child provisions at each level of this hierarchy narrow down the parent rule by articulating further exceptions or constraints. 
+This is further discussed in the <a href="consent.html#provision">Provisions section</a> below.
         </p>
         <p>
 The enforcement of the Privacy Consent Directive is not included but is expected that 

--- a/source/consent/consent-notes.xml
+++ b/source/consent/consent-notes.xml
@@ -53,8 +53,8 @@ consent has been rejected, and consent approved.
     <li>Opt-in: Sharing for some purpose of use is authorized Sharing allowed for Treatment, Payment, and normal Operations; and</li>
     <li>Opt-in with restrictions: Sharing allowed, but the patient may make exceptions.</li>
   </ol>
-  <p>For each of these patterns (positive or negative pattern), there can be exceptions. 
-	  These exceptions are explicitly recorded in the <code>provision</code> element. 
+  <p>For each of these patterns (positive or negative pattern), there can be exceptions or constraints that 
+    may be explicitly recorded in the <code>provision</code> element. 
   </p>
 
 <a name="provisions"></a>
@@ -92,7 +92,7 @@ when matched, will be <code>permit</code>, and so on.
     <li> 
     Provisions at the same level of depth are interpreted as disjunctive (i.e., <em>OR</em>-ed). 
     This means that matching <em>any</em> of the sibling provisions at one level constitutes an exception 
-    to the rule stated in the parent provision.
+    to, or a constraint on the rule stated in the parent provision.
   </li>
 
   <li> 
@@ -140,7 +140,7 @@ In order to match this provision, and therefore for this <em>permit</em> decisio
 applicable, the requestor identifier must match <em>Org A</em> AND the current date must 
 be within the range 01/01/2020-31/12/2022.</p>
 
-  <p>The subsequent child provisions state exceptions to this base rule. 
+  <p>The subsequent child provisions state exceptions to or constraints on this base rule. 
 Matching <em>any</em> of these provisions results in a <em>deny</em> since these 
 are exceptions to a <em>permit</em> parent provision.</p>
 
@@ -271,6 +271,6 @@ necessary consent content derived from a Consent Directive for use in workflow m
     <li>Locally inspect Consent.provision for base policy acceptance/denial with <code>Consent.policyBasis</code></li>
     <li>If <code>Consent.policyBasis</code> not understandable, refer to Privacy Office</li>
     <li>Locally inspect <code>Consent.provision</code> for contexts (e.g., <code>provision.purpose</code>, <code>provision.actor</code>, etc.) as above</li>
-    <li>Inspect nested provisions for exceptions.</li>
+    <li>Inspect nested provisions for exceptions and constraints.</li>
   </ol>
 </div>

--- a/source/consent/structuredefinition-Consent.xml
+++ b/source/consent/structuredefinition-Consent.xml
@@ -602,12 +602,12 @@
       <type>
         <code value="BackboneElement"/>
       </type>
-      <meaningWhenMissing value="There is no specific actor associated with the exception"/>
+      <meaningWhenMissing value="There is no specific actor associated with the provision"/>
     </element>
     <element id="Consent.provision.actor.role">
       <path value="Consent.provision.actor.role"/>
       <short value="How the actor is involved"/>
-      <definition value="How the individual is involved in the resources content that is described in the exception."/>
+      <definition value="How the individual is involved in the resources content targeted by this provision."/>
       <min value="0"/>
       <max value="1"/>
       <type>
@@ -664,7 +664,7 @@
     <element id="Consent.provision.securityLabel">
       <path value="Consent.provision.securityLabel"/>
       <short value="Security Labels that define affected resources"/>
-      <definition value="A security label, comprised of 0..* security label fields (Privacy tags), which define which resources are controlled by this exception."/>
+      <definition value="A security label, comprised of 0..* security label fields (Privacy tags), which define which resources are controlled by this provision."/>
       <comment value="If the consent specifies a security label of &quot;R&quot; then it applies to all resources that are labeled &quot;R&quot; or lower. E.g. for Confidentiality, it's a high water mark. For other kinds of security labels, subsumption logic applies. When the purpose of use tag is on the data, access request purpose of use shall not conflict."/>
       <min value="0"/>
       <max value="*"/>
@@ -700,7 +700,7 @@
           <valueString value="PurposeOfUse"/>
         </extension>
         <strength value="extensible"/>
-        <description value="What purposes of use are controlled by this exception. If more than one label is specified, operations must have all the specified labels."/>
+        <description value="What purposes of use are controlled by this provision. If more than one label is specified, operations must have all the specified labels."/>
         <valueSet value="http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"/>
       </binding>
     </element>
@@ -759,7 +759,7 @@
           <valueString value="ConsentContentCode"/>
         </extension>
         <strength value="example"/>
-        <description value="If this code is found in an instance, then the exception applies."/>
+        <description value="If this code is found in an instance, then the provision applies."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/consent-content-code"/>
       </binding>
     </element>
@@ -827,7 +827,7 @@
     <element id="Consent.provision.provision">
       <path value="Consent.provision.provision"/>
       <short value="Nested provisions to further constraint the parent provision"/>
-      <definition value="Nested provisions adding further constraints and exceptions to the parent provision."/>
+      <definition value="Nested provisions adding further constraints on, or exceptions to the parent provision."/>
       <min value="0"/>
       <max value="*"/>
       <contentReference value="#Consent.provision"/>


### PR DESCRIPTION
## HL7 FHIR Pull Request
https://jira.hl7.org/browse/FHIR-54629

also closes [FHIR-54133](https://jira.hl7.org/browse/FHIR-54133)

## Description
clear up instances of using the word exception when it refers to provisions.