### PR TITLE
Patient Administration R6 Batch 1 from Brian

### DIFF
--- a/source/appointment/appointment-introduction.xml
+++ b/source/appointment/appointment-introduction.xml
@@ -1,5 +1,31 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 	<div>
+<blockquote class="ballot-note" id="bn1">
+<p><b>Note to Balloters:</b> Key changes made since FHIR 6.0.0-ballot4:</p>
+<ul>
+  <li>Non-compatible Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-56302">FHIR-56302</a>: Appointment.recurrenceTemplate.monthlyTemplate changed from Coding to code</li>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55285">FHIR-55285</a>: <i>(duplicate of above)</i> Appointment.recurrenceTemplate.monthlyTemplate changed from Coding to code</li>
+      <li><a href="https://jira.hl7.org/browse/FHIR-57336">FHIR-57336</a>: Appointment.recurrenceTemplate.weeklyTemplate changed from booleans to code[1..*]</li>
+    </ul>
+  </li>
+  <li>Compatible, Substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55288">FHIR-55288</a>: Make the appointment.participant.status property optional</li>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55287">FHIR-55287</a>: Add code "unknown" to appointment.status</li>
+    </ul>
+  </li>
+  <li>Non-substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-53899">FHIR-53899</a>: Remove request for feedback notes</li>
+	  <li><a href="https://jira.hl7.org/browse/FHIR-54400">FHIR-54400</a>: Include extra clarifying documentation on the use of AppointmentResponse resources in a simple chain series</li>
+    </ul>
+  </li>
+</ul>
+</blockquote>
+<p></p>
+
     <a name="scope"></a>
 		<h2>Scope and Usage</h2>
 		<p>
@@ -171,21 +197,23 @@
 		This style of recurring appointment likely will not use the <code>originatingAppointment</code> property either.
 	</p>
 	<p>
-		As each appointment in a series is a separate appointment and booked as needed, the acceptance of requests here is
-		just as it would be normally if they did not have a sequence.
+		As each appointment in a series is a separate appointment and booked as needed (with no template), the acceptance of requests (via individual AppointmentResponse resources)
+		is the same as it would be normally if they were not part of a series.
 	</p>
 	<p>
 		As each occurrence is booked independently there are no specific issues with timezones, as each instance exactly
 		defines when it occurs (there is no template).
 	</p>
 
-	[%stu-note dstu2%]
+	<blockquote class="ballot-note" id="bn1">
+	<p><b>Note to Balloters:</b> 
 		We are seeking input from the implementer community on the recurring appointment functionality
 		and specifically if there is a need for a "recur forever" or similar flag.
 		</p>
 		<p>
 		Feedback <a href="http://hl7.org/fhir-issues">here</a>.
-	[%end-note%]
+	</p>
+	</blockquote>
 	</div>
 	<div>
 

--- a/source/appointment/appointment-notes.xml
+++ b/source/appointment/appointment-notes.xml
@@ -527,13 +527,4 @@ services is described may vary by jurisdiction (e.g., Da Vinci PAS in the US).
 </p>
 
 
-[%stu-note dstu%]
-Implementer feedback is sought on the values for Appointment.priority and how interoperable they are.
-Using an extension to record a CodeableConcept for named values may be tested at a future Connectathon.<br/>
-Implementer feedback is also sought to clarify desired relationship linkages between ServiceCategory, 
-ServiceType and Specialty, along with how they have approached the definition.
-</p>
-<p>
-Feedback <a href="http://hl7.org/fhir-issues">here</a>.
-[%end-note%]
 </div>

--- a/source/appointment/appointment-request-mapping-exceptions.xml
+++ b/source/appointment/appointment-request-mapping-exceptions.xml
@@ -63,7 +63,7 @@
     <divergentElement patternPath="Request.status" resourcePath="Appointment.status">
         <shortUnmatched reason="Unknown">
             <_pattern value="draft | active | on-hold | revoked | completed | entered-in-error | unknown"/>
