### PR TITLE
FHIR-57353: Morphologies spanning multiple BodyStructure.includedStruct…

### DIFF
--- a/source/bodystructure/bodystructure-example-cardiac-myxoma.xml
+++ b/source/bodystructure/bodystructure-example-cardiac-myxoma.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example demonstrates a single morphology spanning multiple included anatomical structures. -->
+<BodyStructure xmlns="http://hl7.org/fhir">
+  <id value="cardiac-myxoma"/>
+  <identifier>
+    <system value="http://example.org/fhir/bodystructure-identifiers"/>
+    <value value="M1"/>
+  </identifier>
+  <spanningMorphology>
+    <text value="Cardiac myxoma"/>
+  </spanningMorphology>
+  <includedStructure>
+    <structure>
+      <text value="Left atrium"/>
+    </structure>
+  </includedStructure>
+  <includedStructure>
+    <structure>
+      <text value="Left ventricle"/>
+    </structure>
+  </includedStructure>
+  <description value="A cardiac myxoma originating in the left atrium and extending through the mitral valve into the left ventricle."/>
+  <patient>
+    <reference value="Patient/example"/>
+  </patient>
+</BodyStructure>

--- a/source/bodystructure/bodystructure-examples-header.xml
+++ b/source/bodystructure/bodystructure-examples-header.xml
@@ -1,6 +1,10 @@
 <div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">﻿<div xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml ../../schema/fhir-xhtml.xsd" xmlns="http://www.w3.org/1999/xhtml">
 
-<!-- content goes here -->
+<p>Multi-resource examples use a Bundle to keep the related BodyStructure resources together:</p>
+<ul>
+  <li><a href="bundle-bodystructure-example-lesion-evolution.html">Merging and splitting liver lesions</a> demonstrates predecessor relationships.</li>
+  <li><a href="bundle-bodystructure-example-aortic-dissection.html">Hierarchical aortic dissection structures</a> demonstrates part-of relationships.</li>
+</ul>
 
 </div>
 </div>

--- a/source/bodystructure/bodystructure-introduction.xml
+++ b/source/bodystructure/bodystructure-introduction.xml
@@ -22,6 +22,7 @@
 <blockquote class="stu-note" style="background-color: lightblue">
   <p><b>Changes since 6.0.0-ballot5:</b></p>
   <ul>
+    <li><a href="https://jira.hl7.org/browse/FHIR-57353">FHIR-57353</a> - Added <code>spanningMorphology</code> for a single morphology spanning multiple included structures, added relationships between included structures and other BodyStructure resources, and added supporting search parameters and examples</li>
     <li><a href="https://jira.hl7.org/browse/FHIR-58415">FHIR-58415</a> - Corrected the <code>BodyStructure.includedStructure.morphology</code> definition to describe the included structure without referencing the removed <code>BodyStructure.location</code> element</li>
     <li><a href="https://jira.hl7.org/browse/FHIR-57931">FHIR-57931</a> - Clarified that a body landmark description locates the corresponding structure</li>
     <li><a href="https://jira.hl7.org/browse/FHIR-57930">FHIR-57930</a> - Corrected a grammatical typo in the clock-face position definition</li>
@@ -34,6 +35,8 @@
 <p>BodyStructure is used when a coded concept alone does not provide sufficient detail, identity, persistence, or reuse for the use case. It supports representation of complex anatomical structures and locations using included and excluded structures and can provide additional detail such as laterality, directionality, qualifiers, morphology, images, landmark-based positioning, and spatial references.</p>
 <p>Some anatomical structures are discontiguous or consist of multiple related structures. A single BodyStructure instance may represent multiple included structures when they are considered a single anatomical or pathological entity for recording, tracking, or clinical management purposes. Separate BodyStructure instances should be used when structures need to be identified, assessed, tracked, treated, or managed independently over time.
 </p>
