### PR TITLE
Apply remaining OO clarifications and SampledData examples

### DIFF
--- a/source/bodystructure/bodystructure-introduction.xml
+++ b/source/bodystructure/bodystructure-introduction.xml
@@ -19,6 +19,12 @@
 	<li>Guidance text for the usage of <code>BodyStructure.active</code> has been clarified <a href="https://jira.hl7.org/browse/FHIR-54873">FHIR-54873</a></li>
   </ul>
 </blockquote>
+<blockquote class="stu-note" style="background-color: lightblue">
+  <p><b>Changes since 6.0.0-ballot5:</b></p>
+  <ul>
+    <li><a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a> - Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included structure without referencing the removed <code>BodyStructure.location</code> element</li>
+  </ul>
+</blockquote>
 <a name="scope"></a>
 <h2>Scope and Usage</h2>
 <p>The BodyStructure resource contains details about an anatomical or pathological structure (e.g. a cyst) and may include patient information, identifiers, text descriptions, images, and spatially relevant characteristics.

--- a/source/bodystructure/bodystructure-introduction.xml
+++ b/source/bodystructure/bodystructure-introduction.xml
@@ -24,6 +24,7 @@
   <ul>
     <li><a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a> - Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included structure without referencing the removed <code>BodyStructure.location</code> element</li>
     <li><a href="https://jira.hl7.org/browse/FHIR-57931">FHIR-57931</a> - Clarified that a body landmark description locates the corresponding structure</li>
+    <li><a href="https://jira.hl7.org/browse/FHIR-57930">FHIR-57930</a> - Corrected a grammatical typo in the clock-face position definition</li>
   </ul>
 </blockquote>
 <a name="scope"></a>

--- a/source/bodystructure/bodystructure-introduction.xml
+++ b/source/bodystructure/bodystructure-introduction.xml
@@ -23,6 +23,7 @@
   <p><b>Changes since 6.0.0-ballot5:</b></p>
   <ul>
     <li><a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a> - Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included structure without referencing the removed <code>BodyStructure.location</code> element</li>
+    <li><a href="https://jira.hl7.org/browse/FHIR-57931">FHIR-57931</a> - Clarified that a body landmark description locates the corresponding structure</li>
   </ul>
 </blockquote>
 <a name="scope"></a>

--- a/source/bodystructure/bodystructure-introduction.xml
+++ b/source/bodystructure/bodystructure-introduction.xml
@@ -17,14 +17,9 @@
     <li>Added a mammography breast-mass example and linked it from the BodyStructure examples list <a href="https://jira.hl7.org/browse/FHIR-57518">FHIR-57518</a>, <a href="https://jira.hl7.org/browse/FHIR-54747">FHIR-54747</a></li>
     <li>Updated the BodyStructure Five Ws mapping exceptions <a href="https://jira.hl7.org/browse/FHIR-54961">FHIR-54961</a></li>
 	<li>Guidance text for the usage of <code>BodyStructure.active</code> has been clarified <a href="https://jira.hl7.org/browse/FHIR-54873">FHIR-54873</a></li>
-  </ul>
-</blockquote>
-<blockquote class="stu-note" style="background-color: lightblue">
-  <p><b>Changes since 6.0.0-ballot5:</b></p>
-  <ul>
-    <li><a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a> - Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included structure without referencing the removed <code>BodyStructure.location</code> element</li>
-    <li><a href="https://jira.hl7.org/browse/FHIR-57931">FHIR-57931</a> - Clarified that a body landmark description locates the corresponding structure</li>
-    <li><a href="https://jira.hl7.org/browse/FHIR-57930">FHIR-57930</a> - Corrected a grammatical typo in the clock-face position definition</li>
+    <li>Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included anatomical or pathological structure without referring to the removed <code>BodyStructure.location</code> element <a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a></li>
+    <li>Clarified that <code>BodyStructure.includedStructure.bodyLandmarkOrientation.landmarkDescription</code> locates the corresponding structure <a href="https://jira.hl7.org/browse/FHIR-57931">FHIR-57931</a></li>
+    <li>Corrected a grammatical typo in the <code>BodyStructure.includedStructure.bodyLandmarkOrientation.clockFacePosition</code> definition <a href="https://jira.hl7.org/browse/FHIR-57930">FHIR-57930</a></li>
   </ul>
 </blockquote>
 <a name="scope"></a>