-            <resource value="proposed | pending | booked | arrived | fulfilled | cancelled | noshow | entered-in-error | checked-in | waitlist"/>
+            <resource value="proposed | pending | booked | arrived | fulfilled | cancelled | noshow | entered-in-error | checked-in | waitlist | unknown"/>
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="The current state of the appointment."/>

--- a/source/appointment/codesystem-appointmentstatus.xml
+++ b/source/appointment/codesystem-appointmentstatus.xml
@@ -97,4 +97,9 @@
     <display value="Waitlisted"/>
     <definition value="The appointment has been placed on a waitlist, to be scheduled/confirmed in the future when a slot/service is available.&#xA;A specific time might or might not be pre-allocated."/>
   </concept>
+  <concept>
+    <code value="unknown"/>
+    <display value="Unknown"/>
+    <definition value="The appointment status is unknown."/>
+  </concept>
 </CodeSystem>

--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -183,7 +183,7 @@
     </element>
     <element id="Appointment.status">
       <path value="Appointment.status"/>
-      <short value="proposed | pending | booked | arrived | fulfilled | cancelled | noshow | entered-in-error | checked-in | waitlist"/>
+      <short value="proposed | pending | booked | arrived | fulfilled | cancelled | noshow | entered-in-error | checked-in | waitlist | unknown"/>
       <definition value="The overall status of the Appointment. Each of the participants has their own participation status which indicates their involvement in the process, however this status indicates the shared status."/>
       <comment value="If the Appointment's status is &quot;cancelled&quot; then all participants are expected to have their calendars released for the appointment period, and as such any Slots that were marked as BUSY can be re-set to FREE.&#xA;&#xA;This element is labeled as a modifier because the status contains the code entered-in-error that mark the Appointment as not currently valid."/>
       <min value="1"/>
@@ -1029,7 +1029,7 @@
       <path value="Appointment.participant.status"/>
       <short value="accepted | declined | tentative | needs-action"/>
       <definition value="Participation status of the actor."/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="code"/>
@@ -1206,75 +1206,23 @@
         <code value="BackboneElement"/>
       </type>
     </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.monday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.monday"/>
-      <short value="Recurs on Mondays"/>
-      <definition value="Indicates that recurring appointments should occur on Mondays."/>
-      <min value="0"/>
-      <max value="1"/>
+    <element id="Appointment.recurrenceTemplate.weeklyTemplate.dayOfWeek">
+      <path value="Appointment.recurrenceTemplate.weeklyTemplate.dayOfWeek"/>
+      <short value="mon | tue | wed | thu | fri | sat | sun"/>
+      <definition value="Indicates which days of the week the appointment will occur on."/>
+      <min value="1"/>
+      <max value="*"/>
       <type>
-        <code value="boolean"/>
+        <code value="code"/>
       </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.tuesday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.tuesday"/>
-      <short value="Recurs on Tuesday"/>
-      <definition value="Indicates that recurring appointments should occur on Tuesdays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.wednesday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.wednesday"/>
-      <short value="Recurs on Wednesday"/>
-      <definition value="Indicates that recurring appointments should occur on Wednesdays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.thursday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.thursday"/>
-      <short value="Recurs on Thursday"/>
-      <definition value="Indicates that recurring appointments should occur on Thursdays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.friday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.friday"/>
-      <short value="Recurs on Friday"/>
-      <definition value="Indicates that recurring appointments should occur on Fridays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.saturday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.saturday"/>
-      <short value="Recurs on Saturday"/>
-      <definition value="Indicates that recurring appointments should occur on Saturdays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
-    </element>
-    <element id="Appointment.recurrenceTemplate.weeklyTemplate.sunday">
-      <path value="Appointment.recurrenceTemplate.weeklyTemplate.sunday"/>
-      <short value="Recurs on Sunday"/>
-      <definition value="Indicates that recurring appointments should occur on Sundays."/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="boolean"/>
-      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="DaysOfWeek"/>
+        </extension>
+        <strength value="required"/>
+        <description value="The days of the week."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/days-of-week"/>
+      </binding>
     </element>
     <element id="Appointment.recurrenceTemplate.weeklyTemplate.weekInterval">
       <path value="Appointment.recurrenceTemplate.weeklyTemplate.weekInterval"/>
