### PR TITLE
QA: Update the r5-r6 mappings for Goal and ClinicalUseDefinition (take2)

### DIFF
--- a/source/fhir.ini
+++ b/source/fhir.ini
@@ -2190,14 +2190,17 @@ Claim.prescription=@Claim.request
 Claim.statusReason=+
 Claim.supportingInfo.subCategory=+
 ClaimResponse.patient=@ClaimResponse.subject
+
 # These changes are due to a restructuring of the resource and thus the content reference is in a different place
-ClinicalUseDefinition.contraindication.otherTherapy.relationshipType=
-ClinicalUseDefinition.contraindication.otherTherapy.treatment=
-ClinicalUseDefinition.indication.otherTherapy.relationshipType=+
-ClinicalUseDefinition.indication.otherTherapy.treatment=+
-ClinicalUseDefinition.interaction.interactant.route=+
-ClinicalUseDefinition.interaction.severity=+
-ClinicalUseDefinition.undesirableEffect.management=+
+ClinicalUseDefinition.undesirableEffect.management=+This is also shared by the `indication` backbone element
+ClinicalUseDefinition.indication.undesirableEffect=*Uses the `undesirableEffect` structure (via contentReference) rather than a reference to another instance
+ClinicalUseDefinition.indication.otherTherapy.relationshipType=+not a change - content reference definition moved
+ClinicalUseDefinition.indication.otherTherapy.treatment=+not a change - content reference definition moved
+ClinicalUseDefinition.contraindication.indication=*Uses the `indication` structure (via contentReference) rather than a reference to another instance
+ClinicalUseDefinition.contraindication.otherTherapy=*Uses the `indication.otherTherapy` structure (via contentReference) - elements the same
+ClinicalUseDefinition.contraindication.otherTherapy.relationshipType=not a change - contentReference definition moved to `indication`
+ClinicalUseDefinition.contraindication.otherTherapy.treatment=not a change - contentReference definition moved to `indication`
+
 Condition.asserter=+Could be migrated from participant depending on participant.function
 Condition.bodyStructure=+
 Condition.participant=-> recorder or asserter depending on function
@@ -2347,6 +2350,9 @@ Goal.acceptance=+
 Goal.outcome=
 Goal.recorder=+
 Group.active=-> this should map to status=active, but the status property is now a code with more options, so is not a direct mapping
+# https://chat.fhir.org/#narrow/channel/294552-Patient-Care-WG/topic/Goal.20R5.20to.20R6.20mapping/with/607968126
+Goal.statusDate=@Goal.achievementStatusDate
+Goal.statusReason=@Goal.lifecycleStatusReason
 Group.characteristic.description=+
 Group.status=+This can be derived from the active property, but the status property is now a code with more options, so this is not a direct mapping
 Group.versionAlgorithm[x]=+


### PR DESCRIPTION
## Description

QA: Update the R5 to R6 mappings for the diff tab _(after checking with editors/owners)_:
* Goal https://chat.fhir.org/#narrow/channel/294552-Patient-Care-WG/topic/Goal.20R5.20to.20R6.20mapping/with/607968126
* ClinicalUseDefinition [#committers > ClinicalUseDefinition](https://chat.fhir.org/#narrow/channel/179165-committers/topic/ClinicalUseDefinition/with/607964829)

(same as #4272 - just in a new branch to test the build issue)