--- a/source/bodystructure/structuredefinition-BodyStructure.xml
+++ b/source/bodystructure/structuredefinition-BodyStructure.xml
@@ -271,7 +271,7 @@
     <element id="BodyStructure.includedStructure.bodyLandmarkOrientation.clockFacePosition">
       <path value="BodyStructure.includedStructure.bodyLandmarkOrientation.clockFacePosition"/>
       <short value="Clockface orientation"/>
-      <definition value="An description of the direction away from a landmark something is located based on a radial clock dial."/>
+      <definition value="A description of the direction away from a landmark something is located based on a radial clock dial."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/bodystructure/structuredefinition-BodyStructure.xml
+++ b/source/bodystructure/structuredefinition-BodyStructure.xml
@@ -424,7 +424,7 @@
       </extension>
       <path value="BodyStructure.includedStructure.morphology"/>
       <short value="Kind of Structure"/>
-      <definition value="The kind of structure being represented by the body structure at `BodyStructure.location`.  This can define both normal and abnormal morphologies."/>
+      <definition value="The morphology of the included anatomical or pathological structure. This can define both normal and abnormal morphologies."/>
       <comment value="The minimum cardinality of 0 supports the use case of specifying a location without defining a morphology. When multiple morphologic characteristics apply to the same body structure, a single pre-coordinated terminology concept or post-coordinated expression may be used when an appropriate representation exists. Multiple repetitions of morphology can be used to represent individual morphologic characteristics when no suitable single concept or expression is available."/>
       <min value="0"/>
       <max value="*"/>

--- a/source/bodystructure/structuredefinition-BodyStructure.xml
+++ b/source/bodystructure/structuredefinition-BodyStructure.xml
@@ -249,7 +249,7 @@
     <element id="BodyStructure.includedStructure.bodyLandmarkOrientation.landmarkDescription">
       <path value="BodyStructure.includedStructure.bodyLandmarkOrientation.landmarkDescription"/>
       <short value="Explanation of landmark"/>
-      <definition value="Body landmark description used as a reference to locate something else."/>
+      <definition value="Body landmark description used as a reference to locate the corresponding structure."/>
       <min value="0"/>
       <max value="*"/>
       <type>

--- a/source/observation/list-Observation-examples.xml
+++ b/source/observation/list-Observation-examples.xml
@@ -342,6 +342,30 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="EKG annotation example using a paired Observation with valuePeriod"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="observation-example-ekg-abnormal-period"/>
+    </extension>
+    <item>
+      <reference value="Observation/ekg-abnormal-period"/>
+      <display value="Abnormal EKG period"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="EKG annotation example using coded SampledData and a ConceptMap"/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="observation-example-ekg-coded-annotations"/>
+    </extension>
+    <item>
+      <reference value="Observation/ekg-coded-annotations"/>
+      <display value="Coded EKG annotations"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
       <valueString value="Clinical assessment tool example - GCS with individual score as components"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">

--- a/source/observation/observation-example-ekg-abnormal-period.xml
+++ b/source/observation/observation-example-ekg-abnormal-period.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A paired Observation annotates an abnormal interval in the referenced EKG waveform. -->
+<Observation xmlns="http://hl7.org/fhir">
+  <id value="ekg-abnormal-period"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>This Observation identifies the abnormal interval from 09:30:35.240 to 09:30:35.320 in the EKG waveform referenced by derivedFrom.</p>
+    </div>
+  </text>
+  <status value="final"/>
+  <code>
+    <text value="Abnormal EKG period"/>
+  </code>
+  <subject>
+    <reference value="Patient/f001"/>
+    <display value="P. van de Heuvel"/>
+  </subject>
+  <effectiveDateTime value="2015-02-19T10:00:00+01:00"/>
+  <performer>
+    <reference value="Practitioner/f005"/>
+    <display value="A. Langeveld"/>
+  </performer>
+  <valuePeriod>
+    <start value="2015-02-19T09:30:35.240+01:00"/>
+    <end value="2015-02-19T09:30:35.320+01:00"/>
+  </valuePeriod>
+  <derivedFrom>
+    <reference value="Observation/ekg"/>
+    <display value="EKG waveform"/>
+  </derivedFrom>
+</Observation>

