### PR TITLE
J#57823 Update AdverseEvent.category value set definition to exclude …

### DIFF
--- a/source/adverseevent/adverseevent-introduction.xml
+++ b/source/adverseevent/adverseevent-introduction.xml
@@ -16,7 +16,7 @@
 		  </li>
 		  <li>Non-Substantive Changes
 			<ul>
-			  <li>None</li>
+			  <li><a href="https://jira.hl7.org/browse/FHIR-57823">FHIR-57823</a>: Update AdverseEvent.category value set definition</li>
 			</ul>
 		  </li>
 		</ul>

--- a/source/adverseevent/structuredefinition-AdverseEvent.xml
+++ b/source/adverseevent/structuredefinition-AdverseEvent.xml
@@ -179,10 +179,10 @@
     </element>
     <element id="AdverseEvent.category">
       <extension url="http://hl7.org/fhir/build/StructureDefinition/committee-notes">
-        <valueString value="FHIR-25396."/>
+        <valueString value="FHIR-25396, FHIR-57823"/>
       </extension>
       <path value="AdverseEvent.category"/>
-      <short value="wrong-patient | procedure-mishap | medication-mishap | device | unsafe-physical-environment | hospital-aquired-infection | wrong-body-site"/>
+      <short value="wrong-patient | procedure-mishap | medication-mishap | device | unsafe-physical-environment | hospital-acquired-infection | wrong-body-site"/>
       <definition value="The overall type of event, intended for search and filtering purposes."/>
       <min value="0"/>
       <max value="*"/>

--- a/source/adverseevent/valueset-adverse-event-category.xml
+++ b/source/adverseevent/valueset-adverse-event-category.xml
@@ -44,5 +44,11 @@
     <include>
       <system value="http://terminology.hl7.org/CodeSystem/adverse-event-category"/>
     </include>
+	<exclude>
+	  <system value="http://terminology.hl7.org/CodeSystem/adverse-event-category"/>
+	  <concept>
+	    <code value="hospital-aquired-infection"/>
+	  </concept>
+	</exclude>
   </compose>
 </ValueSet>


### PR DESCRIPTION
## Description

J#57823 Update AdverseEvent.category value set definition to exclude misspelled code

Note: Left the correctly spelled code in the category short display/definition since there is UP-600 to add the new code to the code system, which means it will be included in the value set when that UP-600 is applied.