### PR TITLE
FHIR-54102 Add .suportingInfo.subCategory to match that in Claim to C…

### DIFF
--- a/source/claimresponse/claimresponse-introduction.xml
+++ b/source/claimresponse/claimresponse-introduction.xml
@@ -6,6 +6,10 @@
     <blockquote class="ballot-note" id="bn1">
     <p><b>Note to Balloters:</b> Changes made since the previous ballot</p>
     <ul>
+        <li>Substantive:</li>
+            <ul>
+                <li><a href="https://jira.hl7.org/browse/FHIR-54102">FHIR-54102</a> - Added .supportingInfo.subCategory to match Claim.</li>
+            </ul>
         <li>Non-substantive:</li>
             <ul>
                 <li><a href="https://jira.hl7.org/browse/FHIR-53099">FHIR-53099</a> - Change binding strength of payeeType to Preferred</li>

--- a/source/claimresponse/structuredefinition-ClaimResponse.xml
+++ b/source/claimresponse/structuredefinition-ClaimResponse.xml
@@ -557,6 +557,24 @@
         <valueSet value="http://hl7.org/fhir/ValueSet/claim-informationcategory"/>
       </binding>
     </element>
+    <element id="ClaimResponse.supportingInfo.subCategory">
+      <path value="ClaimResponse.supportingInfo.subCategory"/>
+      <short value="Finer-grained classification of the supplied information"/>
+      <definition value="A finer classification within the more general category."/>
+      <requirements value="Required to provide more detailed categorization, for example lab-test grouping: blood, tissue etc."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="InformationSubCategory"/>
+        </extension>
+        <strength value="example"/>
+        <description value="The valuset used for additional information subcategory codes."/>
+      </binding>
+    </element>
     <element id="ClaimResponse.supportingInfo.code">
       <path value="ClaimResponse.supportingInfo.code"/>
       <short value="Type of information"/>


### PR DESCRIPTION
…laimResponse and ExplanationOfBenefit.

Note the change to Explanation of Benefit was included in a prior PR (probably 57238 - 4228)

## HL7 FHIR Pull Request

_Note: No pull requests will be accepted against `./source` unless logged in the_ [HL7 Jira issue tracker](https://jira.hl7.org/projects/FHIR/issues/).

If you made changes to any files within `./source` please indicate the Jira tracker number this pull request is associated with: `   `

## Description

FHIR-54102 Add .suportingInfo.subCategory to match that in Claim to ClaimResponse and ExplanationOfBenefit.

Note the change to Explanation of Benefit was included in a prior PR (probably 57238 - 4228)
