### PR TITLE
FHIR-58530: Allow ServiceRequest.reason to reference more types of resources

### DIFF
--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -21,6 +21,12 @@
 			  <li>Corrected the <code>ServiceRequest.statusReason</code> definition to remove a reference to a non-existent status <a href="https://jira.hl7.org/browse/FHIR-54624">FHIR-54624</a></li>
 			</ul>
 		</blockquote>
+		<blockquote class="stu-note" style="background-color: lightblue">
+			<p><b>Changes since 6.0.0-ballot5:</b></p>
+			<ul>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58530">FHIR-58530</a> - Added FamilyMemberHistory, MedicationAdministration, MedicationRequest, and AllergyIntolerance as reference targets on ServiceRequest.reason</li>
+			</ul>
+		</blockquote>
 		<a name="scope"></a>
 		<h2>Scope and Usage</h2>
 		<p>

--- a/source/servicerequest/structuredefinition-ServiceRequest.xml
+++ b/source/servicerequest/structuredefinition-ServiceRequest.xml
@@ -1095,6 +1095,10 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/DetectedIssue"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Procedure"/>
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/RiskAssessment"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationAdministration"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"/>
       </type>
       <isSummary value="true"/>
       <binding>


### PR DESCRIPTION
Resolves [FHIR-58530](https://jira.hl7.org/browse/FHIR-58530): Allow ServiceRequest.reason to reference more types of resources

## What changed
Added FamilyMemberHistory, MedicationAdministration, MedicationRequest, and AllergyIntolerance as reference targets on ServiceRequest.reason (a CodeableReference), extending the existing set (Condition, Observation, DiagnosticReport, DocumentReference, DetectedIssue, Procedure, RiskAssessment). Recorded the change in the resource's "Changes since 6.0.0-ballot5" note. No search parameter references ServiceRequest.reason, so none required updating; the Gradle publish build completed with Errors=0.

## Files touched
- `source/servicerequest/servicerequest-introduction.xml`
- `source/servicerequest/structuredefinition-ServiceRequest.xml`