+<p><code>spanningMorphology</code> represents one morphologic entity that encompasses more than one included structure. In contrast, <code>includedStructure.morphology</code> applies only to the included structure in which it appears.</p>
+<p><code>includedStructure.related</code> links an included structure to another BodyStructure when the structures must remain independently identifiable. The relationship type is read from the included structure to the referenced BodyStructure; for example, <code>predecessor</code> means the referenced BodyStructure preceded the included structure, while <code>part-of</code> means the included structure is part of the referenced BodyStructure.</p>
 <p>The BodyStructure resource supports recording and tracking an anatomic location or structure on a patient outside the context of another resource.
 </p>
 </div>

--- a/source/bodystructure/bundle-BodyStructure-search-params.xml
+++ b/source/bodystructure/bundle-BodyStructure-search-params.xml
@@ -67,14 +67,95 @@
           <valueCode value="normative"/>
         </extension>
         <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
-          <valueString value="BodyStructure.includedStructure.morphology"/>
+          <valueString value="BodyStructure.spanningMorphology | BodyStructure.includedStructure.morphology"/>
         </extension>
         <url value="http://hl7.org/fhir/build/SearchParameter/BodyStructure-morphology"/>
-        <description value="The kind of structure"/>
+        <description value="A spanning or structure-specific morphology"/>
         <code value="morphology"/>
         <type value="token"/>
-        <expression value="BodyStructure.includedStructure.morphology"/>
+        <expression value="BodyStructure.spanningMorphology | BodyStructure.includedStructure.morphology"/>
         <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="BodyStructure-spanning-morphology"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="BodyStructure.spanningMorphology"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/BodyStructure-spanning-morphology"/>
+        <description value="A morphology spanning multiple included structures"/>
+        <code value="spanning-morphology"/>
+        <type value="token"/>
+        <expression value="BodyStructure.spanningMorphology"/>
+        <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="BodyStructure-related"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="BodyStructure.includedStructure.related.reference"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/BodyStructure-related"/>
+        <description value="A BodyStructure related to an included structure"/>
+        <code value="related"/>
+        <type value="reference"/>
+        <expression value="BodyStructure.includedStructure.related.reference"/>
+        <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="BodyStructure-relationship"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <extension url="http://hl7.org/fhir/build/StructureDefinition/path">
+          <valueString value="BodyStructure.includedStructure.related.type"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/BodyStructure-relationship"/>
+        <description value="The relationship to another BodyStructure"/>
+        <code value="relationship"/>
+        <type value="token"/>
+        <expression value="BodyStructure.includedStructure.related.type"/>
+        <processingMode value="normal"/>
+      </SearchParameter>
+    </resource>
+  </entry>
+  <entry>
+    <resource>
+      <SearchParameter>
+        <id value="BodyStructure-related-relationship"/>
+        <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+          <valueCode value="normative"/>
+        </extension>
+        <url value="http://hl7.org/fhir/build/SearchParameter/BodyStructure-related-relationship"/>
+        <description value="A related BodyStructure and its relationship type"/>
+        <code value="related-relationship"/>
+        <type value="composite"/>
+        <expression value="BodyStructure.includedStructure.related"/>
+        <processingMode value="normal"/>
+        <component>
+          <definition value="related"/>
+          <expression value="reference"/>
+        </component>
+        <component>
+          <definition value="relationship"/>
+          <expression value="type"/>
+        </component>
       </SearchParameter>
     </resource>
   </entry>