@@ -1308,12 +1256,12 @@
     </element>
     <element id="Appointment.recurrenceTemplate.monthlyTemplate.nthWeekOfMonth">
       <path value="Appointment.recurrenceTemplate.monthlyTemplate.nthWeekOfMonth"/>
-      <short value="Indicates which week of the month the appointment should occur"/>
+      <short value="first | second | third | fourth | last"/>
       <definition value="Indicates which week within a month the appointments in the series of recurring appointments should occur on."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="Coding"/>
+        <code value="code"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
@@ -1326,13 +1274,13 @@
     </element>
     <element id="Appointment.recurrenceTemplate.monthlyTemplate.dayOfWeek">
       <path value="Appointment.recurrenceTemplate.monthlyTemplate.dayOfWeek"/>
-      <short value="Indicates which day of the week the appointment should occur"/>
+      <short value="mon | tue | wed | thu | fri | sat | sun"/>
       <definition value="Indicates which day of the week the recurring appointments should occur each nth week."/>
       <comment value="This property is intended to be used with Appointment.recurrenceTemplate.monthly.nthWeek."/>
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="Coding"/>
+        <code value="code"/>
       </type>
       <binding>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">

--- a/source/documentreference/documentreference-example-composition.xml
+++ b/source/documentreference/documentreference-example-composition.xml
@@ -74,7 +74,7 @@
   <relatesTo>
     <code>
       <coding>
-        <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+        <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
         <code value="replaces"/>
       </coding>
     </code>

--- a/source/documentreference/documentreference-example-comprehensive.xml
+++ b/source/documentreference/documentreference-example-comprehensive.xml
@@ -109,7 +109,7 @@
   <relatesTo>
     <code>
       <coding>
-        <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+        <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
         <code value="appends"/>
       </coding>
     </code>

--- a/source/documentreference/documentreference-example.xml
+++ b/source/documentreference/documentreference-example.xml
@@ -118,7 +118,7 @@ source data from http://wiki.ihe.net/index.php?title=Annotated_ProvideAndRegiste
 	<relatesTo>
 	    <code>
 			<coding>
-			  <system value="http://terminology.hl7.org/ValueSet/document-relationship-type"/>
+			  <system value="http://terminology.hl7.org/CodeSystem/document-relationship-type"/>
 			  <code value="appends"/>
 			</coding>
 		</code>

--- a/source/endpoint/codesystem-endpoint-status.xml
+++ b/source/endpoint/codesystem-endpoint-status.xml
@@ -56,6 +56,11 @@
     <definition value="This endpoint is available for limited use (for example, it is undergoing internal testing).  I.e. the endpoint is not fully available, might not always be available, or might only be available for some users."/>
   </concept>
   <concept>
+    <code value="test"/>
+    <display value="Test"/>
+    <definition value="This endpoint is not intended for production usage."/>
+  </concept>
+  <concept>
     <code value="suspended"/>
     <display value="Suspended"/>
     <definition value="This endpoint is temporarily unavailable."/>
@@ -74,5 +79,10 @@
     <code value="entered-in-error"/>
     <display value="Entered in error"/>
     <definition value="This instance should not have been part of this patient's medical record."/>
+  </concept>
+  <concept>
+    <code value="unknown"/>
+    <display value="Unknown"/>
+    <definition value="The endpoint status is unknown."/>
   </concept>
 </CodeSystem>

--- a/source/endpoint/endpoint-introduction.xml
+++ b/source/endpoint/endpoint-introduction.xml
@@ -1,6 +1,29 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 
   <div>
+<blockquote class="ballot-note" id="bn1">
+<p><b>Note to Balloters:</b> Key changes made since FHIR 6.0.0-ballot4:</p>
+<ul>
+  <li>Non-compatible Changes
+    <ul>
+      <li>(none)</li>
+    </ul>
+  </li>
+  <li>Compatible, Substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-57362">FHIR-57362</a>: Add test to the Endpoint status CodeSystem</li>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55293">FHIR-55293</a>: Add "unknown" to the endpoint status</li>
+    </ul>
+  </li>
+  <li>Non-substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-53615">FHIR-53615</a>: Endpoint.header definition request</li>
+    </ul>
+  </li>
+</ul>
+</blockquote>
+<p></p>
+
 <a name="scope"></a>
     <h2>Scope and Usage</h2>
     <p>