--- a/source/observation/observation-example-ekg-coded-annotations.xml
+++ b/source/observation/observation-example-ekg-coded-annotations.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- A paired Observation uses coded SampledData to annotate each sample in the referenced EKG waveform. -->
+<Observation xmlns="http://hl7.org/fhir">
+  <id value="ekg-coded-annotations"/>
+  <text>
+    <status value="generated"/>
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <p>This Observation annotates samples in the EKG waveform referenced by derivedFrom. SampledData code 426783006 indicates sinus rhythm; code 5370000 indicates atrial flutter. The contained ConceptMap maps those SNOMED CT codes to LOINC answer codes.</p>
+    </div>
+  </text>
+  <contained>
+    <ConceptMap>
+      <id value="ekg-annotation-map"/>
+      <status value="draft"/>
+      <experimental value="true"/>
+      <group>
+        <source value="http://snomed.info/sct"/>
+        <target value="http://loinc.org"/>
+        <element>
+          <code value="426783006"/>
+          <display value="ECG: sinus rhythm"/>
+          <target>
+            <code value="LA17718-0"/>
+            <display value="Sinus rhythm"/>
+            <relationship value="equivalent"/>
+          </target>
+        </element>
+        <element>
+          <code value="5370000"/>
+          <display value="Atrial flutter"/>
+          <target>
+            <code value="LA17085-4"/>
+            <display value="Atrial flutter"/>
+            <relationship value="equivalent"/>
+          </target>
+        </element>
+      </group>
+    </ConceptMap>
+  </contained>
+  <status value="final"/>
+  <code>
+    <coding>
+      <system value="http://loinc.org"/>
+      <code value="76281-5"/>
+      <display value="Type of arrhythmia on EKG"/>
+    </coding>
+  </code>
+  <subject>
+    <reference value="Patient/f001"/>
+    <display value="P. van de Heuvel"/>
+  </subject>
+  <effectiveDateTime value="2015-02-19T09:30:35+01:00"/>
+  <performer>
+    <reference value="Practitioner/f005"/>
+    <display value="A. Langeveld"/>
+  </performer>
+  <valueSampledData>
+    <origin>
+      <value value="2048"/>
+    </origin>
+    <interval value="10"/>
+    <intervalUnit value="ms"/>
+    <dimensions value="1"/>
+    <codeMap value="#ekg-annotation-map"/>
+    <data value="426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 426783006 5370000 5370000 5370000 5370000 5370000 5370000 5370000 5370000 5370000 426783006 426783006 426783006 426783006 426783006 426783006 426783006"/>
+  </valueSampledData>
+  <derivedFrom>
+    <reference value="Observation/ekg"/>
+    <display value="EKG waveform"/>
+  </derivedFrom>
+</Observation>

--- a/source/observation/observation-examples-header.xml
+++ b/source/observation/observation-examples-header.xml
@@ -156,6 +156,12 @@
 			<a href="observation-example-sample-data.html">EKG Example using SampledData data type</a>
 		</li>
 		<li>
+			<a href="observation-example-ekg-abnormal-period.html">EKG annotation using a paired Observation with valuePeriod</a>
+		</li>
+		<li>
+			<a href="observation-example-ekg-coded-annotations.html">EKG annotation using coded SampledData and a ConceptMap</a>
+		</li>
+		<li>
 			<a href="observation-example-devicemetricfocus.html">IV Pump Flow Rate (Device)</a>
 		</li>
 	</ul>

--- a/source/observation/observation-introduction.xml
+++ b/source/observation/observation-introduction.xml
@@ -1,7 +1,7 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
   <div>
     <blockquote class="ballot-note" id="bn1">
-        <p><b>Note to Balloters for Ballot5</b>: Observation changes in this window include structural updates to observation context, status reason, supporting device traceability, and Vital Signs Panel organizer handling, plus Vital Signs profile, terminology, mapping, and narrative cleanup.</p>
+        <p><b>Note to Balloters for Ballot5</b>: Observation changes in this window include structural updates to observation context, status reason, supporting device traceability, and Vital Signs Panel organizer handling, plus Vital Signs profile, example, terminology, mapping, and narrative updates.</p>
         <p>Reviewers should pay particular attention to the organizer/grouping guidance for Observation and DiagnosticReport, including use of organizer Observations and consistency with the Diagnostics Module guidance.</p>
         <p>This resource is referenced from the <a href="diagnostics-module.html">Diagnostics Module</a>; reviewers should also consider related module-page ballot content when reviewing this resource.</p>
         <p><b>Non-compatible</b></p>