--- a/source/bodystructure/codesystem-bodystructure-relationship-type.xml
+++ b/source/bodystructure/codesystem-bodystructure-relationship-type.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="bodystructure-relationship-type"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="informative"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="0"/>
+  </extension>
+  <url value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+  <version value="6.0.0"/>
+  <name value="BodyStructureRelationshipType"/>
+  <title value="Body Structure Relationship Type Codes"/>
+  <status value="active"/>
+  <experimental value="true"/>
+  <date value="2026-09-12"/>
+  <publisher value="HL7 (FHIR Project)"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/fhir"/>
+    </telecom>
+    <telecom>
+      <system value="email"/>
+      <value value="fhir@lists.hl7.org"/>
+    </telecom>
+  </contact>
+  <description value="Codes describing how an included structure relates to another BodyStructure."/>
+  <caseSensitive value="true"/>
+  <content value="complete"/>
+  <concept>
+    <code value="predecessor"/>
+    <display value="Predecessor"/>
+    <definition value="The referenced BodyStructure is a predecessor from which this included structure originated, such as a lesion that merged into the current lesion."/>
+  </concept>
+  <concept>
+    <code value="successor"/>
+    <display value="Successor"/>
+    <definition value="The referenced BodyStructure is a successor derived from this included structure, such as a lesion created when the current lesion split."/>
+  </concept>
+  <concept>
+    <code value="includes"/>
+    <display value="Includes"/>
+    <definition value="This included structure includes the referenced BodyStructure."/>
+  </concept>
+  <concept>
+    <code value="part-of"/>
+    <display value="Part Of"/>
+    <definition value="This included structure is part of the referenced BodyStructure."/>
+  </concept>
+</CodeSystem>

--- a/source/bodystructure/list-BodyStructure-examples.xml
+++ b/source/bodystructure/list-BodyStructure-examples.xml
@@ -30,6 +30,18 @@
   </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="This example demonstrates a cardiac myxoma represented as one morphologic entity spanning the left atrium and left ventricle."/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="bodystructure-example-cardiac-myxoma"/>
+    </extension>
+    <item>
+      <reference value="BodyStructure/cardiac-myxoma"/>
+      <display value="Cardiac myxoma spanning two included structures"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
       <valueString value="This example demonstrates using the bodystructure resource to identify skin patches or other portions of a person or animal that are a focus of a clinical trial and that are subject to repeated observations and/or procedures over time. It also illustrates recording multiple morphology codes (basal cell carcinoma and nevus sebaceus) at a single included structure"/>
     </extension>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
@@ -54,7 +66,7 @@
     </entry>
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
-      <valueString value="This example demonstrates using BodyStructure to describe a breast mass."/>
+      <valueString value="This example demonstrates a breast mass located using laterality, clock-face position, and distance from a body landmark."/>
     </extension>
       <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
         <valueString value="bodystructure-example-breast-mass"/>

--- a/source/bodystructure/structuredefinition-BodyStructure.xml
+++ b/source/bodystructure/structuredefinition-BodyStructure.xml
@@ -146,6 +146,29 @@
         <map value="statusCode"/>
       </mapping>
     </element>
+    <element id="BodyStructure.spanningMorphology">
+      <path value="BodyStructure.spanningMorphology"/>
+      <short value="Spanning morphology"/>
+      <definition value="A single morphologic entity that encompasses or involves the multiple anatomical structures in the included structures."/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="BodyStructureCode"/>
+        </extension>
+        <strength value="example"/>
+        <description value="SNOMED CT Morphologic Abnormalities"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/bodystructure-code"/>
+      </binding>
+      <mapping>
+        <identity value="w5"/>
+        <map value="FiveWs.what[x]"/>
+      </mapping>
+    </element>
     <element id="BodyStructure.includedStructure">
       <path value="BodyStructure.includedStructure"/>
       <short value="Included anatomic location(s)"/>
@@ -466,6 +489,48 @@
         <description value="Codes describing the origin of a body structure."/>
         <valueSet value="http://hl7.org/fhir/ValueSet/bodystructure-origin"/>
       </binding>
