### PR TITLE
QA: DocumentReference examples have coding system set to a ValueSet, change to be the CodeSystem (fix breaking build)

### DIFF
--- a/source/documentreference/documentreference-example-composition.xml
+++ b/source/documentreference/documentreference-example-composition.xml
@@ -74,7 +74,7 @@
   <relatesTo>
     <code>
       <coding>
-        <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+        <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
         <code value="replaces"/>
       </coding>
     </code>

--- a/source/documentreference/documentreference-example-comprehensive.xml
+++ b/source/documentreference/documentreference-example-comprehensive.xml
@@ -109,7 +109,7 @@
   <relatesTo>
     <code>
       <coding>
-        <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+        <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
         <code value="appends"/>
       </coding>
     </code>

--- a/source/documentreference/documentreference-example.xml
+++ b/source/documentreference/documentreference-example.xml
@@ -118,7 +118,7 @@ source data from http://wiki.ihe.net/index.php?title=Annotated_ProvideAndRegiste
 	<relatesTo>
 	    <code>
 			<coding>
-			  <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+			  <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
 			  <code value="appends"/>
 			</coding>
 		</code>


### PR DESCRIPTION
## Description

Fix the examples that are causing the build to fail