@@ -27,13 +27,8 @@
             <li>Observation narrative and mapping text were clarified for goal extension awareness, obsolete core-extension references, subject guidance, 5Ws mappings, and value-set display names. <a href="https://jira.hl7.org/browse/FHIR-57447">FHIR-57447</a>, <a href="https://jira.hl7.org/browse/FHIR-54040">FHIR-54040</a>, <a href="https://jira.hl7.org/browse/FHIR-54036">FHIR-54036</a>, <a href="https://jira.hl7.org/browse/FHIR-54961">FHIR-54961</a></li>
 			<li>Guidance has been added to clarify intent behind DiagnosticReport and Observation organizer/grouping <a href="https://jira.hl7.org/browse/FHIR-54887">FHIR-54887</a></li>
 			<li>Narrative text providing guidance on the TermInfo pattern has been removed as this content is out of date <a href="https://jira.hl7.org/browse/FHIR-56188">FHIR-56188</a></li>
+            <li>Added paired-Observation examples showing how to annotate an interval or coded samples in an EKG <code>SampledData</code> Observation without adding an extension <a href="https://jira.hl7.org/browse/FHIR-24662">FHIR-24662</a></li>
         </ul>
-    </blockquote>
-    <blockquote class="stu-note" style="background-color: lightblue">
-      <p><b>Changes since 6.0.0-ballot5:</b></p>
-      <ul>
-        <li><a href="https://jira.hl7.org/browse/FHIR-24662">FHIR-24662</a> - Added paired-Observation examples showing both a period-based EKG annotation and coded per-sample annotations using <code>SampledData.codeMap</code></li>
-      </ul>
     </blockquote>
     <h2>Scope and Usage</h2>
     <p>This resource is an <a href="workflow.html#event">

--- a/source/observation/observation-introduction.xml
+++ b/source/observation/observation-introduction.xml
@@ -29,6 +29,12 @@
 			<li>Narrative text providing guidance on the TermInfo pattern has been removed as this content is out of date <a href="https://jira.hl7.org/browse/FHIR-56188">FHIR-56188</a></li>
         </ul>
     </blockquote>
+    <blockquote class="stu-note" style="background-color: lightblue">
+      <p><b>Changes since 6.0.0-ballot5:</b></p>
+      <ul>
+        <li><a href="https://jira.hl7.org/browse/FHIR-24662">FHIR-24662</a> - Added paired-Observation examples showing both a period-based EKG annotation and coded per-sample annotations using <code>SampledData.codeMap</code></li>
+      </ul>
+    </blockquote>
     <h2>Scope and Usage</h2>
     <p>This resource is an <a href="workflow.html#event">
         <em>event resource</em>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -30,6 +30,7 @@
 				<li><a href="https://jira.hl7.org/browse/FHIR-58287">FHIR-58287</a> - Clarified that each ServiceRequest contains only one requested code</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58530">FHIR-58530</a> - Added FamilyMemberHistory, MedicationAdministration, MedicationRequest, and AllergyIntolerance as reference targets on ServiceRequest.reason</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58291">FHIR-58291</a> - Clarified that ServiceRequest.subject identifies the individual or entity of record for the service</li>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58290">FHIR-58290</a> - Added LOINC and SNOMED CT Observable Entity guidance for laboratory and radiology request codes</li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -1,7 +1,7 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 	<div>
 		<blockquote class="ballot-note" id="bn1">
-			<p><b>Note to Balloters for Ballot5</b>: Changes update ServiceRequest order-detail/focus terminology, remove the deprecated specimen element, align reference targets, and include structural and terminology corrections for this ballot window.</p>
+			<p><b>Note to Balloters for Ballot5</b>: Changes update ServiceRequest order-detail/focus terminology, remove the deprecated specimen element, expand reference targets, and include subject, request-code, narrative, and example corrections for this ballot window.</p>
 			<p>This resource is referenced from the <a href="diagnostics-module.html">Diagnostics Module</a> and <a href="workflow-module.html">Workflow Module</a>; reviewers should also consider related module-page ballot content when reviewing this resource.</p>
 			<p><b>Non-compatible</b></p>
 			<ul>
