### PR TITLE
R6 sept 2026 ballot Technical Corrections - FHIR-i

### DIFF
--- a/source/appointment/structuredefinition-Appointment.xml
+++ b/source/appointment/structuredefinition-Appointment.xml
@@ -118,7 +118,7 @@
           <valueBoolean value="true"/>
         </extension>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation">
-          <valueMarkdown value="For a recurring series of appointments, the originating appointment should have the recurrenceTemplate defining the details of the overall recurrence.  Each occurence should refer back to the originatingAppointment as the single source of truth for the details of the recurrence."/>
+          <valueMarkdown value="For a recurring series of appointments, the originating appointment should have the recurrenceTemplate defining the details of the overall recurrence.  Each occurrence should refer back to the originatingAppointment as the single source of truth for the details of the recurrence."/>
         </extension>
         <key value="app-6"/>
         <severity value="warning"/>

--- a/source/async.html
+++ b/source/async.html
@@ -52,7 +52,7 @@
       Incubator</a> while the details are finalised through implementation testing.
   </p>
 
-<h3 id="patterns">Conformance</h3>
+<h3 id="conformance">Conformance</h3>
 <p>
   Operations can declare as part of their definition whether they will be performed synchronously, asynchronously, or either.
   (See <a href="operationdefinition-definitions.html#OperationDefinition.synchronicity">OperationDefinition.synchronicity</a>)
@@ -60,7 +60,7 @@
 
 <p>Systems can also declare whether specific operations or interactions will be handled synchronously, asynchronously, or
 a mixture of them with <a href="[%extensions-location%]StructureDefinition-synchronicity-control.html">synchronicity extensions</a> 
-in their CapabilityStatements.)
+in their CapabilityStatements.
 </p>
 
   [%file newfooter%]

--- a/source/best-practices.html
+++ b/source/best-practices.html
@@ -33,7 +33,7 @@ all contexts. However, it is useful for the FHIR standard to be able to
 document what are known best practices. 
 </p>
 <p>
-Committees can document best practice by one of two different ways:
+Committees can document best practice in one of two ways:
 </p>
 
 <ul>

--- a/source/domainresource/structuredefinition-DomainResource.xml
+++ b/source/domainresource/structuredefinition-DomainResource.xml
@@ -85,7 +85,7 @@
           <valueBoolean value="true"/>
         </extension>
         <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation">
-          <valueMarkdown value="When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."/>
+          <valueMarkdown value="When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust ecosystem and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such ecosystems often open up to new participants over time."/>
         </extension>
         <key value="dom-6"/>
         <severity value="warning"/>

--- a/source/exchanging-messaging.html
+++ b/source/exchanging-messaging.html
@@ -35,13 +35,13 @@
   <a name="notify"> </a>
   <h3>Message-based Notifications</h3>
   <p>
-    In this pattern, the <i>data source</i> packages up a set of information related to an event (e.g., a patient admission, an order creation, etc.) and pushes it to the <i>data consumer</i>.  The consumer then acknowledges receipt and stores or processes the data as it sees fit.  Some notifications might be logged and then ignored.  Others might involve storing and or forwarding some of the information and discarding the rest.  It is up to the recipient to determine what information it deems relevant.  Typically there is no response message beyond a simple acknowledgement of receipt.  (Note that messages can also be used to drive behavior rather than merely delivering information, but that is outside the scope of this section - further information on using messaging to drive workflow can be found <a href="workflow-management.html#optionj">here</a>.)
+    In this pattern, the <i>data source</i> packages up a set of information related to an event (e.g., a patient admission, an order creation, etc.) and pushes it to the <i>data consumer</i>.  The consumer then acknowledges receipt and stores or processes the data as it sees fit.  Some notifications might be logged and then ignored.  Others might involve storing or forwarding some of the information and discarding the rest.  It is up to the recipient to determine what information it deems relevant.  Typically there is no response message beyond a simple acknowledgement of receipt.  (Note that messages can also be used to drive behavior rather than merely delivering information, but that is outside the scope of this section - further information on using messaging to drive workflow can be found <a href="workflow-management.html#optionj">here</a>.)
   </p>
   <p>
