### PR TITLE
FHIR-54162 Change Coverage.statusReason to a CodeableConcept - the st…

### DIFF
--- a/source/coverage/coverage-introduction.xml
+++ b/source/coverage/coverage-introduction.xml
@@ -10,7 +10,7 @@
         <li>Substantive:</li>
             <ul>
                 <li><a href="https://jira.hl7.org/browse/FHIR-54162">FHIR-54162</a> - Changed datatype of Coverage.statusReason to CodeableConcept. 
-				Balloters are invited to propose codes which may included in the next ballot.</li> 
+				Balloters are invited to propose codes which may be included in the next ballot.</li> 
                 <li><a href="https://jira.hl7.org/browse/FHIR-54234">FHIR-54234</a> - Changed cardinality of .class.value from 1..1 to 0..1, 
 				added element .class.code 0..1 Coding 'Code associated with the type' example binding, 
 				added a condition that either value or code may be specified</li>

--- a/source/coverage/coverage-introduction.xml
+++ b/source/coverage/coverage-introduction.xml
@@ -9,6 +9,12 @@
     <ul>
         <li>Substantive:</li>
             <ul>
+                <li><a href="https://jira.hl7.org/browse/FHIR-54162">FHIR-54162</a> - Changed datatype of Coverage.statusReason to CodeableConcept. 
+				Balloters are invited to propose codes which may included in the next ballot.</li> 
+                <li><a href="https://jira.hl7.org/browse/FHIR-54234">FHIR-54234</a> - Changed cardinality of .class.value from 1..1 to 0..1, 
+				added element .class.code 0..1 Coding 'Code associated with the type' example binding, 
+				added a condition that either value or code may be specified</li>
+                <li><a href="https://jira.hl7.org/browse/FHIR-54441">FHIR-54441</a> - Changed datatype of Coverage.network from string to Reference(Organization)</li>
                 <li><a href="https://jira.hl7.org/browse/FHIR-55563">FHIR-55563</a> - Removed Coverage.contract</li>
             </ul>
         <li>Non-substantive:</li>

--- a/source/coverage/structuredefinition-Coverage.xml
+++ b/source/coverage/structuredefinition-Coverage.xml
@@ -185,9 +185,16 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="CodeableConcept"/>
       </type>
       <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CoverageStatusReason"/>
+        </extension>
+        <strength value="example"/>
+        <description value="A reason code for the current status of the instance."/>
+      </binding>
     </element>
     <element id="Coverage.kind">
       <path value="Coverage.kind"/>
@@ -524,7 +531,13 @@
       <requirements value="The codes provided on the health card which identify or confirm the specific policy for the insurer."/>
       <min value="0"/>
       <max value="*"/>
-      <type>
+      <constraint>
+        <key value="cov-classtype"/>
+        <severity value="error"/>
+        <human value="Only one of .value and .code may be specified."/>
+        <expression value="value.exists() xor code.exists()"/>
+      </constraint>
+          <type>
         <code value="BackboneElement"/>
       </type>
     </element>
@@ -554,12 +567,49 @@
       <definition value="The alphanumeric identifier associated with the insurer issued label."/>
       <comment value="For example, the Group or Plan number."/>
       <requirements value="The insurer issued label and identifier are necessary to identify the specific policy, group, etc.."/>
-      <min value="1"/>
+      <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Identifier"/>
       </type>
       <isSummary value="true"/>
+      <mapping>
+        <identity value="cdanetv4"/>
+        <map value="C11 (Division,Section)"/>
+      </mapping>
+      <mapping>
+        <identity value="v2"/>
+        <map value="IN1-8"/>
+      </mapping>
+      <mapping>
+        <identity value="v2"/>
+        <map value="IN1-2"/>
+      </mapping>
+      <mapping>
+        <identity value="cpha3pharm"/>
+        <map value="C.31"/>
+      </mapping>
+    </element>
+    <element id="Coverage.class.code">
+      <path value="Coverage.class.code"/>
+      <short value="Code associated with the type"/>
+      <definition value="The coded term associated with the insurer issued label."/>
+      <comment value="For example, Bronze, Silver, Gold."/>
+      <requirements value="The insurer issued label and identifier or code are necessary to identify the specific policy, group, etc.."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Coding"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="CoverageClassTypeCode"/>
+        </extension>
+        <strength value="example"/>
+        <description value="The type classifications, e.g. Bronze, Silver, Gold., etc."/>
+<!--        <valueSet value="http://hl7.org/fhir/ValueSet/coverage-class-type-code"/> -->
+      </binding>
       <mapping>
         <identity value="cdanetv4"/>
         <map value="C11 (Division,Section)"/>
@@ -621,7 +671,8 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="string"/>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
       </type>
       <isSummary value="true"/>
       <mapping>


### PR DESCRIPTION
…ructural change is made in this ticket and a new ticket (57744) will create the codesystem and valueset after the ballot.

FHIR-54234 Change Coverage.class from 1..1 to 0..1 and add .class.code 0..1 CodeableConcept and add a constrain to permit either .class.vale or class.code.

FHIR-54441 CHange Coverage.network from a string to a Reference(Organization)

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

FHIR-54162 Change Coverage.statusReason to a CodeableConcept - the structural change is made in this ticket and a new ticket (57744) will create the codesystem and valueset after the ballot.

FHIR-54234 Change Coverage.class from 1..1 to 0..1 and add .class.code 0..1 CodeableConcept and add a constrain to permit either .class.vale or class.code.

FHIR-54441 Change Coverage.network from a string to a Reference(Organization)