@@ -15,22 +15,17 @@
 			  <li>Marked <code>codesystem-servicerequest-status-reason</code> as experimental as a part of evaluation for THO/UTG promotion <a href="https://jira.hl7.org/browse/FHIR-55273">FHIR-55273</a></li>
 			  <li>Marked <code>valueset-request-orderdetail-parameter-code</code> as experimental as a part of evaluation for THO/UTG promotion <a href="https://jira.hl7.org/browse/FHIR-55261">FHIR-55261</a></li>
 			  <li>Cardinality of <code>ServiceRequest.bodyStructure</code> has been changed to 0..* as a part of broader OO alignment on supporting bodyStructure reference through multiple codings or, where necessary from a modeling standpoint, multiple instances <a href="https://jira.hl7.org/browse/FHIR-54843">FHIR-54843</a></li>
+			  <li>Added <code>FamilyMemberHistory</code>, <code>MedicationAdministration</code>, <code>MedicationRequest</code>, and <code>AllergyIntolerance</code> as reference targets for <code>ServiceRequest.reason</code> <a href="https://jira.hl7.org/browse/FHIR-58530">FHIR-58530</a></li>
 			</ul>
 			<p><b>Non-substantive</b></p>
 			<ul>
 			  <li>Corrected the <code>ServiceRequest.statusReason</code> definition to remove a reference to a non-existent status <a href="https://jira.hl7.org/browse/FHIR-54624">FHIR-54624</a></li>
-			</ul>
-		</blockquote>
-		<blockquote class="stu-note" style="background-color: lightblue">
-			<p><b>Changes since 6.0.0-ballot5:</b></p>
-			<ul>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a> - Added the triggering ServiceRequest reference to the Free T4 reflex-order example</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58294">FHIR-58294</a> - Added a LOINC code to the glucose test ServiceRequest example</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58293">FHIR-58293</a> - Added the standard LOINC panel code to the lipid panel ServiceRequest example</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58287">FHIR-58287</a> - Clarified that each ServiceRequest contains only one requested code</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58530">FHIR-58530</a> - Added FamilyMemberHistory, MedicationAdministration, MedicationRequest, and AllergyIntolerance as reference targets on ServiceRequest.reason</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58291">FHIR-58291</a> - Clarified that ServiceRequest.subject identifies the individual or entity of record for the service</li>
-				<li><a href="https://jira.hl7.org/browse/FHIR-58290">FHIR-58290</a> - Added LOINC and SNOMED CT Observable Entity guidance for laboratory and radiology request codes</li>
+			  <li>Added a <code>basedOn</code> reference from the Free T4 reflex-order example to the triggering ServiceRequest <a href="https://jira.hl7.org/browse/FHIR-58295">FHIR-58295</a></li>
+			  <li>Added the appropriate LOINC code to the glucose test ServiceRequest example <a href="https://jira.hl7.org/browse/FHIR-58294">FHIR-58294</a></li>
+			  <li>Added the standard LOINC panel code to the lipid panel ServiceRequest example <a href="https://jira.hl7.org/browse/FHIR-58293">FHIR-58293</a></li>
+			  <li>Clarified that each ServiceRequest contains one requested code, avoiding language that implied every request represents a procedure <a href="https://jira.hl7.org/browse/FHIR-58287">FHIR-58287</a></li>
+			  <li>Clarified that <code>ServiceRequest.subject</code> identifies the individual or entity whose record contains the requested service <a href="https://jira.hl7.org/browse/FHIR-58291">FHIR-58291</a></li>
+			  <li>Added guidance to use LOINC or the SNOMED CT Observable Entity hierarchy for laboratory and radiology request codes <a href="https://jira.hl7.org/browse/FHIR-58290">FHIR-58290</a></li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>

--- a/source/servicerequest/servicerequest-introduction.xml
+++ b/source/servicerequest/servicerequest-introduction.xml
@@ -29,6 +29,7 @@
 				<li><a href="https://jira.hl7.org/browse/FHIR-58293">FHIR-58293</a> - Added the standard LOINC panel code to the lipid panel ServiceRequest example</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58287">FHIR-58287</a> - Clarified that each ServiceRequest contains only one requested code</li>
 				<li><a href="https://jira.hl7.org/browse/FHIR-58530">FHIR-58530</a> - Added FamilyMemberHistory, MedicationAdministration, MedicationRequest, and AllergyIntolerance as reference targets on ServiceRequest.reason</li>