--- a/source/endpoint/structuredefinition-Endpoint.xml
+++ b/source/endpoint/structuredefinition-Endpoint.xml
@@ -103,7 +103,7 @@
     </element>
     <element id="Endpoint.status">
       <path value="Endpoint.status"/>
-      <short value="active | limited | suspended | error | off | entered-in-error"/>
+      <short value="active | limited | test | suspended | error | off | entered-in-error | unknown"/>
       <definition value="The endpoint status represents whether the endpoint can currently be used for connections or why it can't be used."/>
       <comment value="This element is labeled as a modifier because the status contains codes that mark the endpoint as not currently valid. Temporary downtimes or other unexpected short-term changes in availability would not be represented in this property."/>
       <min value="1"/>
@@ -392,9 +392,9 @@
     </element>
     <element id="Endpoint.header">
       <path value="Endpoint.header"/>
-      <short value="Usage depends on the channel type"/>
-      <definition value="Additional headers / information to send as part of the notification."/>
-      <comment value="Exactly what these mean depends on the channel type. The can convey additional information to the recipient and/or meet security requirements."/>
+      <short value="Usage depends on the connection type"/>
+      <definition value="Additional headers / information to send when connecting to the endpoint."/>
+      <comment value="Exactly what these mean depends on the connection type. The can convey additional information to the recipient and/or meet security requirements."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/episodeofcare/codesystem-episode-of-care-status.xml
+++ b/source/episodeofcare/codesystem-episode-of-care-status.xml
@@ -82,4 +82,9 @@
     <display value="Entered in Error"/>
     <definition value="This instance should not have been part of this patient's medical record."/>
   </concept>
+  <concept>
+    <code value="unknown"/>
+    <display value="Unknown"/>
+    <definition value="The episode of care status is unknown."/>
+  </concept>
 </CodeSystem>

--- a/source/episodeofcare/episodeofcare-event-mapping-exceptions.xml
+++ b/source/episodeofcare/episodeofcare-event-mapping-exceptions.xml
@@ -40,11 +40,11 @@
     <divergentElement patternPath="Event.status" resourcePath="EpisodeOfCare.status">
         <shortUnmatched reason="Unknown">
             <_pattern value="preparation | in-progress | not-done | suspended | aborted | completed | entered-in-error | unknown"/>
-            <resource value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error"/>
+            <resource value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown"/>
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="The current state of the episode of care."/>
-            <resource value="planned | waitlist | active | onhold | finished | cancelled."/>
+            <resource value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown."/>
         </definitionUnmatched>
         <commentsUnmatched reason="Unknown">
             <_pattern value="A nominal state-transition diagram can be found in the (Event pattern documentation&#10;&#10;Unknown does not represent &quot;other&quot; - one of the defined statuses must apply.  Unknown is used when the authoring system is not sure what the current status is."/>

--- a/source/episodeofcare/episodeofcare-introduction.xml
+++ b/source/episodeofcare/episodeofcare-introduction.xml
@@ -1,6 +1,28 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 
   <div>
+<blockquote class="ballot-note" id="bn1">
+<p><b>Note to Balloters:</b> Key changes made since FHIR 6.0.0-ballot4:</p>
+<ul>
+  <li>Non-compatible Changes
+    <ul>
+      <li>(none)</li>
+    </ul>
+  </li>
+  <li>Compatible, Substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55295">FHIR-55295</a>: Add "unknown" to the episode of care status</li>
+    </ul>
+  </li>
+  <li>Non-substantive Changes
+    <ul>
+      <li>(none)</li>
+    </ul>
+  </li>
+</ul>
+</blockquote>
+<p></p>
+
 <a name="scope"></a>
     <h2>Scope and Usage</h2>
     <p>