+    </element>
+    <element id="BodyStructure.includedStructure.related">
+      <path value="BodyStructure.includedStructure.related"/>
+      <short value="Related body structures"/>
+      <definition value="Another BodyStructure that is related to this included structure."/>
+      <min value="0"/>
+      <max value="*"/>
+      <type>
+        <code value="BackboneElement"/>
+      </type>
+      <isSummary value="true"/>
+    </element>
+    <element id="BodyStructure.includedStructure.related.type">
+      <path value="BodyStructure.includedStructure.related.type"/>
+      <short value="Type of relationship"/>
+      <definition value="The relationship from this included structure to the referenced BodyStructure."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="CodeableConcept"/>
+      </type>
+      <isSummary value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="BodyStructureRelationshipType"/>
+        </extension>
+        <strength value="example"/>
+        <description value="Codes describing how an included structure relates to another BodyStructure."/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/bodystructure-relationship-type"/>
+      </binding>
+    </element>
+    <element id="BodyStructure.includedStructure.related.reference">
+      <path value="BodyStructure.includedStructure.related.reference"/>
+      <short value="Related BodyStructure"/>
+      <definition value="The BodyStructure that has the specified relationship to this included structure."/>
+      <min value="1"/>
+      <max value="1"/>
+      <type>
+        <code value="Reference"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodyStructure"/>
+      </type>
+      <isSummary value="true"/>
     </element>
     <element id="BodyStructure.excludedStructure">
       <path value="BodyStructure.excludedStructure"/>

--- a/source/bodystructure/valueset-bodystructure-relationship-type.xml
+++ b/source/bodystructure/valueset-bodystructure-relationship-type.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="bodystructure-relationship-type"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-wg">
+    <valueCode value="oo"/>
+  </extension>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
+    <valueCode value="informative"/>
+  </extension>
+  <url value="http://hl7.org/fhir/ValueSet/bodystructure-relationship-type"/>
+  <version value="6.0.0"/>
+  <name value="BodyStructureRelationshipType"/>
+  <title value="Body Structure Relationship Type Codes"/>
+  <status value="active"/>
+  <experimental value="true"/>
+  <date value="2026-09-12"/>
+  <publisher value="HL7 International"/>
+  <description value="Example value set for codes describing how an included structure relates to another BodyStructure."/>
+  <compose>
+    <include>
+      <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+    </include>
+  </compose>
+</ValueSet>

--- a/source/bundle/bundle-bodystructure-example-aortic-dissection.xml
+++ b/source/bundle/bundle-bodystructure-example-aortic-dissection.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example demonstrates a hierarchy of related BodyStructure resources for an aortic dissection. -->
+<Bundle xmlns="http://hl7.org/fhir">
+  <id value="bodystructure-aortic-dissection"/>
+  <type value="collection"/>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/aortic-dissection"/>
+    <resource>
+      <BodyStructure>
+        <id value="aortic-dissection"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="A1"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <text value="Aorta"/>
+          </structure>
+          <morphology>
+            <text value="Aortic dissection"/>
+          </morphology>
+        </includedStructure>
+        <description value="Aortic dissection extending from the aortic arch into the thoracic aorta."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/aortic-arch-true-lumen"/>
+    <resource>
+      <BodyStructure>
+        <id value="aortic-arch-true-lumen"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="A2"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <text value="Aortic arch"/>
+          </structure>
+          <morphology>
+            <text value="True lumen"/>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="part-of"/>
+                <display value="Part Of"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/aortic-dissection"/>
+            </reference>
+          </related>
+        </includedStructure>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/aortic-arch-false-lumen"/>
+    <resource>
+      <BodyStructure>
+        <id value="aortic-arch-false-lumen"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="A3"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <text value="Aortic arch"/>
+          </structure>
+          <morphology>
+            <text value="False lumen"/>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="part-of"/>
+                <display value="Part Of"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/aortic-dissection"/>
+            </reference>
+          </related>
+        </includedStructure>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/thoracic-aorta-true-lumen"/>
+    <resource>
+      <BodyStructure>
+        <id value="thoracic-aorta-true-lumen"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="A4"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <text value="Thoracic aorta"/>
+          </structure>
+          <morphology>
+            <text value="True lumen"/>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="part-of"/>
+                <display value="Part Of"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/aortic-dissection"/>
+            </reference>
+          </related>
+        </includedStructure>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/thoracic-aorta-false-lumen"/>
+    <resource>
+      <BodyStructure>
+        <id value="thoracic-aorta-false-lumen"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="A5"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <text value="Thoracic aorta"/>
+          </structure>
+          <morphology>
+            <text value="False lumen"/>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="part-of"/>
+                <display value="Part Of"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/aortic-dissection"/>
+            </reference>
+          </related>
+        </includedStructure>
+      </BodyStructure>
+    </resource>
+  </entry>
+</Bundle>