+				<li><a href="https://jira.hl7.org/browse/FHIR-58291">FHIR-58291</a> - Clarified that ServiceRequest.subject identifies the individual or entity of record for the service</li>
 			</ul>
 		</blockquote>
 		<a name="scope"></a>

--- a/source/servicerequest/structuredefinition-ServiceRequest.xml
+++ b/source/servicerequest/structuredefinition-ServiceRequest.xml
@@ -711,8 +711,8 @@
         <valueString value="[#10296][#11119]#13196]."/>
       </extension>
       <path value="ServiceRequest.subject"/>
-      <short value="Individual or Entity the service is ordered for"/>
-      <definition value="On whom or what the service is to be performed. This is usually a human patient, but can also be requested on animals, groups of humans or animals, devices such as dialysis machines, or even locations (typically for environmental scans)."/>
+      <short value="Individual or Entity of record for whom the service is ordered"/>
+      <definition value="On whose or what record the service to be performed is recorded. This is usually a human patient, but can also be requested on animals, groups of humans or animals, devices such as dialysis machines, or even locations (typically for environmental scans)."/>
       <min value="1"/>
       <max value="1"/>
       <type>

--- a/source/servicerequest/structuredefinition-ServiceRequest.xml
+++ b/source/servicerequest/structuredefinition-ServiceRequest.xml
@@ -483,7 +483,7 @@
       <path value="ServiceRequest.code"/>
       <short value="What is being requested/ordered"/>
       <definition value="A code or reference that identifies a particular service (i.e., procedure, diagnostic investigation, or panel of investigations) that has been requested."/>
-      <comment value="Many laboratory and radiology procedure codes embed the specimen/organ system in the test order name, for example,  serum or serum/plasma glucose, or a chest x-ray. The specimen might not be recorded separately from the test code. The PlanDefinition may be used when you want to group multiple activities together (e.g., order set that are part of a plan)."/>
+      <comment value="For laboratory tests and radiology, codes should be drawn from LOINC or, when using SNOMED CT, from the Observable Entity hierarchy (363787002 | Observable entity (observable entity) |). Many laboratory and radiology procedure codes embed the specimen/organ system in the test order name, for example, serum or serum/plasma glucose, or a chest x-ray. The specimen might not be recorded separately from the test code. The PlanDefinition may be used when you want to group multiple activities together (e.g., order sets that are part of a plan)."/>
       <alias value="service requested"/>
       <min value="0"/>
       <max value="1"/>

--- a/source/specimen/specimen-introduction.xml
+++ b/source/specimen/specimen-introduction.xml
@@ -19,12 +19,7 @@
 		<ul>
 		  <li>Corrected the binding mismatch on the collection device element; <code>collection.device[x]</code> replaced by <code>collection.device</code> <a href="https://jira.hl7.org/browse/FHIR-54488">FHIR-54488</a></li>
 		  <li>Revised the narrative around nesting specimen containers <a href="https://jira.hl7.org/browse/FHIR-54598">FHIR-54598</a></li>
-		</ul>
-	</blockquote>
-	<blockquote class="stu-note" style="background-color: lightblue">
-		<p><b>Changes since 6.0.0-ballot5:</b></p>
-		<ul>
-			<li><a href="https://jira.hl7.org/browse/FHIR-58416">FHIR-58416</a> - Corrected the <code>Specimen.collection.fastingStatus[x]</code> guidance for representing fasting status with an Observation component</li>
+		  <li>Corrected the malformed <code>Observation.component.code</code> reference and stray backtick in the <code>Specimen.collection.fastingStatus[x]</code> guidance <a href="https://jira.hl7.org/browse/FHIR-58416">FHIR-58416</a></li>
 		</ul>
 	</blockquote>
 	<a name="scope"></a>

--- a/source/specimen/specimen-introduction.xml
+++ b/source/specimen/specimen-introduction.xml
@@ -21,6 +21,12 @@
 		  <li>Revised the narrative around nesting specimen containers <a href="https://jira.hl7.org/browse/FHIR-54598">FHIR-54598</a></li>
 		</ul>
 	</blockquote>
