### PR TITLE
Apply ServiceRequest example and scope clarifications

### DIFF
--- a/source/servicerequest/servicerequest-example-ft4.xml
+++ b/source/servicerequest/servicerequest-example-ft4.xml
@@ -1,6 +1,30 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ServiceRequest xmlns="http://hl7.org/fhir">
 	<id value="ft4"/>
+	<contained>
+		<ServiceRequest>
+			<id value="tsh"/>
+			<status value="completed"/>
+			<intent value="original-order"/>
+			<code>
+				<concept>
+					<coding>
+						<system value="http://loinc.org"/>
+						<code value="3016-3"/>
+						<display value="Thyrotropin [Units/volume] in Serum or Plasma"/>
+					</coding>
+					<text value="TSH"/>
+				</concept>
+			</code>
+			<subject>
+				<reference value="Patient/pat2"/>
+			</subject>
+		</ServiceRequest>
+	</contained>
+	<basedOn>
+		<reference value="#tsh"/>
+		<display value="Original request for TSH test"/>
+	</basedOn>
 	<status value="active"/>
 	<intent value="reflex-order"/>
 	<code>

--- a/source/servicerequest/servicerequest-example-glucose.xml
+++ b/source/servicerequest/servicerequest-example-glucose.xml
@@ -3,6 +3,16 @@
 	<id value="glucose"/>
 	<status value="active"/>
 	<intent value="original-order"/>
+	<code>
+		<concept>
+			<coding>
+				<system value="http://loinc.org"/>
+				<code value="2345-7"/>
+				<display value="Glucose [Mass/volume] in Serum or Plasma"/>
+			</coding>
+			<text value="Glucose test"/>
+		</concept>
+	</code>
 	<subject>
 		<reference value="Patient/dicom"/>
 	</subject>

--- a/source/servicerequest/servicerequest-example-lipid.xml
+++ b/source/servicerequest/servicerequest-example-lipid.xml
@@ -44,6 +44,11 @@
 			<system value="http://acme.org/tests"/>
 			<code value="LIPID"/>
 		  </coding>
+		  <coding>
+			<system value="http://loinc.org"/>
+			<code value="100898-6"/>
+			<display value="Lipid panel - Serum or Plasma"/>
+		  </coding>
 		  <text value="Lipid Panel"/>
 		</concept>
 	</code>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -25,6 +25,7 @@
 			<p><b>Changes since 6.0.0-ballot5:</b></p>
 			<ul>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a> - Added the triggering ServiceRequest reference to the Free T4 reflex-order example</li>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58294">FHIR-58294</a> - Added a LOINC code to the glucose test ServiceRequest example</li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -21,6 +21,12 @@
 			  <li>Corrected the <code>ServiceRequest.statusReason</code> definition to remove a reference to a non-existent status <a href="https://jira.hl7.org/browse/FHIR-54624">FHIR-54624</a></li>
 			</ul>
 		</blockquote>
+		<blockquote class="stu-note" style="background-color: lightblue">
+			<p><b>Changes since 6.0.0-ballot5:</b></p>
+			<ul>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a> - Added the triggering ServiceRequest reference to the Free T4 reflex-order example</li>
+			</ul>
+		</blockquote>
 		<a name="scope"></a>
 		<h2>Scope and Usage</h2>
 		<p>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -26,6 +26,7 @@
 			<ul>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a> - Added the triggering ServiceRequest reference to the Free T4 reflex-order example</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58294">FHIR-58294</a> - Added a LOINC code to the glucose test ServiceRequest example</li>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58293">FHIR-58293</a> - Added the standard LOINC panel code to the lipid panel ServiceRequest example</li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -27,6 +27,7 @@
 				<li><a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a> - Added the triggering ServiceRequest reference to the Free T4 reflex-order example</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58294">FHIR-58294</a> - Added a LOINC code to the glucose test ServiceRequest example</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58293">FHIR-58293</a> - Added the standard LOINC panel code to the lipid panel ServiceRequest example</li>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58287">FHIR-58287</a> - Clarified that each ServiceRequest contains only one requested code</li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>