--- a/source/bundle/bundle-bodystructure-example-lesion-evolution.xml
+++ b/source/bundle/bundle-bodystructure-example-lesion-evolution.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example demonstrates predecessor relationships when lesions merge and subsequently split. -->
+<Bundle xmlns="http://hl7.org/fhir">
+  <id value="bodystructure-lesion-evolution"/>
+  <type value="collection"/>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/liver-lesion-l1"/>
+    <resource>
+      <BodyStructure>
+        <id value="liver-lesion-l1"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="L1"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="10200004"/>
+              <display value="Liver structure"/>
+            </coding>
+          </structure>
+          <morphology>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="4147007"/>
+              <display value="Mass (morphologic abnormality)"/>
+            </coding>
+          </morphology>
+        </includedStructure>
+        <description value="First liver lesion before merging."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/liver-lesion-l2"/>
+    <resource>
+      <BodyStructure>
+        <id value="liver-lesion-l2"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="L2"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="10200004"/>
+              <display value="Liver structure"/>
+            </coding>
+          </structure>
+          <morphology>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="4147007"/>
+              <display value="Mass (morphologic abnormality)"/>
+            </coding>
+          </morphology>
+        </includedStructure>
+        <description value="Second liver lesion before merging."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/merged-liver-lesion"/>
+    <resource>
+      <BodyStructure>
+        <id value="merged-liver-lesion"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="L3"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="10200004"/>
+              <display value="Liver structure"/>
+            </coding>
+          </structure>
+          <morphology>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="4147007"/>
+              <display value="Mass (morphologic abnormality)"/>
+            </coding>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="predecessor"/>
+                <display value="Predecessor"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/liver-lesion-l1"/>
+            </reference>
+          </related>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="predecessor"/>
+                <display value="Predecessor"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/liver-lesion-l2"/>
+            </reference>
+          </related>
+        </includedStructure>
+        <description value="Liver lesion formed by the merging of lesions L1 and L2."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/split-liver-lesion-l4"/>
+    <resource>
+      <BodyStructure>
+        <id value="split-liver-lesion-l4"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="L4"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="10200004"/>
+              <display value="Liver structure"/>
+            </coding>
+          </structure>
+          <morphology>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="4147007"/>
+              <display value="Mass (morphologic abnormality)"/>
+            </coding>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="predecessor"/>
+                <display value="Predecessor"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/merged-liver-lesion"/>
+            </reference>
+          </related>
+        </includedStructure>
+        <description value="First lesion produced when merged lesion L3 split."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+  <entry>
+    <fullUrl value="http://example.org/fhir/BodyStructure/split-liver-lesion-l5"/>
+    <resource>
+      <BodyStructure>
+        <id value="split-liver-lesion-l5"/>
+        <identifier>
+          <system value="http://example.org/fhir/bodystructure-identifiers"/>
+          <value value="L5"/>
+        </identifier>
+        <includedStructure>
+          <structure>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="10200004"/>
+              <display value="Liver structure"/>
+            </coding>
+          </structure>
+          <morphology>
+            <coding>
+              <system value="http://snomed.info/sct"/>
+              <code value="4147007"/>
+              <display value="Mass (morphologic abnormality)"/>
+            </coding>
+          </morphology>
+          <related>
+            <type>
+              <coding>
+                <system value="http://hl7.org/fhir/bodystructure-relationship-type"/>
+                <code value="predecessor"/>
+                <display value="Predecessor"/>
+              </coding>
+            </type>
+            <reference>
+              <reference value="BodyStructure/merged-liver-lesion"/>
+            </reference>
+          </related>
+        </includedStructure>
+        <description value="Second lesion produced when merged lesion L3 split."/>
+      </BodyStructure>
+    </resource>
+  </entry>
+</Bundle>