+	<blockquote class="stu-note" style="background-color: lightblue">
+		<p><b>Changes since 6.0.0-ballot5:</b></p>
+		<ul>
+			<li><a href="https://jira.hl7.org/browse/FHIR-58416">FHIR-58416</a> - Corrected the <code>Specimen.collection.fastingStatus[x]</code> guidance for representing fasting status with an Observation component</li>
+		</ul>
+	</blockquote>
 	<a name="scope"></a>
 	<h2>Scope and Usage</h2>
 

--- a/source/specimen/structuredefinition-Specimen.xml
+++ b/source/specimen/structuredefinition-Specimen.xml
@@ -626,7 +626,7 @@ For accession identifiers, the Accession Identifier code, ACSN, should be used i
       <path value="Specimen.collection.fastingStatus[x]"/>
       <short value="Whether or how long patient abstained from food and/or drink"/>
       <definition value="Abstinence or reduction from some or all food, drink, or both, for a period of time prior to sample collection."/>
-      <comment value="Representing fasting status using this element is preferred to representing it with an observation using a 'pre-coordinated code'  such as  LOINC 2005-7 (Calcium [Moles/​time] in 2 hour Urine --12 hours fasting), or  using  a component observation ` such as `Observation.component code`  = LOINC 49541-6 (Fasting status - Reported)."/>
+      <comment value="Representing fasting status using this element is preferred to representing it with an observation using a 'pre-coordinated code' such as LOINC 2005-7 (Calcium [Moles/​time] in 2 hour Urine --12 hours fasting), or using a component observation such as `Observation.component.code` = LOINC 49541-6 (Fasting status - Reported)."/>
       <requirements value="Many diagnostic tests require fasting  to facilitate accurate interpretation."/>
       <min value="0"/>
       <max value="1"/>


### PR DESCRIPTION
This PR implements the seven remaining tickets from a 12-ticket batch and records the resource-page ballot impact of all 12 tickets.

## Requested batch context