-    The set of information conveyed is up to the design of the message.  There could be a single focal resource or many, along with other related resources that may be relevant to the receiver.  Quite often the same notification payload may be sent to a variety of systems, each of which may extract different sets of inforamtion.  As with queries, notifications can be generic or specific.  However, because the conformance expectations on receipt of a notification are light ("acknowledge receipt and do with the information as you will"), conformance implications for generic events are typically lower than for queries.
+    The set of information conveyed is up to the design of the message.  There could be a single focal resource or many, along with other related resources that may be relevant to the receiver.  Quite often the same notification payload may be sent to a variety of systems, each of which may extract different sets of information.  As with queries, notifications can be generic or specific.  However, because the conformance expectations on receipt of a notification are light ("acknowledge receipt and do with the information as you will"), conformance implications for generic events are typically lower than for queries.
   </p>
   <p>
-    Because the response to notification messages is generally just an acknowledgement of receipt, notification mesage exchanges are typically <a href="#sync">synchronous</a>.
+    Because the response to notification messages is generally just an acknowledgement of receipt, notification message exchanges are typically <a href="#sync">synchronous</a>.
   </p>
   <a name="sync"> </a>
   <h3>Synchronous messaging</h3>
@@ -55,7 +55,7 @@
   <a name="async"> </a>
   <h3>Asynchronous messaging</h3>
   <p>
-    With asynchronous, the <i>data consumer</i> transmits the request message to the <i>data source</i>, which optionally acknowledges it.  At some later point, the <i>data source</i> transmits a message to the <i>data consumer</i> containing the requested data.  The response is linked to the request using <code>MessageHeader.response.identifier</code>.  The <i>data source</i> could also support a 'status check' message event that allows a synchronous response indicating progress/timeline to response.
+    With asynchronous, the <i>data consumer</i> transmits the request message to the <i>data source</i>, which optionally acknowledges it.  At some later point, the <i>data source</i> transmits a message to the <i>data consumer</i> containing the requested data.  The response is linked to the request using <code>MessageHeader.response.identifier</code>.  The <i>data source</i> could also support a 'status check' message event that allows a synchronous response indicating progress toward completion.
   </p>
   <p>
     [%file message-async.svg %]

--- a/source/workflow-management.html
+++ b/source/workflow-management.html
@@ -243,8 +243,8 @@ in order to support consistent definitions for schema and UML derived code.
         <p>See IGs that follow this pattern on the <a href="https://confluence.hl7.org/pages/viewpage.action?pageId=234784905#WorkflowPatternExamples-WorkflowPatternI-POSTofTasktofulfiller'ssystem,followedbyPOSTofsub-Taskonplacer'ssystem">HL7 Confluence page</a></p>
         <p>Also see the example scenario of a workflow using this approach on the <a href="workflow-examples.html#optionI-ex1">examples tab</a>, including example instances.</p>
 
-        <a name="optioni"></a>
-        <h3>Option I: Messaging Task from placer to fulfiller</h3>
+        <a name="optionj"></a>
+        <h3>Option J: Messaging Task from placer to fulfiller</h3>
         <p>
             <i>TODO: needs more details</i>
         </p>


### PR DESCRIPTION
FHIR-58621

**Summary**
This PR applies a set of technical corrections across FHIR source content, including async and best-practices updates plus a workflow messaging anchor/label fix.

**What changed**
Corrected the duplicated workflow option labeling in source/workflow-management.html:
The second Option I section is now Option J.
The section anchor is now optionj at the correct location.
Option K remains separately anchored.
Updated cross-reference in source/exchanging-messaging.html to point to workflow-management optionj.
Removed an accidental duplicate Asynchronous messaging header in source/exchanging-messaging.html.
Applied small wording/spelling fixes in source/exchanging-messaging.html for clarity.
Included prior branch technical corrections in:
source/async.html
source/best-practices.html
source/appointment/structuredefinition-Appointment.xml
source/domainresource/structuredefinition-DomainResource.xml
Commits in this PR
44e1164709 Fix async page technical corrections
0b23cb5d09 Fix best-practices page technical corrections
c1245c0144 Fix messaging option anchor and clean exchanging-messaging text