--- a/source/bundle/list-Bundle-examples.xml
+++ b/source/bundle/list-Bundle-examples.xml
@@ -138,6 +138,31 @@
   </entry>
 
 
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="This bundle demonstrates predecessor relationships between BodyStructure resources when liver lesions merge and subsequently split."/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="bundle-bodystructure-example-lesion-evolution"/>
+    </extension>
+    <item>
+      <reference value="Bundle/bodystructure-lesion-evolution"/>
+      <display value="Merging and splitting liver lesions"/>
+    </item>
+  </entry>
+  <entry>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/description">
+      <valueString value="This bundle demonstrates part-of relationships between BodyStructure resources representing true and false lumens, affected aortic regions, and an aortic dissection."/>
+    </extension>
+    <extension url="http://hl7.org/fhir/build/StructureDefinition/title">
+      <valueString value="bundle-bodystructure-example-aortic-dissection"/>
+    </extension>
+    <item>
+      <reference value="Bundle/bodystructure-aortic-dissection"/>
+      <display value="Hierarchical aortic dissection structures"/>
+    </item>
+  </entry>
+
   <!--
   <entry>
     <extension url="http://hl7.org/fhir/build/StructureDefinition/description">

--- a/source/servicerequest/servicerequest-request-mapping-exceptions.xml
+++ b/source/servicerequest/servicerequest-request-mapping-exceptions.xml
@@ -191,11 +191,11 @@
         <extraTypes _resource="Reference(Location,Device)" reason="Unknown"/>
         <shortUnmatched reason="Unknown">
             <_pattern value="Individual the service is ordered/prohibited for"/>
-            <resource value="Individual or Entity the service is ordered for"/>
+            <resource value="Individual or Entity of record for whom the service is ordered"/>
         </shortUnmatched>
         <definitionUnmatched reason="Unknown">
             <_pattern value="The individual or set of individuals the action is to be performed/not performed on or for."/>
-            <resource value="On whom or what the service is to be performed. This is usually a human patient, but can also be requested on animals, groups of humans or animals, devices such as dialysis machines, or even locations (typically for environmental scans)."/>
+            <resource value="On whose or what record the service to be performed is recorded. This is usually a human patient, but can also be requested on animals, groups of humans or animals, devices such as dialysis machines, or even locations (typically for environmental scans)."/>
         </definitionUnmatched>
         <requirementsUnmatched reason="Unknown">
             <_pattern value="Links the request to the Patient context."/>


### PR DESCRIPTION
Resolves [FHIR-57353](https://jira.hl7.org/browse/FHIR-57353): Morphologies spanning multiple BodyStructure.includedStructures

## What changed
Added the approved `BodyStructure.spanningMorphology` element and extended `includedStructure` with typed references to related BodyStructure resources. Added relationship terminology, correlated search parameters, and examples for cardiac myxoma, lesion merging and splitting, aortic-dissection hierarchy, and landmark-based breast-mass location. The relationship backbone and terminology extend beyond FHIR-57353's disposition based on the user-confirmed proposal associated with unresolved FHIR-57384.

The publisher also refreshed the tracked ServiceRequest request-pattern mapping exception for the current subject wording. That publisher-produced source update is retained in this PR.

## Files touched
- `source/bodystructure/bodystructure-example-cardiac-myxoma.xml`
- `source/bodystructure/bodystructure-examples-header.xml`
- `source/bodystructure/bodystructure-introduction.xml`
- `source/bodystructure/bundle-BodyStructure-search-params.xml`
- `source/bodystructure/codesystem-bodystructure-relationship-type.xml`
- `source/bodystructure/list-BodyStructure-examples.xml`
- `source/bodystructure/structuredefinition-BodyStructure.xml`
- `source/bodystructure/valueset-bodystructure-relationship-type.xml`
- `source/bundle/bundle-bodystructure-example-aortic-dissection.xml`
- `source/bundle/bundle-bodystructure-example-lesion-evolution.xml`
- `source/bundle/list-Bundle-examples.xml`
- `source/servicerequest/servicerequest-request-mapping-exceptions.xml`

## Publisher QA

- errors: 0
- warnings: 3851
- info: 391
- broken_links: 0