The original batch contained 12 tickets. [FHIR-58530](https://jira.hl7.org/browse/FHIR-58530) was already merged in [#4289](https://github.com/HL7/fhir/pull/4289), while [FHIR-58295](https://jira.hl7.org/browse/FHIR-58295), [FHIR-58294](https://jira.hl7.org/browse/FHIR-58294), [FHIR-58293](https://jira.hl7.org/browse/FHIR-58293), and [FHIR-58287](https://jira.hl7.org/browse/FHIR-58287) were already merged in [#4290](https://github.com/HL7/fhir/pull/4290). This PR contains the seven remaining implementations without duplicating the five completed changes. It also adds the impact of all 12 tickets to the existing categorized `Note to Balloters for Ballot5` on the affected resource pages.

## Resource-page ballot impact

- **Compatible substantive:** FHIR-58530 on ServiceRequest.
- **Non-substantive:** FHIR-58416 on Specimen; FHIR-58415, FHIR-57931, and FHIR-57930 on BodyStructure; FHIR-58295, FHIR-58294, FHIR-58293, FHIR-58291, FHIR-58290, and FHIR-58287 on ServiceRequest; and FHIR-24662 on Observation.
- Updated each resource note's opening impact summary where needed and retained its relevant module-page cross-reference: Diagnostics for all four resources, plus Workflow for ServiceRequest.
- Integrated each ticket into the existing categorized ballot note rather than adding a parallel changes-since note.

## Tickets
- [FHIR-58416](https://jira.hl7.org/browse/FHIR-58416): Specimen.collection.fastingStatus has minor typos
- [FHIR-58415](https://jira.hl7.org/browse/FHIR-58415): Definition of BodyStructure.includedStructure.morphology references an element that was removed in R5
- [FHIR-58291](https://jira.hl7.org/browse/FHIR-58291): Clarify the definition fo ServiceRequest.subject
- [FHIR-58290](https://jira.hl7.org/browse/FHIR-58290): Add to comment, that for lab tests the binding for .code should be LOINC or a SCT from the observablehierarchy
- [FHIR-57931](https://jira.hl7.org/browse/FHIR-57931): Rephrase definition for more clarity
- [FHIR-57930](https://jira.hl7.org/browse/FHIR-57930): Typo at the definition of BodyStructure.includedStructure.bodyLandmarkOrientation.clockFacePosition
- [FHIR-24662](https://jira.hl7.org/browse/FHIR-24662): Add means to allow an annotation to a sample in SampledData

## FHIR-58416: Specimen.collection.fastingStatus has minor typos

Corrected the Specimen.collection.fastingStatus[x] comment so the component reference is rendered as Observation.component.code without the stray backtick, and recorded the correction as non-substantive in the Specimen ballot note.

**Files:** `source/specimen/structuredefinition-Specimen.xml`, `source/specimen/specimen-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58416)

---

## FHIR-58415: Definition of BodyStructure.includedStructure.morphology references an element that was removed in R5

Replaced the BodyStructure.includedStructure.morphology definition with the approved wording describing the included anatomical or pathological structure, removing the obsolete BodyStructure.location reference. Recorded the correction as non-substantive in the BodyStructure ballot note.

**Files:** `source/bodystructure/structuredefinition-BodyStructure.xml`, `source/bodystructure/bodystructure-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58415)

---

## FHIR-58291: Clarify the definition fo ServiceRequest.subject

Clarified ServiceRequest.subject to distinguish the individual or entity of record from the target of the requested service. The short description and definition now describe whose or what record holds the service request, while retaining the existing examples of supported subject types. Recorded the change as non-substantive in the ServiceRequest ballot note.

**Files:** `source/servicerequest/structuredefinition-ServiceRequest.xml`, `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58291)

---

## FHIR-58290: Add to comment, that for lab tests the binding for .code should be LOINC or a SCT from the observablehierarchy

Added terminology guidance to ServiceRequest.code for laboratory tests and radiology. The comment now directs authors to LOINC or the SNOMED CT Observable Entity hierarchy, while retaining the existing guidance about codes that include specimen or organ-system context and the use of PlanDefinition for grouped activities. Recorded the change as non-substantive in the ServiceRequest ballot note.

**Files:** `source/servicerequest/structuredefinition-ServiceRequest.xml`, `source/servicerequest/servicerequest-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-58290)

---

## FHIR-57931: Rephrase definition for more clarity

Clarified the BodyStructure landmarkDescription definition. The revised wording states that the body landmark description locates the corresponding structure rather than the vague phrase “something else.” Recorded the change as non-substantive in the BodyStructure ballot note.

**Files:** `source/bodystructure/structuredefinition-BodyStructure.xml`, `source/bodystructure/bodystructure-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-57931)

---

## FHIR-57930: Typo at the definition of BodyStructure.includedStructure.bodyLandmarkOrientation.clockFacePosition

Corrected the grammatical typo in the BodyStructure clockFacePosition definition by changing “An description” to “A description.” Recorded the change as non-substantive in the BodyStructure ballot note.

**Files:** `source/bodystructure/structuredefinition-BodyStructure.xml`, `source/bodystructure/bodystructure-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-57930)

---

## FHIR-24662: Add means to allow an annotation to a sample in SampledData

Added two paired-Observation examples showing how to annotate samples in an existing EKG SampledData Observation without changing the SampledData structure. One example identifies an abnormal interval with valuePeriod. The other uses coded SampledData and a contained ConceptMap to map per-sample SNOMED CT rhythm codes to LOINC answer codes. Both derive from the existing Observation/ekg example and are registered in the Observation example list and Device Generated Data section. Recorded the change as non-substantive in the Observation ballot note.

**Files:** `source/observation/observation-example-ekg-abnormal-period.xml`, `source/observation/observation-example-ekg-coded-annotations.xml`, `source/observation/list-Observation-examples.xml`, `source/observation/observation-examples-header.xml`, `source/observation/observation-introduction.xml`

[Ticket](https://jira.hl7.org/browse/FHIR-24662)

---

## Publisher QA

| metric | baseline | current | delta |
|---|---:|---:|---:|
| errors | 1 | 1 | 0 |
| warnings | 3753 | 3754 | +1 |
| info | 373 | 374 | +1 |
| broken_links | 0 | 0 | 0 |

The sole publisher error is unchanged from the baseline and is the existing terminology validation failure in `riskassessment-example-prognosis`. None of the edited resources introduced a new error or broken link. Both new Observation examples passed instance validation. Generated-output checks passed for the seven implemented tickets, and the Specimen, BodyStructure, ServiceRequest, and Observation main resource pages were verified to contain each of the 12 requested JIRA links exactly once under the intended impact category, with their module-page cross-references intact.
