### PR TITLE
Clarify Consent permission provisions

### DIFF
--- a/source/consent/structuredefinition-Consent.xml
+++ b/source/consent/structuredefinition-Consent.xml
@@ -564,6 +564,7 @@
       <path value="Consent.provision"/>
       <short value="Constraints to the base Consent.policyBasis/Consent.policyText"/>
       <definition value="Constraints and exceptions to the base policy that can add or remove some access permissions under specific conditions."/>
+      <comment value="The patient specific provisions can be encoded using the Permission Resource. When this is done the `Consent.provision` shall not be populated, and the `http://hl7.org/fhir/StructureDefinition/permission-from-consent` extension will be used to indicate the Permission instance that holds the patient specific rules (aka provisions)."/>
       <min value="0"/>
       <max value="*"/>
       <type>


### PR DESCRIPTION
Clarifies that patient-specific consent provisions may be represented by a Permission resource referenced through the `permission-from-consent` extension, and that `Consent.provision` must then be empty.

References: [FHIR-53535](https://jira.hl7.org/browse/FHIR-53535)