--- a/source/episodeofcare/structuredefinition-EpisodeOfCare.xml
+++ b/source/episodeofcare/structuredefinition-EpisodeOfCare.xml
@@ -112,8 +112,8 @@
     </element>
     <element id="EpisodeOfCare.status">
       <path value="EpisodeOfCare.status"/>
-      <short value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error"/>
-      <definition value="planned | waitlist | active | onhold | finished | cancelled."/>
+      <short value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown"/>
+      <definition value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown."/>
       <comment value="This element is labeled as a modifier because the status contains codes that mark the episode as not currently valid."/>
       <min value="1"/>
       <max value="1"/>
@@ -155,8 +155,8 @@
     </element>
     <element id="EpisodeOfCare.statusHistory.status">
       <path value="EpisodeOfCare.statusHistory.status"/>
-      <short value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error"/>
-      <definition value="planned | waitlist | active | onhold | finished | cancelled."/>
+      <short value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown"/>
+      <definition value="planned | waitlist | active | onhold | finished | cancelled | entered-in-error | unknown."/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/source/group/structuredefinition-Group.xml
+++ b/source/group/structuredefinition-Group.xml
@@ -49,7 +49,7 @@
       <value value="http://www.hl7.org/Special/committees/fiwg/index.cfm"/>
     </telecom>
   </contact>
-  <description value="Represents a defined collection of entities that may be discussed or acted upon collectively but which are not typically expected to act collectively*. These collections are also not typically formally or legally recognized.\r\n\r\n*NOTE: Group may be used to define families or households, which in some circumstances may act collectively or have a degree of legal or formal recognition. This should be considered an exception. When Group is used for types of entities other than Patient or RelatedPerson, the expectation remains that the Group will not act collectively or have formal recognition - use Organization if these behaviors are needed. See more discussion [below](group.html#group-usage)"/>
+  <description value="Represents a defined collection of entities that may be discussed or acted upon collectively but which are not typically expected to act collectively. These collections are also not typically formally or legally recognized.&#xD;&#xD;NOTE: Group may be used to define families or households, which in some circumstances may act collectively or have a degree of legal or formal recognition. This should be considered an exception. When Group is used for types of entities other than Patient or RelatedPerson, the expectation remains that the Group will not act collectively or have formal recognition - use Organization if these behaviors are needed." />
   <fhirVersion value="6.0.0"/>
   <mapping>
     <identity value="rim"/>

--- a/source/slot/bundle-Slot-search-params.xml
+++ b/source/slot/bundle-Slot-search-params.xml
@@ -157,6 +157,25 @@
   <entry>
     <resource>
       <SearchParameter>
+        <id value="Slot-end"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="Slot.end"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/Slot-end"/>
+        <description value="Appointment date/time."/>
+        <code value="end"/>
+        <type value="date"/>
+        <expression value="Slot.end"/>
+        <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
         <id value="Slot-status"/>
         <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
           <valueCode value="normative"/>

--- a/source/slot/codesystem-slotstatus.xml
+++ b/source/slot/codesystem-slotstatus.xml
@@ -72,4 +72,9 @@
     <display value="Entered in error"/>
     <definition value="This instance should not have been part of this patient's medical record."/>
   </concept>
+  <concept>
+    <code value="unknown"/>
+    <display value="Unknown"/>
+    <definition value="The free/busy status of the slot is unknown."/>
+  </concept>
 </CodeSystem>

--- a/source/slot/slot-introduction.xml
+++ b/source/slot/slot-introduction.xml
@@ -1,6 +1,29 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 
 	<div>
