### PR TITLE
J#53692Because it's now back to preferred binding

### DIFF
--- a/source/researchstudy/researchstudy-introduction.xml
+++ b/source/researchstudy/researchstudy-introduction.xml
@@ -8,7 +8,7 @@
 <p>Changed the ResearchStudy.progressStatus.state ValueSet binding to be HL7 Terminology and &quot;preferred&quot; binding.</p>
 <p>Added DocumentReference as a possible Resource type to ResearchStudy.result.</p>
 <p>Added ResearchStudy.comparisonGroup.name string element.</p>
-<p>Changed ResearchStudy.primaryPurposeType 0..1 to ResearchStudy.purposeType 0..* and example binding strength..</p>
+<p>Changed ResearchStudy.primaryPurposeType 0..1 to ResearchStudy.purposeType 0..*.</p>
 <p>Updated the definition of ResearchStudy.progressStatus.</p>
 </blockquote>
 <blockquote style="background-color: lightblue">


### PR DESCRIPTION
`Proceed as suggested, with a temporary "Example" binding strength pointing to an example value set in the FHIR build until the target value set is available in THO.`

And now that it's available on THO, the binding is no longer the temporary "example" binding strength.