@@ -59,7 +60,7 @@
 			The general work flow that this resource facilitates is that a clinical system creates a service request. The service request is then accessed by or exchanged, perhaps via intermediaries, with a system that represents an organization (e.g., diagnostic or imaging service, surgical team, physical therapy department) that can perform the procedure. The organization receiving the service request will, after it accepts the request, update the request as the work is performed, and then finally issue a report that references the requests that it fulfilled.
 		</p>
 		<p>
-			Only a single procedure is requested by each ServiceRequest; if a workflow requires requesting multiple procedures simultaneously, this is done using multiple ServiceRequests. These instances can be linked in different ways, depending on the needs of the workflow. For guidance, refer to the <a href="request.html">Request pattern</a>.
+			Each ServiceRequest can only contain a single code; if a workflow requires requesting multiple codes, this is done using multiple ServiceRequests. These instances can be linked in different ways, depending on the needs of the workflow. For guidance, refer to the <a href="request.html">Request pattern</a>.
 		</p>
 		<p>
 			Multiple ServiceRequests may exist that are associated in some way. When the association is a simple grouping, say for billing, that grouping can be indicated with the <code>ServiceRequest.requisition</code> element. When the ServiceRequest execution needs to be coordinated in some fashion, another resource such as <a href="requestorchestration.html">RequestOrchestration</a> may be needed.


### PR DESCRIPTION
This PR addresses 4 tickets.

## Tickets

- [FHIR-58295](https://jira.hl7.org/browse/FHIR-58295): Add-on Example - should that have a link to the original ServiceRequest
- [FHIR-58294](https://jira.hl7.org/browse/FHIR-58294): Glucose example seems to be missing ServiceRequest.code
- [FHIR-58293](https://jira.hl7.org/browse/FHIR-58293): Add LOINC to Lipid Panel order example
- [FHIR-58287](https://jira.hl7.org/browse/FHIR-58287): Update "procedure" to "service" to avoid confusion

## FHIR-58295: Link the reflex order to its triggering request

Added a contained TSH ServiceRequest to the Free T4 example and linked the reflex order to it with `basedOn`. The self-contained reference avoids a broken published link while clearly showing the original order that initiated the reflex.

**Files:** `source/servicerequest/servicerequest-example-ft4.xml`, `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58295)

---

## FHIR-58294: Add a code to the glucose request

Added LOINC `2345-7` and its standard display to the glucose ServiceRequest example, with concise concept text identifying the glucose test.

**Files:** `source/servicerequest/servicerequest-example-glucose.xml`, `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58294)

---

## FHIR-58293: Add the standard lipid panel coding

Added LOINC `100898-6` and its standard display alongside the existing local lipid panel coding. The coding uses the canonical FHIR LOINC system URI, `http://loinc.org`.

**Files:** `source/servicerequest/servicerequest-example-lipid.xml`, `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58293)

---

## FHIR-58287: Clarify the single-code scope

Replaced the procedure-based scope sentence with the approved single-code wording. The surrounding guidance for linking multiple ServiceRequests and using the Request pattern remains unchanged.

**Files:** `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58287)

---

## Publisher QA

Final command: `./gradlew clean publish`

| metric | baseline | current | delta |
|---|---:|---:|---:|
| errors | 0 | 0 | 0 |
| warnings | 3752 | 3752 | 0 |
| info | 374 | 374 | 0 |
| broken_links | 0 | 0 | 0 |

## Published-output acceptance QA

| ticket | generated specification check |
|---|---|
| FHIR-58295 | The Free T4 narrative renders `basedOn` as a working link to the contained TSH original order; the TSH request renders LOINC `3016-3`; no broken/red reference remains. |
| FHIR-58294 | The glucose narrative renders “Glucose test” with LOINC `2345-7`, and the XML rendering includes the standard display. |
| FHIR-58293 | The lipid narrative renders both `{http://acme.org/tests LIPID}` and `{http://loinc.org 100898-6}`; the XML rendering includes “Lipid panel - Serum or Plasma”. |
| FHIR-58287 | The Scope and Usage page contains the approved “single code” wording, omits the replaced “single procedure” sentence, and preserves the adjacent Request-pattern guidance. |

The ServiceRequest “Changes since 6.0.0-ballot5” block renders one entry for each ticket.