+<blockquote class="ballot-note" id="bn1">
+<p><b>Note to Balloters:</b> Key changes made since FHIR 6.0.0-ballot4:</p>
+<ul>
+  <li>Non-compatible Changes
+    <ul>
+      <li>(none)</li>
+    </ul>
+  </li>
+  <li>Compatible, Substantive Changes
+    <ul>
+      <li><a href="https://jira.hl7.org/browse/FHIR-55314">FHIR-55314</a>: Add "unknown" to the slot status</li>
+      <li><a href="https://jira.hl7.org/browse/FHIR-54189">FHIR-54189</a>: Add "end" Search Parameter to Slot Resource</li>
+    </ul>
+  </li>
+  <li>Non-substantive Changes
+    <ul>
+      <li>(none)</li>
+    </ul>
+  </li>
+</ul>
+</blockquote>
+<p></p>
+
 <a name="scope"></a>
 		<h2>Scope and Usage</h2>
 		<p>

--- a/source/slot/structuredefinition-Slot.xml
+++ b/source/slot/structuredefinition-Slot.xml
@@ -211,8 +211,8 @@
         <valueString value="This is not a modifier element as the status of the slot being busy is not a change in the interpretation of the slot."/>
       </extension>
       <path value="Slot.status"/>
-      <short value="busy | free | busy-unavailable | busy-tentative | entered-in-error"/>
-      <definition value="busy | free | busy-unavailable | busy-tentative | entered-in-error."/>
+      <short value="busy | free | busy-unavailable | busy-tentative | entered-in-error | unknown"/>
+      <definition value="busy | free | busy-unavailable | busy-tentative | entered-in-error | unknown."/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/source/status-codes.xml
+++ b/source/status-codes.xml
@@ -1624,7 +1624,7 @@
     <Cell ss:Index="3" ss:StyleID="s64"><Data ss:Type="String">entered-in-error</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s64"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s64"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">test</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -1637,7 +1637,7 @@
     <Cell ss:StyleID="s68"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><Data ss:Type="String">off</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">unknown</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/source/status-codes.xml
+++ b/source/status-codes.xml
@@ -3275,7 +3275,7 @@
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">unknown</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><Data ss:Type="String">busy-tentative</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/source/status-codes.xml
+++ b/source/status-codes.xml
@@ -581,7 +581,7 @@
     <Cell ss:StyleID="s65"><Data ss:Type="String">fulfilled</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><Data ss:Type="String">cancelled</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">unknown</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>

--- a/source/status-codes.xml
+++ b/source/status-codes.xml
@@ -1668,7 +1668,7 @@
     <Cell ss:StyleID="s65"><Data ss:Type="String">finished</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><Data ss:Type="String">cancelled</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">unknown</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
@@ -1699,7 +1699,7 @@
     <Cell ss:StyleID="s65"><Data ss:Type="String">finished</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><Data ss:Type="String">cancelled</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
-    <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
+    <Cell ss:StyleID="s65"><Data ss:Type="String">unknown</Data><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>
     <Cell ss:StyleID="s65"><NamedCell ss:Name="_FilterDatabase"/></Cell>


### PR DESCRIPTION
## HL7 FHIR Pull Request
Appointment, Endpoint, EpisodeOfCare, Slot and Administrative Module page (in Group description)

## Description
The following issues have been applied:
* FHIR-56302 Appointment.recurrenceTemplate.monthlyTemplate changed from Coding to code
* FHIR-55285 (duplicate of FHIR-56302) Appointment.recurrenceTemplate.monthlyTemplate changed from Coding to code
* FHIR-57336 Appointment.recurrenceTemplate.weeklyTemplate changed from booleans to code[1..*]
* FHIR-55288 Make the appointment.participant.status property optional
* FHIR-55287 Add code "unknown" to appointment.status
* FHIR-53899 Remove request for feedback notes
* FHIR-54400 Include extra clarifying documentation on the use of AppointmentResponse resources in a simple chain series
* FHIR-54093 Admin Module Page, Formatting & Links (tidy up group description)
* FHIR-57362 EndPoint.status add code test
* FHIR-55293 Endpoint.status has no escape valve - add code unknown
* FHIR-53615 Endpoint.header definition request
* FHIR-55295 Add "unknown" to the episode of care status
* FHIR-55314 Add "unknown" to the slot status
* FHIR-54189 Add "end" Search Parameter to Slot Resource

_(also included is the fixes to the DocumentReference examples that are the same commit as in the other PR https://github.com/HL7/fhir/pull/4222)_